### PR TITLE
chore: lefthook hardening + .gitignore secret patterns (M2 kickoff prep)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,21 @@
 
 # Claude Code harness (local state)
 .claude/
+
+# Secrets / credentials
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+*.keystore
+credentials.json
+service-account*.json
+*_rsa
+*_ecdsa
+*_ed25519
+id_rsa*
+id_ecdsa*
+id_ed25519*

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,11 @@
 # Kotoha lefthook configuration
 # Origin: ~/.claude/templates/lefthook.yml.template
+# Guard model:
+# - pre-commit fmt-check: uses lefthook-native glob ("*.rs") to skip when no .rs is staged.
+# - pre-commit doc-naming: uses glob to skip when no doc files are staged.
+# - pre-push build/clippy/test: use shell guard '[ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]'
+#   because Cargo workspace commands cannot be skipped by lefthook glob alone (they need to inspect
+#   the full workspace). Until the first crate is added in M2, these are intentional no-ops.
 
 pre-commit:
   parallel: true
@@ -8,6 +14,7 @@ pre-commit:
       glob: "*.rs"
       run: cargo fmt --all --check
     doc-naming:
+      glob: "{docs/**/*.md,CLAUDE.md,**/CLAUDE.md}"
       run: ./scripts/pre-commit-doc-naming.sh
 
 pre-push:
@@ -20,21 +27,21 @@ pre-push:
       run: cargo metadata --no-deps --format-version=1 > /dev/null
     build:
       run: |
-        if [ -d crates ]; then
+        if [ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]; then
           cargo build --workspace
         else
           echo "lefthook: skip build (no crates/ yet; enforced from M2)"
         fi
     clippy:
       run: |
-        if [ -d crates ]; then
+        if [ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]; then
           cargo clippy --workspace --all-targets -- -D warnings
         else
           echo "lefthook: skip clippy (no crates/ yet; enforced from M2)"
         fi
     test:
       run: |
-        if [ -d crates ]; then
+        if [ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]; then
           cargo test --workspace
         else
           echo "lefthook: skip test (no crates/ yet; enforced from M2)"


### PR DESCRIPTION
Follow-up from M1 PR #2 review. Prepares lefthook and .gitignore for M2.

## Changes

### lefthook.yml
- Strengthened guard: pre-push build/clippy/test now use `[ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]` so M2 intermediate commits (crates/ created but Cargo.toml not yet updated) do not hit Cargo hard-error.
- Added glob to pre-commit doc-naming so the script is skipped on Rust-only commits.
- Added top-of-file comment documenting the guard model (glob for pre-commit, shell for pre-push).

### .gitignore
- Added standard secret patterns (.env, *.pem, *.key, id_rsa*, etc.) as defense-in-depth before M2 potentially introduces integration test fixtures or external service integrations.

## Test plan

- [ ] `grep -c 'ls -A crates' lefthook.yml` returns 3
- [ ] `lefthook run pre-commit` and `lefthook run pre-push` both exit 0 on current develop state
- [ ] `.gitignore` matches common secret patterns

Closes #6