### PR TITLE
M6 (impl): kotoha-cli — kotoha-romaji binary + phase0-smoke.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +90,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "equivalent"
@@ -140,10 +236,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "kotoha-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "kotoha-core",
+]
 
 [[package]]
 name = "kotoha-core"
@@ -198,6 +308,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
@@ -397,6 +513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +610,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
     "crates/kotoha-core",
-    # crates/kotoha-cli は M6 で追加
+    "crates/kotoha-cli",
 ]
 
 [workspace.package]
@@ -19,3 +19,4 @@ anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 proptest = "1.5"
+clap = { version = "4.5", features = ["derive"] }

--- a/crates/kotoha-cli/Cargo.toml
+++ b/crates/kotoha-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kotoha-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Kotoha: command-line frontend for manual verification of the Kotoha Japanese IME core"
+
+[dependencies]
+kotoha-core = { path = "../kotoha-core" }
+clap = { workspace = true }
+
+[[bin]]
+name = "kotoha-romaji"
+path = "src/bin/romaji.rs"
+
+# src/lib.rs は process_line / format_line_output を unit-testable に切り出すために存在する。
+# binary 側は `use kotoha_cli::process_line;` 等でライブラリ層を参照する。

--- a/crates/kotoha-cli/src/bin/romaji.rs
+++ b/crates/kotoha-cli/src/bin/romaji.rs
@@ -1,0 +1,92 @@
+//! `kotoha-romaji` — Phase 0 manual-verification CLI for the Kotoha IME.
+//!
+//! Reads stdin line by line, feeds each char through
+//! [`kotoha_core::InputContext`], and prints the committed string (with
+//! an optional mode suffix) to stdout.
+//!
+//! See spec §10 for the full contract and spec §13.2 for the 10
+//! acceptance assertions covered by `scripts/phase0-smoke.sh`.
+
+use std::io::{self, BufRead, Write};
+use std::process::ExitCode;
+
+use clap::{Parser, ValueEnum};
+use kotoha_cli::{format_line_output, process_line};
+use kotoha_core::{InputContext, InputMode};
+
+/// CLI mode selector.
+///
+/// Mirrors [`kotoha_core::InputMode`] but is declared locally so we can
+/// attach `#[derive(ValueEnum)]`. The conversion to the library type
+/// happens in [`CliMode::into_input_mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliMode {
+    /// Romaji → kana conversion mode (default).
+    Hiragana,
+    /// Direct ASCII / punctuation passthrough mode (Sticky origin).
+    Direct,
+}
+
+impl CliMode {
+    fn into_input_mode(self) -> InputMode {
+        match self {
+            CliMode::Hiragana => InputMode::Hiragana,
+            CliMode::Direct => InputMode::Direct,
+        }
+    }
+}
+
+/// Phase 0 CLI for manual verification of Kotoha's romaji → kana core.
+#[derive(Debug, Parser)]
+#[command(
+    name = "kotoha-romaji",
+    version,
+    about = "Phase 0 CLI for manual verification of Kotoha's romaji → kana core"
+)]
+struct Cli {
+    /// Initial input mode.
+    #[arg(short = 'm', long = "mode", value_enum, default_value_t = CliMode::Hiragana)]
+    mode: CliMode,
+
+    /// Append ` [H]` or ` [D]` to each output line to show the current mode.
+    #[arg(long = "show-mode", default_value_t = false)]
+    show_mode: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let mut ctx = InputContext::new();
+    // `--mode direct` sets Sticky Direct before entering the stdin loop
+    // so commit() does NOT auto-return to Hiragana (plan 既知懸念 3).
+    if cli.mode == CliMode::Direct {
+        ctx.set_mode(cli.mode.into_input_mode());
+    }
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+
+    for line_result in stdin.lock().lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("kotoha-romaji: failed to read from stdin: {e}");
+                // Spec §10.5 maps read failure to exit 1. (Arg-parse errors
+                // exit 2 via clap default; see plan 既知懸念 4.)
+                return ExitCode::from(1);
+            }
+        };
+        let committed = process_line(&mut ctx, &line);
+        // `--show-mode` reflects the mode AFTER commit (i.e., what the
+        // next line would start in). Transient → Hiragana auto-return
+        // has already happened inside process_line.
+        let formatted = format_line_output(&committed, ctx.mode(), cli.show_mode);
+        if let Err(e) = writeln!(stdout, "{formatted}") {
+            eprintln!("kotoha-romaji: failed to write to stdout: {e}");
+            return ExitCode::from(1);
+        }
+    }
+
+    ExitCode::SUCCESS
+}

