### PR TITLE
test(kotoha-core): close 55-key golden fixture coverage gap (#25)

### DIFF
--- a/crates/kotoha-core/src/lib.rs
+++ b/crates/kotoha-core/src/lib.rs
@@ -11,3 +11,21 @@ pub mod romaji;
 pub use error::{Error, Result};
 pub use input::{InputContext, InputMode, InputStep};
 pub use romaji::{ConvertStep, RomajiConverter};
+
+/// Test-only accessor for the romaji rule table.
+///
+/// Returns the raw `(romaji_key, kana_value)` pairs as declared in
+/// `romaji::rules::RULES`. Exposed for integration tests that need to
+/// assert that the golden fixture (`tests/fixtures/romaji_cases.tsv`)
+/// covers every rule key, without leaking the `pub(crate)` visibility
+/// of the underlying `romaji::rules` module to downstream consumers.
+///
+/// # Stability
+/// Not part of the stable public API. The `__test_only_` prefix and
+/// `#[doc(hidden)]` attribute signal that external crates must not
+/// depend on this function; it exists solely for the `kotoha-core`
+/// integration test suite.
+#[doc(hidden)]
+pub fn __test_only_romaji_rules() -> &'static [(&'static str, &'static str)] {
+    crate::romaji::rules::RULES
+}

--- a/crates/kotoha-core/tests/fixtures/romaji_cases.tsv
+++ b/crates/kotoha-core/tests/fixtures/romaji_cases.tsv
@@ -244,3 +244,88 @@ onegaishimasu	おねがいします
 gakkou	がっこう	
 nihongo	にほんご	
 kyou	きょう	
+
+# --- yoon k-row extensions (kye, kyi) ---
+kyi	きぃ	
+kye	きぇ	
+
+# --- yoon s-row extensions (syi, sye, she) ---
+syi	しぃ	
+sye	しぇ	
+she	しぇ	
+
+# --- yoon t-row extensions (tyi, tye, che) ---
+tyi	ちぃ	
+tye	ちぇ	
+che	ちぇ	
+
+# --- yoon n-row extensions (nyi, nye) ---
+nyi	にぃ	
+nye	にぇ	
+
+# --- yoon h-row extensions (hyi, hye) ---
+hyi	ひぃ	
+hye	ひぇ	
+
+# --- yoon m-row extensions (myi, mye) ---
+myi	みぃ	
+mye	みぇ	
+
+# --- yoon r-row extensions (ryi, rye) ---
+ryi	りぃ	
+rye	りぇ	
+
+# --- yoon g-row extensions (gyi, gye) ---
+gyi	ぎぃ	
+gye	ぎぇ	
+
+# --- yoon z-row / j-row (zya/zyu/zyo/zye/zyi + ja/ju/je/jo) ---
+zya	じゃ	
+zyi	じぃ	
+zyu	じゅ	
+zye	じぇ	
+zyo	じょ	
+ja	じゃ	
+ju	じゅ	
+je	じぇ	
+jo	じょ	
+
+# --- yoon d-row (dya/dyi/dyu/dye/dyo) ---
+dya	ぢゃ	
+dyi	ぢぃ	
+dyu	ぢゅ	
+dye	ぢぇ	
+dyo	ぢょ	
+
+# --- yoon b-row (bya/byi/byu/bye/byo) ---
+bya	びゃ	
+byi	びぃ	
+byu	びゅ	
+bye	びぇ	
+byo	びょ	
+
+# --- yoon p-row (pya/pyi/pyu/pye/pyo) ---
+pya	ぴゃ	
+pyi	ぴぃ	
+pyu	ぴゅ	
+pye	ぴぇ	
+pyo	ぴょ	
+
+# --- extended gw-row (gwi, gwe, gwo) ---
+gwi	ぐぃ	
+gwe	ぐぇ	
+gwo	ぐぉ	
+
+# --- extended wh-row (whe, who) ---
+whe	うぇ	
+who	うぉ	
+
+# --- small-form x-prefixed kana (xya/xyu/xyo/xn/xwa/xtsu + lwa/ltsu) ---
+xya	ゃ	
+xyu	ゅ	
+xyo	ょ	
+xn	ん	
+xwa	ゎ	
+xtsu	っ	
+lwa	ゎ	
+ltsu	っ	

