### PR TITLE
fix(kotoha-core): normalize convert() mid-stream buffer (#29)

### DIFF
--- a/crates/kotoha-core/src/romaji/mod.rs
+++ b/crates/kotoha-core/src/romaji/mod.rs
@@ -110,11 +110,15 @@ impl RomajiConverter {
                 PushResult::Pending => {}
                 PushResult::Invalid(_) => {}
             }
+            // Mid-stream normalize: settle may leave a residue in the buffer
+            // (e.g. after dropping a leading Invalid char), and that residue
+            // can itself be a complete rule (e.g. "!") that would otherwise
+            // be lost on the next push. See ISSUE #29.
+            out.push_str(&tmp.normalize());
         }
-        // Normalize the terminal buffer so the returned `pending` is idempotent
-        // under a fresh `convert` call. Without this step, partial-then-invalid
-        // transitions (e.g. "byb" → "yb") leak unstable pending values, breaking
-        // associativity. See ISSUE #23.
+        // EOF normalize is now redundant (the loop above keeps the buffer
+        // stable after every push) but kept as defense-in-depth. See ISSUE
+        // #23 for the original buffer-normalization rationale.
         out.push_str(&tmp.normalize());
         let pending = tmp.take_buffer();
         (out, pending)
@@ -441,5 +445,44 @@ mod tests {
                 input, pending
             );
         }
+    }
+
+    #[test]
+    fn convert_commits_punctuation_after_partial_invalid_transition() {
+        // Regression for #29: a partial consonant followed by punctuation
+        // followed by a vowel should commit the punctuation, not drop it.
+        // Before the fix: "b!a" returned ("あ", "") — the "!" was silently dropped
+        // because the mid-stream residue wasn't normalized.
+        let c = RomajiConverter::new();
+        assert_eq!(c.convert("b!a"), ("!あ".to_string(), "".to_string()));
+        assert_eq!(c.convert("b?a"), ("?あ".to_string(), "".to_string()));
+        assert_eq!(c.convert("b.a"), ("。あ".to_string(), "".to_string()));
+        assert_eq!(c.convert("b,a"), ("、あ".to_string(), "".to_string()));
+        assert_eq!(c.convert("b-a"), ("ーあ".to_string(), "".to_string()));
+        assert_eq!(c.convert("b/a"), ("・あ".to_string(), "".to_string()));
+        assert_eq!(c.convert("b[a"), ("「あ".to_string(), "".to_string()));
+        assert_eq!(c.convert("b]a"), ("」あ".to_string(), "".to_string()));
+    }
+
+    #[test]
+    fn convert_associative_across_partial_punctuation_split() {
+        // Regression for #29: split-and-glue evaluation around
+        // partial-consonant + punctuation must match whole evaluation.
+        let c = RomajiConverter::new();
+
+        // Input "b!a", split at 2 ("b!" + "a")
+        let whole = c.convert("b!a");
+        let (lc, lp) = c.convert("b!");
+        let glued = format!("{}{}", lp, "a");
+        let (rc, rp) = c.convert(&glued);
+        assert_eq!(format!("{}{}", lc, rc), whole.0);
+        assert_eq!(rp, whole.1);
+
+        // Input "b!a", split at 1 ("b" + "!a")
+        let (lc, lp) = c.convert("b");
+        let glued = format!("{}{}", lp, "!a");
+        let (rc, rp) = c.convert(&glued);
+        assert_eq!(format!("{}{}", lc, rc), whole.0);
+        assert_eq!(rp, whole.1);
     }
 }


### PR DESCRIPTION
## Summary

Fix for ISSUE #29: `RomajiConverter::convert()` lost mid-stream punctuation commits when a partial-consonant was followed by punctuation and then more input (e.g. `convert(\"b!a\")` returned `(\"あ\", \"\")` instead of `(\"!あ\", \"\")`).

### Root cause

PR #27 (#23 hotfix) added `StateMachine::normalize()` and called it once **after** convert's per-char for-loop. End-of-input residues were stabilized, but mid-stream residues persisted in the buffer. If the next char triggered another Invalid-drop, the previously-stranded residue was silently lost.

### Fix

Call `self.machine.normalize()` **inside** the for-loop after each `push`. Salvaged kana is appended to the `committed` accumulator. The EOF `normalize` call stays as defense-in-depth.

## Before / After

| input | before | after |
|-------|--------|-------|
| `b!a` | `(\"あ\", \"\")` | `(\"!あ\", \"\")` |
| `b?a` | `(\"あ\", \"\")` | `(\"?あ\", \"\")` |
| `b,a` | `(\"あ\", \"\")` | `(\"、あ\", \"\")` |
| `b[a` | `(\"あ\", \"\")` | `(\"「あ\", \"\")` |

(8 punctuation variants total — see commit body.)

## Verification

- **lib tests**: 76 PASS (74 existing + 2 new regression).
- **golden**: 2/2 PASS, all 207 fixture rows unchanged (behaviorally neutral for well-formed inputs).
- **property (M3b narrow strategy)**: 2/2 PASS.
- **clippy workspace -D warnings**: zero.
- **fmt**: no diff.
- **lefthook pre-push**: all PASS.

## Related

- Closes #29
- Unblocks PR #26 (M3b property strategy broaden from `[aeioun]{0,12}` to `[a-z\-'.,!?\[\]/]{0,12}`).
- Builds on PR #27 (#23 hotfix — EOF normalize), PR #28 (#22 ADR 0001 — non-ASCII retraction policy).

## Test plan

- [x] \`cargo test --workspace\` 81 PASS
- [x] \`cargo test -p kotoha-core --test romaji_golden\` 2/2 PASS (207 rows unchanged)
- [x] \`cargo test -p kotoha-core --test romaji_property\` 2/2 PASS
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: zero
- [x] \`cargo fmt --all --check\`: no diff
- [x] \`lefthook run pre-push\`: all PASS