### PR TITLE
docs(adr): add ADR 0008 stub — canonical romaji tracking hook (#16)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,12 @@ Kotoha プロジェクトの開発フェーズと、各フェーズの到達目�
 
 Phase 0 の詳細マイルストーン分割は `docs/superpowers/plans/2026-04-22-kotoha-phase-0-implementation.md` を参照。
 
+## Phase 1 への申し送り
+
+Phase 0 完了時に Phase 1 へ引き継ぐ設計判断事項を記録する。
+
+- **canonical romaji ADR** (`docs/adr/0008-canonical-romaji-and-partial-invertibility.md`): Phase 0 の spec §11.3 revision 2 で除外した「可逆性」プロパティについて、canonical romaji を定義して部分的可逆性を回復する拡張を Phase 1 で検討する。本 ADR はステータス「提案」の placeholder であり、Phase 1 計画開始時に 3 選択肢 (現状維持 / canonical 定義 / configuration で選択) から決定して正式 ADR に昇格する。
+
 ## 注記
 
 - Phase 5 の「Shift 挙動設定」は、設計書 revision 2 の判断により Phase 0 に前倒しされた。Phase 5 は「タイポ訂正 + 文脈リランキング」のみ。

--- a/docs/adr/0008-canonical-romaji-and-partial-invertibility.md
+++ b/docs/adr/0008-canonical-romaji-and-partial-invertibility.md
@@ -1,0 +1,32 @@
+# 0008: canonical romaji 定義と部分的可逆性の回復 (Phase 1 検討事項)
+
+## ステータス
+
+提案 (2026-04-23) — Phase 1 で最終決定する placeholder
+
+## コンテキスト
+
+Phase 0 の romaji 変換は多対一マッピングを採用している: `ji` / `zi` → じ、`tu` / `tsu` → つ、`si` / `shi` → し、`ti` / `chi` → ち などの異体ペアが複数存在する。strict な round-trip invertibility (`romaji → kana → romaji == romaji`) は数学的に定義不能なため、spec §11.3 revision 2 でプロパティテスト集合から除外した。
+
+§11.3 の該当段落は「canonical romaji を定義して部分的に可逆性を回復する拡張は Phase 1 以降で検討する(ADR 候補)」で結ばれている。本 ADR はその「ADR 候補」を placeholder として開設し、Phase 1 計画時に忘れず参照されることを保証する tracking hook の役割を果たす。
+
+## 検討した選択肢 (Phase 1 で正式評価)
+
+- **選択肢 1: canonical romaji を定義しない (現状維持)** — 多対一のまま。Phase 1 以降のかな漢字変換層は invariants を romaji 側に戻せない前提で設計。
+- **選択肢 2: canonical romaji を定義し partial invertibility を確立** — 各異体ペアから 1 つを正規形として選択 (例: `ji` / `tsu` / `shi` / `chi` を採用)。property test に `canonicalize_then_invert` を追加。
+- **選択肢 3: canonical romaji を configuration で選択可能にする** — ユーザ / ライブラリ利用者が正規形を選ぶ。複雑性が高い。
+
+## 決定
+
+**保留 (Phase 1 で決定)**。本 ADR は tracking hook であり、Phase 1 計画開始時に本 ADR をレビューし上記 3 選択肢から決定する。決定が確定した時点で本 ADR のステータスを「承認」に更新し、必要に応じて別 ADR 番号として fork する。
+
+## 影響 (決定後に記述)
+
+Phase 1 の計画で選択肢を決定した後に追記する。
+
+## 参照
+
+- `docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md` §11.3 (invariants 集合と canonical romaji の言及)
+- `docs/ROADMAP.md` Phase 1 carry-over セクション
+- ISSUE #16 (本 ADR 作成 tracking)
+- PR #14 architecture review (発見経緯)

--- a/docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md
+++ b/docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md
@@ -619,7 +619,7 @@ Karukan の既存挙動と Kotoha で結果が異なる入力パターンを並�
 
 既存 2 条件(冪等性 / 結合性)に加えて、モード系の不変条件を `proptest` で検証する。
 
-なお、revision 1 では可逆性(invertibility)も "既存" プロパティとして列挙していたが、romaji → かな は多対一(`ji`/`zi` → じ、`tu`/`tsu` → つ、`si`/`shi` → し、`ti`/`chi` → ち 等)であり strict な round-trip invertibility は数学的に定義不能なため、Phase 0 のプロパティ集合からは除外する。canonical romaji を定義して部分的に可逆性を回復する拡張は Phase 1 以降で検討する(ADR 候補)。
+なお、revision 1 では可逆性(invertibility)も "既存" プロパティとして列挙していたが、romaji → かな は多対一(`ji`/`zi` → じ、`tu`/`tsu` → つ、`si`/`shi` → し、`ti`/`chi` → ち 等)であり strict な round-trip invertibility は数学的に定義不能なため、Phase 0 のプロパティ集合からは除外する。canonical romaji を定義して部分的に可逆性を回復する拡張は Phase 1 以降で検討する(ADR 候補: `docs/adr/0008-canonical-romaji-and-partial-invertibility.md` — 提案ステータスの placeholder)。
 
 | 不変条件 | 意味 |
 |---|---|


### PR DESCRIPTION
## Summary

Adds three independent tracking hooks for the "canonical romaji ADR 候補" commitment buried in spec §11.3 revision 2, so the Phase 1 carry-over decision does not silently disappear:

- **ADR 0008 stub** (`docs/adr/0008-canonical-romaji-and-partial-invertibility.md`) at status 提案, documenting three Phase 1 options (status quo / define canonical / user-configurable).
- **ROADMAP.md** gains a new `Phase 1 への申し送り` subsection explicitly citing ADR 0008.
- **Spec §11.3** edit promotes the bare "ADR 候補" phrase into a concrete pointer at the stub ADR file path.

## Numbering choice rationale

ISSUE #16 body suggested number `0005`, but the canonical ADR numbering settled after #16 was filed: 0005 (Trie, PR #45) / 0006 (non_exhaustive, PR #45) / 0007 (rust-toolchain, reserved for M7) are already consumed. Next free slot is **0008**.

## Out of scope

- This PR does **not** decide canonical romaji itself — it only opens a placeholder so Phase 1 planning does not miss the decision.
- No code changes; docs-only.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] lefthook pre-commit + pre-push passed
- [x] ADR cross-links (spec §11.3 → ADR 0008, ROADMAP → ADR 0008, ADR 0008 → spec §11.3) verified

Closes #16