### PR TITLE
perf(kotoha-core): cache Trie in OnceLock to eliminate per-call rebuild (#19)

### DIFF
--- a/crates/kotoha-core/src/romaji/state.rs
+++ b/crates/kotoha-core/src/romaji/state.rs
@@ -13,8 +13,35 @@
 //! module implements it.
 
 use std::borrow::Cow;
+use std::sync::OnceLock;
 
 use crate::romaji::trie::{Lookup, Trie};
+
+/// Returns a reference to the process-wide cached [`Trie`].
+///
+/// Builds the trie from [`crate::romaji::rules::RULES`] on first call via
+/// [`OnceLock::get_or_init`] and returns the same `&'static Trie` on every
+/// subsequent call. Thread-safe by `OnceLock`'s documented contract
+/// (exactly one initializer wins, other threads block until it completes).
+///
+/// # Rationale
+/// Prior to ISSUE #19, [`StateMachine::new`] called
+/// [`Trie::from_rules`] on every construction, which happened once per
+/// [`crate::romaji::RomajiConverter::new`] and once per
+/// [`crate::romaji::RomajiConverter::convert`] call (the batch path
+/// allocates an internal `StateMachine`). The rebuild is μs-order for the
+/// current 207-entry rule table but is strictly wasted work and puts
+/// allocator pressure on any keystroke-frequency hot path (for example
+/// the Phase 3 IBus engine). Caching the trie in a `static OnceLock`
+/// eliminates all rebuild cost after the first call.
+///
+/// # Postconditions
+/// - Every call returns a reference that compares equal (by pointer) to
+///   every other call's return value within the same process.
+fn global_trie() -> &'static Trie {
+    static TRIE: OnceLock<Trie> = OnceLock::new();
+    TRIE.get_or_init(Trie::from_rules)
+}
 
 /// Outcome of feeding a single char to the state machine.
 ///
