### PR TITLE
docs: refine CI/CD section (remove GCP refs, add lefthook setup note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Cargo workspace として以下の crate を持つ:
 
 詳細は `docs/superpowers/specs/` の各設計書を参照。
 
+## 開発環境セットアップ
+
+本プロジェクトはローカルの Git hook(lefthook)で品質ゲートを担保する。CI/CD システムは導入していないため、**clone 後は必ず `lefthook install` を実行する**。
+
+```bash
+git clone <repo-url>
+cd kotoha-ime
+lefthook install
+```
+
+`lefthook install` を忘れると pre-commit / pre-push の検査がスキップされ、フォーマット違反・文書命名規則違反・ビルド破壊を含むコミットが走ってしまうため注意。
+
 ## ライセンス
 
 本プロジェクトは [MIT License](./LICENSE-MIT) または [Apache License 2.0](./LICENSE-APACHE) のデュアルライセンスで配布される。利用者はいずれか一方を選択できる。

--- a/docs/superpowers/plans/2026-04-22-kotoha-phase-0-implementation.md
+++ b/docs/superpowers/plans/2026-04-22-kotoha-phase-0-implementation.md
@@ -1055,7 +1055,14 @@ git push
 - `docs/adr/0001-input-mode-transient-vs-sticky.md`
 - `docs/adr/0002-shift-via-uppercase-char.md`
 - `docs/adr/0003-cli-line-based-commit.md`
+- `docs/adr/0004-rust-toolchain-and-publishing-policy.md` (M1 PR review からの拡張)
 - `docs/wbs/2026-04-XX-feature-N-phase0-adrs.md`(N は対応 ISSUE 番号)
+
+> **M1 PR review からの M7 追加事項**: ADR 0004 は以下を集約する設計判断を記録する。
+> - MSRV 1.80 / Edition 2021 の選定理由(lang-rust.md 推奨の Edition 2024 を採用しない判断)
+> - M1 期間中の `cargo build` 検証例外(global CLAUDE.md mandatory mitigation #1 の明示的例外扱い、Cargo 1.94+ の empty virtual workspace ハードエラーに起因)
+> - LICENSE-MIT の copyright holder に GitHub handle `std-koh-hinooka` を採用した判断
+> - `Cargo.toml` authors への公開メール `koh.hinooka@student.it.com` 埋め込み方針(crates.io publish 時の露出許容)
 
 **Files to modify:**
 

--- a/docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md
+++ b/docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md
@@ -586,7 +586,9 @@ pre-push:
 
 ### 12.2 CI
 
-GitHub Actions は global CLAUDE.md の方針により導入しない。ローカル lefthook に加え、将来は GCP Cloud Build トリガで代替する。
+Kotoha はローカル実行のデスクトップアプリケーション(日本語 IME)であり、クラウドへのデプロイは発生しない。したがって CI/CD システムは導入せず、品質ゲートはローカル lefthook のみで担保する。配布は `.deb` / `.rpm` / Flatpak / AUR 等のパッケージングで行う(Phase 5 以降で詳細化)。
+
+global CLAUDE.md の CI/CD Policy(GitHub Actions 禁止 + GCP Cloud Build Trigger で Deploy)は、クラウドデプロイを前提とする他プロジェクト向け方針である。Kotoha はローカル実行アプリのため GCP は関与しない(言及があれば削除対象)。
 
 ## 13. 成功基準 (Phase 0 完了条件)
 

--- a/docs/wbs/2026-04-22-feature-1-project-setup.md
+++ b/docs/wbs/2026-04-22-feature-1-project-setup.md
@@ -44,7 +44,7 @@ finished: 2026-04-22
 
 - M7 ADR 対象拡張: MSRV/edition 選定理由、M1 cargo build 例外、LICENSE copyright holder、Cargo.toml 公開メール埋め込み方針
 - M2 kickoff 前の lefthook 小改善 PR: `[ -d crates ]` → member 数検査に強化、無害化方式統一、doc-naming に glob 付与、pre-push test timeout、`.gitignore` にシークレットパターン追加
-- Phase 1 前: GCP Cloud Build trigger 構築を ROADMAP に追加
+- ~~Phase 1 前: GCP Cloud Build trigger 構築を ROADMAP に追加~~ → 廃止 (PR #4 で spec §12.2 改訂、Kotoha はローカル実行の日本語 IME で GCP 不要と判断)
 - .github テンプレートの英訳
 - CLAUDE.md 改善(TOC、API doc 明確化、proptest 注記、glossary stub)
 


### PR DESCRIPTION
Follow-up from M1 PR #2 review (issues H3 + M7 ADR expansion).

## Changes

- **spec §12.2**: Remove 'future GCP Cloud Build trigger' — Kotoha is a local desktop app, not a cloud service. Restate as 'no CI/CD, lefthook-only quality gate, future .deb/.rpm/Flatpak packaging in Phase 5+'.
- **README**: Add '開発環境セットアップ' section with mandatory 'lefthook install' step. Mitigates pre-push hook bypass risk.
- **plan M7**: Extend ADR list with 'docs/adr/0004-rust-toolchain-and-publishing-policy.md' to consolidate M1 review follow-ups (MSRV 1.80 / edition 2021 choice, M1 cargo-build exception, LICENSE copyright handle, Cargo.toml authors email).

## Test plan

- [ ] grep confirms no lingering GCP/Cloud Build references in spec/plan (besides the one explanatory deletion-target disclaimer)
- [ ] lefthook pre-push passes (manifest-check only; build/clippy/test skip in M1)
- [ ] README renders on GitHub with new section visible

Closes #3