### PR TITLE
docs(adr): record romaji Trie and non_exhaustive decisions (#20)

### DIFF
--- a/crates/kotoha-core/src/romaji/mod.rs
+++ b/crates/kotoha-core/src/romaji/mod.rs
@@ -22,6 +22,8 @@ use crate::romaji::state::{PushResult, StateMachine};
 /// (for example a future "emitted punctuation" or "would-commit-on-flush"
 /// outcome) without breaking external match sites.
 ///
+/// `#[non_exhaustive]` 採用根拠: `docs/adr/0006-non-exhaustive-on-streaming-enums.md`。
+///
 /// Use `Cow<'static, str>` so that common commit values (from the static
 /// rule table) are zero-allocation. Rarely-needed owned strings (from
 /// future computed-commit paths) go through `Cow::Owned`.

--- a/crates/kotoha-core/src/romaji/trie.rs
+++ b/crates/kotoha-core/src/romaji/trie.rs
@@ -7,6 +7,8 @@
 //! - no match and no prefix (`Lookup::None`)
 //!
 //! Consumed by [`crate::romaji::state::StateMachine`].
+//!
+//! 設計判断根拠: `docs/adr/0005-romaji-trie-over-hashmap.md`。
 
 use std::collections::HashMap;
 

--- a/docs/adr/0005-romaji-trie-over-hashmap.md
+++ b/docs/adr/0005-romaji-trie-over-hashmap.md
@@ -1,0 +1,55 @@
+# 0005: ローマ字 lookup に HashMap ではなくカスタム Trie を採用する
+
+## ステータス
+
+承認 (2026-04-23)
+
+## コンテキスト
+
+Kotoha のローマ字→かな変換層は M3a で 207 エントリのルール表を実装した (`crates/kotoha-core/src/romaji/rules.rs`)。`StateMachine::push(char)` は streaming 変換であり、各入力後に「pending buffer = 完全 rule 一致 / rule の proper prefix のみ / どちらでもない」の 3-way 判定を一度の lookup で決定する必要がある (spec §9.3 pending バッファの backtrack 規則)。採用データ構造は、この 3-way lookup と、ルール表 `&'static str` の寿命、将来的な OnceLock キャッシュ化 (ISSUE #19) を同時に満たす必要がある。
+
+## 検討した選択肢
+
+### 選択肢 1: `HashMap<&'static str, &'static str>` + 別途 prefix set
+
+- 利点: 標準ライブラリのみで済み、実装工数が最小。
+- 欠点: 完全一致と prefix 判定で 2 回 lookup が必要。prefix set を別管理すると 2 データ構造の整合性コストが発生し、ルール追加のたびに両方を更新する boilerplate が増える。
+
+### 選択肢 2: カスタム Trie (採用)
+
+- 利点: ノード 1 走査で `Match | Partial | None` を得られる (`Trie::lookup`)。`&'static str` からそのまま構築でき、ISSUE #19 の OnceLock キャッシュと互換。ルール追加は `RULES` 配列だけで完結し、Trie は `from_rules()` で自動構築される。
+- 欠点: HashMap 案比で実装コードが 50 行ほど多い。ノード毎の HashMap により間接参照が増える。
+
+### 選択肢 3: `phf` crate による compile-time perfect hash
+
+- 利点: compile 時ハッシュ化によりランタイム構築コストがゼロ。
+- 欠点: prefix 判定を別データ構造に分離せざるを得ず、3-way lookup の「1 回走査」性を満たせない。build-time code gen の複雑性も Phase 0 に不要。Phase 3 perf tuning 時に再評価候補として deferring する。
+
+## 決定
+
+**選択肢 2 (カスタム Trie)** を採用する。`crates/kotoha-core/src/romaji/trie.rs` に `Trie` と 3-way 分類 `Lookup::{Match, Partial, None}` を実装し、`StateMachine::settle` から単一の `trie.lookup(buffer)` 呼び出しで backtrack 判定を駆動する。
+
+## 影響
+
+### 実装への影響
+
+- `StateMachine::push` / `normalize` は単一の `trie.lookup` 呼び出しで次状態を決定できる (spec §9.3 で normative 化)。
+- Trie は `pub(crate)` に閉じる。将来データ構造を差し替えても `Lookup` 3-way インタフェースを維持すれば呼び出し側は無変更。
+
+### パフォーマンスへの影響
+
+- 初期実装は `StateMachine::new` ごとに Trie を per-call rebuild する。207 エントリでは実測問題なし。OnceLock キャッシュ化は ISSUE #19 で別途 tracking する。
+
+### 将来への影響
+
+- Phase 3 perf tuning で `phf` 再評価の余地がある。`Lookup::{Match, Partial, None}` インタフェースを維持すれば実装差し替え可能。
+
+## 参照
+
+- `crates/kotoha-core/src/romaji/trie.rs` — 本 ADR が決定した Trie 実装。
+- `crates/kotoha-core/src/romaji/rules.rs` — 207 エントリのルール表。
+- `crates/kotoha-core/src/romaji/state.rs` — Trie の呼び出し元 (`StateMachine::settle` / `normalize`)。
+- `docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md` §9 / §9.3。
+- ISSUE #19 — OnceLock キャッシュ最適化 (deferred)。
+- ISSUE #20 — 本 ADR を新設する docs-only ISSUE。
+- PR #18 architecture review (Low finding) — 本 ADR 新設の発端。

--- a/docs/adr/0006-non-exhaustive-on-streaming-enums.md
+++ b/docs/adr/0006-non-exhaustive-on-streaming-enums.md
@@ -1,0 +1,52 @@
+# 0006: Streaming 結果 enum に `#[non_exhaustive]` を付与する
+
+## ステータス
+
+承認 (2026-04-23)
+
+## コンテキスト
+
+ローマ字変換レイヤは 2 種類の streaming 結果 enum を持つ: `ConvertStep` (`crates/kotoha-core/src/romaji/mod.rs`, 外部公開 `pub`) と `PushResult` (`crates/kotoha-core/src/romaji/state.rs`, クレート内部 `pub(crate)`)。M3a 時点の variants は両 enum とも `{Committed(Cow<'static, str>), Pending, Invalid(char)}` である。将来、両 enum に新 variants (例: "emitted punctuation" / "would-commit-on-flush" / Phase 3 の句読点やモード遷移イベント) を足す余地がある。外部 match サイトの網羅性制約と将来拡張の SemVer コストのトレードオフを決定する必要がある。
+
+## 検討した選択肢
+
+### 選択肢 1: 無印 (exhaustive) のまま維持する
+
+- 利点: downstream の `match` は網羅的に書け、variants 追加を compile error で検知できる。
+- 欠点: variants 追加が外部クレート側で breaking change となり SemVer major bump が必要。Phase 3 以降の拡張コストが高い。
+
+### 選択肢 2: `ConvertStep` / `PushResult` の両方に `#[non_exhaustive]` を付与 (採用)
+
+- 利点: クレート境界越しの match サイトで `_ => ...` arm が必須化され、variants 追加を non-breaking (SemVer minor) で行える。`PushResult` にも付与することで、将来 `kotoha-core` から別 crate (例: `kotoha-ibus`) へ再エクスポートする場合も安全性が維持される。streaming 結果 enum 全てが拡張可能という明示的ポリシーとなり、API 設計の一貫性が保たれる。
+- 欠点: 外部利用者は必ず `_` arm を書く必要があり、網羅性チェックの強みを 1 段階弱める。
+
+### 選択肢 3: `ConvertStep` のみ `#[non_exhaustive]`、`PushResult` は無印
+
+- 利点: `PushResult` は `pub(crate)` のため後方互換性問題は無く、最小付与で済む。
+- 欠点: streaming 結果 enum 同士のポリシーが不揃いとなり、将来 refactor 時に「`PushResult` は公開してよいか」の判断が複雑化する。一貫性を犠牲にする利点が軽微な可読性向上に見合わない。
+
+## 決定
+
+**選択肢 2 (両 enum に `#[non_exhaustive]` を付与)** を採用する。M3a 時点で両 enum には既に `#[non_exhaustive]` が付与済みであり、本 ADR はそのポリシーを normative として記録する。
+
+## 影響
+
+### 実装への影響
+
+- クレート内 match は依然として網羅的に書ける (`#[non_exhaustive]` はクレート境界をまたぐ場合のみ制約するため)。
+- 外部クレート (将来の `kotoha-ibus` など) は `ConvertStep` を match する際に `_ => ...` arm が必須となる。
+
+### API 拡張への影響
+
+- 将来 variants の追加 (`EmittedPunctuation` / `WouldCommitOnFlush` 等) は SemVer minor bump で済む。Phase 3 以降の拡張コストが下がる。
+
+### ドキュメントへの影響
+
+- 外部公開 rustdoc に「`_` arm 必須」の注意を明記することが望ましい。`ConvertStep` の rustdoc (`mod.rs:19-37`) には既にその旨が記載されている。
+
+## 参照
+
+- `crates/kotoha-core/src/romaji/mod.rs` — `ConvertStep` 定義 (`pub`, `#[non_exhaustive]`)。
+- `crates/kotoha-core/src/romaji/state.rs` — `PushResult` 定義 (`pub(crate)`, `#[non_exhaustive]`)。
+- ISSUE #20 — 本 ADR を新設する docs-only ISSUE。
+- PR #18 architecture review (Low finding) — 本 ADR 新設の発端。


### PR DESCRIPTION
## Summary

- Add ADR 0005 — custom Trie over HashMap for romaji rule lookup. Records why a trie with a 3-way `Match | Partial | None` interface was chosen over `HashMap<&'static str, &'static str>` + a separate prefix set, and why `phf` was deferred to Phase 3 perf tuning.
- Add ADR 0006 — `#[non_exhaustive]` on `ConvertStep` / `PushResult`. Records why both streaming-result enums carry `#[non_exhaustive]` so future variants (e.g. `EmittedPunctuation`, `WouldCommitOnFlush`) can be added as SemVer minor bumps.
- Add one-line rustdoc citations from `trie.rs` module-level doc and `ConvertStep` doc pointing at the new ADRs, so future readers can find the normative rationale from the source.
- Both decisions were flagged in PR #18 architecture review (Low finding) as undocumented; this PR closes that gap.

## Out of scope

- The M7 section of `docs/superpowers/plans/2026-04-22-kotoha-phase-0-implementation.md` still references the pre-renumbering ADR scheme (0001=retraction already merged, 0002=input-mode already merged, 0003 / 0004 reserved). Fixing those stale references is tracked as a separate follow-up ISSUE and is intentionally not part of #20.

## Test plan

- [x] `cargo build --workspace` (passes)
- [x] `cargo test --workspace` (all unit + golden + property + doc-tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings)
- [x] `cargo fmt --all --check` (clean)
- [x] lefthook pre-commit (doc-naming + fmt-check) passes
- [x] lefthook pre-push (build + clippy + manifest-check + test) passes
- [x] Code premise verified: `ConvertStep` and `PushResult` are both `#[non_exhaustive]` in current code; trie implements the 3-way `Match | Partial | None` lookup interface described in ADR 0005.

Closes #20