@@ -44,7 +71,10 @@ pub(crate) enum PushResult {
 ///   such matches are consumed immediately by [`StateMachine::settle`].
 #[derive(Debug)]
 pub(crate) struct StateMachine {
-    trie: Trie,
+    /// Reference to the process-wide cached trie obtained via
+    /// [`global_trie`]. The trie itself is immutable after
+    /// initialization; only the pending buffer mutates per push.
+    trie: &'static Trie,
     /// Pending input buffer, ASCII bytes only (push rejects non-ASCII).
     buffer: String,
 }
@@ -52,11 +82,14 @@ pub(crate) struct StateMachine {
 impl StateMachine {
     /// Constructs a new state machine with an empty buffer.
     ///
+    /// Takes a reference to the globally cached trie (see [`global_trie`]);
+    /// the trie is not rebuilt per construction.
+    ///
     /// # Postconditions
     /// - `self.buffer()` returns the empty string.
     pub(crate) fn new() -> Self {
         Self {
-            trie: Trie::from_rules(),
+            trie: global_trie(),
             buffer: String::new(),
         }
     }
@@ -421,5 +454,32 @@ mod tests {
         let committed = sm.normalize();
         assert_eq!(committed, "", "no kana salvaged from yk");
         assert_eq!(sm.buffer(), "k", "yk should reduce to k");
+    }
+
+    #[test]
+    fn global_trie_returns_same_instance_across_calls() {
+        // Regression for ISSUE #19: global_trie() must return the cached
+        // &'static Trie, never a freshly built one. Pointer equality is the
+        // strongest observable signal of cache behavior — a rebuilt Trie
+        // would live at a different address.
+        let ptr1 = std::ptr::from_ref(super::global_trie());
+        let ptr2 = std::ptr::from_ref(super::global_trie());
+        assert_eq!(
+            ptr1, ptr2,
+            "global_trie() must return the cached &'static Trie, not a rebuilt one"
+        );
+    }
+
+    #[test]
+    fn state_machine_new_shares_trie_with_global_cache() {
+        // Companion to the above: construct two StateMachines and confirm
+        // both hold the same &'static Trie as global_trie(). Guards against
+        // a future regression where StateMachine::new() accidentally falls
+        // back to per-call construction.
+        let sm1 = StateMachine::new();
+        let sm2 = StateMachine::new();
+        let global_ptr = std::ptr::from_ref(super::global_trie());
+        assert_eq!(std::ptr::from_ref(sm1.trie), global_ptr);
+        assert_eq!(std::ptr::from_ref(sm2.trie), global_ptr);
     }
 }

--- a/docs/adr/0005-romaji-trie-over-hashmap.md
+++ b/docs/adr/0005-romaji-trie-over-hashmap.md
@@ -39,6 +39,7 @@ Kotoha のローマ字→かな変換層は M3a で 207 エントリのルール
 ### パフォーマンスへの影響
 
 - 初期実装は `StateMachine::new` ごとに Trie を per-call rebuild する。207 エントリでは実測問題なし。OnceLock キャッシュ化は ISSUE #19 で別途 tracking する。
+- **更新 (2026-04-23)**: ISSUE #19 で `std::sync::OnceLock<Trie>` による process-wide cache を `crates/kotoha-core/src/romaji/state.rs::global_trie` に導入し、per-call rebuild 問題は解消済み。`StateMachine.trie` は `&'static Trie` として cache を参照する。
 
 ### 将来への影響
 


### PR DESCRIPTION
## Summary

Introduce a process-wide `OnceLock<Trie>` cache so that the romaji trie is built exactly once per process instead of on every `StateMachine::new()` call. `StateMachine.trie` becomes `&'static Trie`, sharing the cached instance across every `RomajiConverter::new()` and every `RomajiConverter::convert()` batch call.

Closes #19.

## Why

`StateMachine::new()` previously called `Trie::from_rules()` on every construction. That construction happened once per `RomajiConverter::new()` and once more per `RomajiConverter::convert()` (the batch path allocates a throwaway internal state machine). With the current 207-entry rule table the rebuild is μs-order, but it is strictly wasted work and puts allocator pressure on any keystroke-frequency hot path (for example the Phase 3 IBus engine).

ADR 0005 (`docs/adr/0005-romaji-trie-over-hashmap.md` "影響" section) explicitly deferred this optimization to this ISSUE; the `Trie` type interface (Send + Sync, immutable after `from_rules`) was already compatible.

## Implementation notes

- New module-private function `global_trie() -> &'static Trie` in `romaji/state.rs` wraps a `static TRIE: OnceLock<Trie>` and calls `get_or_init(Trie::from_rules)`.
- `StateMachine.trie` field changes from owned `Trie` to `&'static Trie`. All existing `self.trie.lookup(&self.buffer)` call sites compile unchanged (lookup takes `&self`).
- No public API change. `RomajiConverter::new()`, `::convert()`, `::push()`, `::flush()`, `::reset()`, `::normalize_pending()` all keep their signatures and semantics.
- `trie.rs` is untouched. The in-module tests continue to exercise `Trie::from_rules()` directly, which is correct because those tests exercise the constructor itself rather than the cached instance.
- ADR 0005 "影響" section gets a one-line update noting the cache is now in place (1 line added).

## Thread-safety argument

- `OnceLock::get_or_init` guarantees exactly one initializer wins under contention; other threads block until the winner returns, then all readers see the same `&T`.
- `Trie` contains `Node { value: Option<&'static str>, children: HashMap<u8, Node> }`; every field is Send + Sync, so `Trie: Send + Sync` and `OnceLock<Trie>: Send + Sync` by auto-trait propagation.
- `Trie::from_rules()` is pure and panic-free (only `HashMap::entry` + `Option` writes; no fallible I/O, no `unwrap`/`expect`). Racing initializers therefore observe the same final state.

## Test plan

- [x] `cargo build --workspace`: clean
- [x] `cargo test --workspace`: 102 lib tests + all integration + doc tests pass
- [x] `cargo test -p kotoha-core --lib romaji`: 53 passed (baseline 51 + 2 new cache-coverage tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all --check`: clean
- [x] New test `global_trie_returns_same_instance_across_calls` asserts `std::ptr::from_ref` equality across two `global_trie()` calls.
- [x] New test `state_machine_new_shares_trie_with_global_cache` asserts two independent `StateMachine::new()` instances share the same trie pointer as `global_trie()`.

## Out of scope

- No `phf` evaluation (still deferred per ADR 0005 to Phase 3 perf tuning).
- No benchmark numbers; the change is a strict improvement (one fewer allocation-heavy step per `convert` call) and the test suite verifies functional equivalence.