--- a/crates/kotoha-core/tests/romaji_golden.rs
+++ b/crates/kotoha-core/tests/romaji_golden.rs
@@ -4,6 +4,7 @@
 //! `RomajiConverter::convert(input)` equals `(expected_committed, expected_pending)`
 //! for every non-comment, non-empty row.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -45,13 +46,31 @@ fn load_cases() -> Vec<Case> {
     cases
 }
 
+/// Ensures the golden fixture exercises every key declared in the
+/// `romaji::rules::RULES` table.
+///
+/// Without this cross-check, a newly added (or regressed) rule entry
+/// that lacks a fixture row would silently escape the
+/// `every_fixture_row_matches_converter` check, because that test
+/// only iterates the fixture — not the rule table. The check below
+/// turns the invariant "every RULES key has golden coverage" into a
+/// compile-and-run-time guard: any uncovered key is reported with
+/// its kana value to simplify adding the missing fixture row.
 #[test]
-fn fixture_has_at_least_200_cases() {
+fn every_rule_key_has_golden_coverage() {
     let cases = load_cases();
+    let fixture_inputs: HashSet<&str> = cases.iter().map(|c| c.input.as_str()).collect();
+    let rules = kotoha_core::__test_only_romaji_rules();
+    let missing: Vec<(&'static str, &'static str)> = rules
+        .iter()
+        .filter(|(k, _)| !fixture_inputs.contains(*k))
+        .copied()
+        .collect();
     assert!(
-        cases.len() >= 200,
-        "fixture must have >= 200 cases, got {}",
-        cases.len()
+        missing.is_empty(),
+        "{} rule key(s) missing from golden fixture (each entry is (romaji_key, expected_kana)): {:?}",
+        missing.len(),
+        missing
     );
 }
 


### PR DESCRIPTION
## Summary

- Close the 55-key coverage gap between `romaji::rules::RULES` (207 entries) and `tests/fixtures/romaji_cases.tsv` (was 152 covered).
- Add `#[doc(hidden)] pub fn __test_only_romaji_rules()` accessor at crate root so integration tests can cross-check fixture coverage without leaking `pub(crate)` visibility of the `romaji::rules` module.
- Add `every_rule_key_has_golden_coverage` test that fails with a concrete missing-keys list if any rule key lacks a fixture row. Replaces the weaker `fixture_has_at_least_200_cases` floor check.

Coverage: 152/207 rule keys (73.4%) → 207/207 (100%).

## Implementation notes

- The 55 new fixture rows are grouped by morphological family with section comments matching the existing fixture style:
  - yoon extensions for k/s/t/n/h/m/r/g rows (yi / ye variants)
  - z-row ji-variants (zya..zyo) + hepburn j-row (ja/ju/je/jo)
  - dy-row (dya..dyo), b-row (bya..byo), p-row (pya..pyo)
  - gw-row extensions (gwi/gwe/gwo), wh-row (whe/who)
  - small x-prefixed kana (xya/xyu/xyo/xn/xwa/xtsu + lwa/ltsu)
  - she / che / syi / sye / tyi / tye (hepburn / Nihon-shiki extensions)
- Accessor design rationale: the `__test_only_` prefix + `#[doc(hidden)]` keeps production visibility intact while granting integration tests read access to the rule table. No `cfg(test)` gate was necessary; the function is cheap and emits no binary overhead beyond a slice return.
- The existing `every_fixture_row_matches_converter` check confirmed every new row's `(input, committed, pending)` triple matches `RomajiConverter::convert`. No RULES table or production code changes.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all crates green (kotoha-core: 48 passed, others green)
- [x] `cargo test -p kotoha-core --test romaji_golden` — `every_rule_key_has_golden_coverage` PASSES on first run alongside `every_fixture_row_matches_converter`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] lefthook pre-commit (doc-naming + fmt-check) — pass
- [x] lefthook pre-push (build + clippy + manifest + test) — pass

## Out of scope

- No RULES table changes.
- No production code changes outside the crate-root accessor addition.
- No changes to the aggregated-failure reporting format in `every_fixture_row_matches_converter`.

Closes #25