--- a/crates/kotoha-cli/src/lib.rs
+++ b/crates/kotoha-cli/src/lib.rs
@@ -1,0 +1,163 @@
+//! Line-based helpers for the `kotoha-romaji` CLI binary.
+//!
+//! This crate exposes two pure functions ([`process_line`] and
+//! [`format_line_output`]) that the binary entry point
+//! (`src/bin/romaji.rs`) calls. Keeping the logic pure keeps the
+//! binary thin and the behavior covered by unit tests without spawning
+//! a subprocess.
+//!
+//! # Behavior pins (see plan M6 §『本 M6 plan 内で解決する既知の懸念』)
+//!
+//! - [`InputStep::Preedit`] is dropped silently (Phase 0 CLI is not a
+//!   REPL; spec §10.4 defers interactive preedit to Phase 3).
+//! - [`InputStep::Invalid`] is dropped silently (matches spec §9.3.2
+//!   `InputContext` internal behavior).
+//! - `--show-mode` suffix uses `[H]` for [`InputMode::Hiragana`] and
+//!   `[D]` for [`InputMode::Direct`] with no Transient / Sticky
+//!   distinction (`ModeOrigin` is `pub(crate)`).
+
+use kotoha_core::{InputContext, InputMode, InputStep};
+
+/// Feeds every char of `line` through the mode state machine, then
+/// commits at end-of-line. Returns the committed-per-line string,
+/// excluding any trailing newline.
+///
+/// # Preconditions
+/// - `ctx` is in any valid state (the caller guarantees the state-tuple
+///   invariant documented on [`InputContext`]).
+///
+/// # Postconditions
+/// - `ctx` has its per-line buffer drained (Hiragana pending flushed,
+///   Direct buffer cleared).
+/// - If `ctx.mode()` was `(Direct, Transient)` at the start of the
+///   call and a commit actually occurred, the post-call mode is
+///   [`InputMode::Hiragana`] per ADR 0002.
+pub fn process_line(ctx: &mut InputContext, line: &str) -> String {
+    let mut out = String::new();
+    for ch in line.chars() {
+        match ctx.input_char(ch) {
+            InputStep::Committed(s) => out.push_str(&s),
+            InputStep::Preedit | InputStep::Invalid(_) => {
+                // Intentionally silent per plan M6 既知懸念 1.
+            }
+            // `InputStep` is `#[non_exhaustive]`; future variants default to silent drop.
+            _ => {}
+        }
+    }
+    out.push_str(&ctx.commit());
+    out
+}
+
+/// Formats the per-line CLI output with the optional mode suffix.
+///
+/// # Preconditions
+/// - `committed` is the value returned from [`process_line`] (no trailing newline).
+///
+/// # Postconditions
+/// - If `show_mode == false`, returns `committed` verbatim.
+/// - If `show_mode == true`, appends ` [H]` for [`InputMode::Hiragana`]
+///   or ` [D]` for [`InputMode::Direct`] (separator = single ASCII space).
+pub fn format_line_output(committed: &str, mode: InputMode, show_mode: bool) -> String {
+    if !show_mode {
+        return committed.to_string();
+    }
+    let tag = match mode {
+        InputMode::Hiragana => "H",
+        InputMode::Direct => "D",
+        _ => "?", // `InputMode` is `#[non_exhaustive]`; defensive fallback.
+    };
+    format!("{committed} [{tag}]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T1
+    #[test]
+    fn process_line_hiragana_basic() {
+        let mut ctx = InputContext::new();
+        let out = process_line(&mut ctx, "konnnichiha");
+        assert_eq!(out, "こんにちは");
+        assert_eq!(ctx.mode(), InputMode::Hiragana);
+    }
+
+    // T2
+    #[test]
+    fn process_line_shift_trigger_auto_returns() {
+        let mut ctx = InputContext::new();
+        let out = process_line(&mut ctx, "Hello");
+        assert_eq!(out, "Hello");
+        // Transient Direct → commit auto-returns to (Hiragana, Sticky).
+        assert_eq!(ctx.mode(), InputMode::Hiragana);
+    }
+
+    // T3
+    #[test]
+    fn process_line_sticky_direct_persists() {
+        let mut ctx = InputContext::new();
+        ctx.set_mode(InputMode::Direct);
+        let out = process_line(&mut ctx, "hello");
+        assert_eq!(out, "hello");
+        // Sticky Direct → commit does NOT auto-return.
+        assert_eq!(ctx.mode(), InputMode::Direct);
+    }
+
+    // T4
+    #[test]
+    fn process_line_empty_is_empty() {
+        let mut ctx = InputContext::new();
+        let out = process_line(&mut ctx, "");
+        assert_eq!(out, "");
+        assert_eq!(ctx.mode(), InputMode::Hiragana);
+    }
+
+    // T5
+    #[test]
+    fn format_line_output_with_hiragana_shows_h() {
+        let s = format_line_output("こん", InputMode::Hiragana, true);
+        assert_eq!(s, "こん [H]");
+    }
+
+    // T6
+    #[test]
+    fn format_line_output_with_direct_shows_d() {
+        let s = format_line_output("hi", InputMode::Direct, true);
+        assert_eq!(s, "hi [D]");
+    }
+
+    // T7
+    #[test]
+    fn format_line_output_without_show_mode_no_suffix() {
+        let s = format_line_output("こん", InputMode::Hiragana, false);
+        assert_eq!(s, "こん");
+    }
+
+    // T8
+    #[test]
+    fn process_line_carries_mode_between_calls() {
+        let mut ctx = InputContext::new();
+        ctx.set_mode(InputMode::Direct);
+        // Line 1 in Sticky Direct.
+        let o1 = process_line(&mut ctx, "hello");
+        assert_eq!(o1, "hello");
+        assert_eq!(ctx.mode(), InputMode::Direct);
+        // Line 2 also in Sticky Direct.
+        let o2 = process_line(&mut ctx, "world");
+        assert_eq!(o2, "world");
+        assert_eq!(ctx.mode(), InputMode::Direct);
+    }
+
+    // T9
+    #[test]
+    fn process_line_invalid_chars_are_dropped_silently() {
+        // Non-ASCII single char in Hiragana mode: InputContext drops it
+        // via Invalid(char) path (spec §9.3.2). CLI must not surface it.
+        // Feeding U+3042 'あ' first then 'a':
+        // 'あ' is Invalid in Hiragana context and is dropped.
+        // 'a' follows the romaji 'a' rule → 'あ'.
+        let mut ctx = InputContext::new();
+        let out = process_line(&mut ctx, "\u{3042}a");
+        assert_eq!(out, "あ");
+    }
+}

--- a/scripts/phase0-smoke.sh
+++ b/scripts/phase0-smoke.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Phase 0 smoke test — runs spec §13.2's 10 CLI acceptance assertions.
+#
+# Usage:
+#   scripts/phase0-smoke.sh
+#
+# Exit codes:
+#   0   — all 10 assertions PASS
+#   1   — at least one assertion FAILED (or build error)
+#
+# Invocation model: uses `cargo run -p kotoha-cli --bin kotoha-romaji --`
+# (debug build) per plan M6 §『本 M6 plan 内で解決する既知の懸念』. The
+# first invocation triggers compilation; subsequent invocations re-use
+# the cache and start in < 200 ms.
+#
+# Reference:
+#   - Spec §13.2 (docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md)
+#   - Plan  M6   (docs/superpowers/plans/2026-04-23-kotoha-phase-0-m6.md)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FAIL_COUNT=0
+PASS_COUNT=0
+TOTAL=10
+
+# Pre-build once so per-assertion timings are uniform (the first
+# `cargo run` otherwise dominates the wall-clock of assertion #1).
+echo "=== phase0-smoke: pre-building kotoha-cli (debug) ==="
+cargo build -p kotoha-cli --quiet
+
+RUN=(cargo run --quiet -p kotoha-cli --bin kotoha-romaji --)
+
+assert_eq() {
+    local name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf 'PASS  %s\n' "$name"
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf 'FAIL  %s\n' "$name"
+        printf '      expected: %q\n' "$expected"
+        printf '      actual:   %q\n' "$actual"
+    fi
+}
+
+echo "=== phase0-smoke: running ${TOTAL} assertions ==="
+
+# --- Romaji → kana (4 assertions, spec §13.2) -------------------------
+
+A1=$(printf 'konnnichiha\n' | "${RUN[@]}")
+assert_eq "1. konnnichiha → こんにちは"        "こんにちは" "$A1"
+
+A2=$(printf 'tsumugi\n'     | "${RUN[@]}")
+assert_eq "2. tsumugi → つむぎ"                  "つむぎ"     "$A2"
+
+A3=$(printf "n'ya\n"        | "${RUN[@]}")
+assert_eq "3. n'ya → んや"                       "んや"       "$A3"
+
+A4=$(printf 'nya\n'         | "${RUN[@]}")
+assert_eq "4. nya → にゃ"                        "にゃ"       "$A4"
+
+# --- Mode management (6 assertions, spec §13.2) -----------------------
+
+A5=$(printf 'HELLO\n'       | "${RUN[@]}")
+assert_eq "5. HELLO (Shift trigger) → HELLO"     "HELLO"      "$A5"
+
+EXPECTED6=$'Ko\nこんにちは'
+A6=$(printf 'Ko\nkonnnichiha\n' | "${RUN[@]}")
+assert_eq "6. Ko\\nkonnnichiha (Transient auto-return) → Ko\\nこんにちは" \
+          "$EXPECTED6" "$A6"
+
+EXPECTED7=$'hello\nworld'
+A7=$(printf 'hello\nworld\n' | "${RUN[@]}" --mode direct)
+assert_eq "7. hello\\nworld --mode direct (Sticky) → hello\\nworld" \
+          "$EXPECTED7" "$A7"
+
+EXPECTED8=$'Konnichiwa\nこんにちは'
+A8=$(printf 'Konnichiwa\nkonnnichiha\n' | "${RUN[@]}")
+assert_eq "8. Konnichiwa\\nkonnnichiha (mixed) → Konnichiwa\\nこんにちは" \
+          "$EXPECTED8" "$A8"
+
+A9=$(printf 'Hi\n'          | "${RUN[@]}" --show-mode)
+assert_eq "9. Hi --show-mode → Hi [H]"           "Hi [H]"     "$A9"
+
+A10=$(printf 'hi\n'         | "${RUN[@]}" --mode direct --show-mode)
+assert_eq "10. hi --mode direct --show-mode → hi [D]" "hi [D]" "$A10"
+
+# --- Summary ----------------------------------------------------------
+
+echo "=== phase0-smoke: ${PASS_COUNT}/${TOTAL} PASS, ${FAIL_COUNT}/${TOTAL} FAIL ==="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Phase 0 Milestone 6: implement the manual-verification CLI and the smoke-test
script that covers spec §13.2's 10 acceptance assertions.

- New workspace member \`crates/kotoha-cli\` (binary crate → \`kotoha-romaji\`)
- \`crates/kotoha-cli/src/lib.rs\`: \`process_line\` + \`format_line_output\` pure
  helpers (9 unit tests)
- \`crates/kotoha-cli/src/bin/romaji.rs\`: clap 4.5 derive Parser + stdin
  BufRead::lines() loop
- \`scripts/phase0-smoke.sh\`: 10 assertions from spec §13.2 via
  \`cargo run -p kotoha-cli --bin kotoha-romaji --\` + diff
- Workspace \`Cargo.toml\`: add \`crates/kotoha-cli\` to members, add clap to
  [workspace.dependencies]

## Behavior pins (from plan M6)

- preedit events NOT surfaced (spec §10.4: no REPL in Phase 0)
- invalid chars dropped silently (matches \`InputContext\` §9.3.2)
- \`--show-mode\` suffix uses \`[H]\` / \`[D]\` without Transient/Sticky distinction
- \`--mode direct\` calls \`InputContext::set_mode(InputMode::Direct)\` once
  before the stdin loop (Sticky origin persists across commits)
- exit codes follow clap defaults (arg-parse errors → 2); spec §10.5 remap
  deferred to M7 / ADR 0004 scope

## Deferred (Phase 0 non-goals per spec §10.4)

- Interactive REPL (\`:toggle\` etc.)
- Mid-line explicit toggle
- Keycode emulation (Phase 3 IBus engine)
- ADR 0004 (cli-line-based-commit) — canonical numbering reserves 0004 for M7

## Related

- Spec: docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md §10 / §13.2
- Plan: docs/superpowers/plans/2026-04-23-kotoha-phase-0-m6.md
- Parent tracking ISSUE: #32
- Closes #52

## Test plan

- [x] \`cargo build --workspace\` passes
- [x] \`cargo test --workspace\` passes (kotoha-core regression + 9 new
      kotoha-cli unit tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: zero warnings
- [x] \`cargo fmt --all --check\`: no diff
- [x] \`scripts/phase0-smoke.sh\` exits 0 with 10/10 PASS
- [x] lefthook pre-commit + pre-push all PASS
- [x] Manual smoke: \`echo "konnnichiha" | cargo run -p kotoha-cli --bin
      kotoha-romaji --\` emits \`こんにちは\`