### PR TITLE
docs(m7): ADRs 0003/0004/0007 + Phase 0 finishing docs (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Cargo workspace として以下の crate を持つ:
 
 | Phase | 内容 | 状態 |
 |---|---|---|
-| 0 | Cargo workspace + ローマ字→かな変換 + CLI | 設計完了、実装未着手 |
+| 0 | Cargo workspace + ローマ字→かな変換 + CLI | 完了 |
 | 1 | かな→漢字変換 (Zenz + llama.cpp) | 未着手 |
 | 2 | システム辞書 + ユーザ辞書 + 学習 | 未着手 |
 | 3 | IBus engine (GNOME) | 未着手 |
@@ -32,6 +32,74 @@ Cargo workspace として以下の crate を持つ:
 | 6 | 設定 UI, 辞書自動更新, 同期 | 未着手 |
 
 詳細は `docs/superpowers/specs/` の各設計書を参照。
+
+## kotoha-romaji CLI 使用例
+
+Phase 0 で実装した `kotoha-romaji` は、ローマ字→かな変換と Shift トリガによる Direct モード遷移を動作確認するための CLI である。標準入力から行単位で読み込み、行末を commit として扱う (詳細は `docs/adr/0004-cli-line-based-commit.md` と spec §10 を参照)。
+
+### ビルド
+
+```bash
+cargo build -p kotoha-cli
+# バイナリは target/debug/kotoha-romaji に生成される
+```
+
+### 基本的な使い方
+
+以下の例は `target/debug/kotoha-romaji` を `kotoha-romaji` として PATH 上で実行できる前提で記述する。
+
+1. **基本: ローマ字→ひらがな変換**
+
+    ```bash
+    $ echo "konnnichiha" | kotoha-romaji
+    こんにちは
+    ```
+
+2. **Shift トリガ: 大文字入力で Transient Direct モード**
+
+    ```bash
+    $ echo "HELLO" | kotoha-romaji
+    HELLO
+    ```
+
+3. **混在: 大文字始まりの行の後に Enter で自動復帰**
+
+    ```bash
+    $ printf "Konnichiwa\nkonnnichiha\n" | kotoha-romaji
+    Konnichiwa
+    こんにちは
+    ```
+
+4. **Sticky Direct モード (`--mode direct` で明示起動)**
+
+    ```bash
+    $ printf "hello\nworld\n" | kotoha-romaji --mode direct
+    hello
+    world
+    ```
+
+5. **モード表示 (デバッグ用、`--show-mode`)**
+
+    ```bash
+    $ printf "Hi\nkon\n" | kotoha-romaji --show-mode
+    Hi [H]
+    こん [H]
+    ```
+
+6. **Sticky Direct + モード表示**
+
+    ```bash
+    $ echo "hi" | kotoha-romaji --mode direct --show-mode
+    hi [D]
+    ```
+
+### スモークテスト
+
+Phase 0 の canonical smoke test として `scripts/phase0-smoke.sh` を提供する。上記 6 例を含む spec §13.2 の assertion を一括検証する。
+
+```bash
+./scripts/phase0-smoke.sh
+```
 
 ## 開発環境セットアップ
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ Kotoha プロジェクトの開発フェーズと、各フェーズの到達目�
 
 | Phase | 名称 | 内容 | 状態 |
 |---|---|---|---|
-| 0 | Foundation | Cargo workspace + ローマ字→かな変換 + 入力モード管理 + CLI | 実装中 |
+| 0 | Foundation | Cargo workspace + ローマ字→かな変換 + 入力モード管理 + CLI | 完了 |
 | 1 | Kana→Kanji conversion | Zenz + llama.cpp によるかな→漢字変換 | 未着手 |
 | 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ | 未着手 |
 | 3 | IBus integration | IBus engine(GNOME Mutter 用) | 未着手 |

--- a/docs/adr/0003-shift-via-uppercase-char.md
+++ b/docs/adr/0003-shift-via-uppercase-char.md
@@ -1,0 +1,64 @@
+# 0003: Phase 0 CLI では Shift トリガを ASCII 大文字入力で代替する
+
+## ステータス
+
+承認 (2026-04-24)
+
+## コンテキスト
+
+Kotoha の入力モード仕様 (spec §8) は、Hiragana モード中に Shift キーが押された場合に `(Direct, Transient)` へ遷移する挙動を normative に定義している (ADR 0002)。しかし Phase 0 の CLI `kotoha-romaji` は標準入力を **行単位の文字列** として受け取るため、物理 Shift キー押下という生のキーコードイベントを観測できない。
+
+Phase 3 の IBus engine では `KeyPress` イベントから `Shift` modifier の状態を直接取得できるが、Phase 0 CLI は spec §10.4 で「キーコード模擬 (raw キーイベント流し込み) は Phase 0 では実装しない」と明記されている。このため Phase 0 CLI では Shift トリガを別の手段で表現する必要がある。一方、M4b で実装済みの `InputContext::input_char(ch)` は既に `ch.is_ascii_uppercase()` を Shift 相当として扱うロジックを持つ (spec §8.4 擬似コード line 352 参照)。
+
+本 ADR は、Phase 0 CLI における「Shift トリガ = ASCII 大文字入力」という対応付けを Phase 0 限定の pragmatic 判断として記録し、Phase 3 IBus engine では物理キーコードイベントに置き換えることを明示する。
+
+## 検討した選択肢
+
+### 選択肢 1: ASCII 大文字を Shift トリガとして扱う (採用)
+
+- 利点:
+  - `InputContext::input_char` が既に採用しているロジックに CLI を揃えるだけで実装コストがゼロ。
+  - パイプ入力 (`echo "HELLO" | kotoha-romaji`) で Shift の挙動を smoke test できるため、`scripts/phase0-smoke.sh` と組み合わせやすい。
+  - spec §10.2 (大文字入力は Shift トリガ扱い) と整合する。
+- 欠点:
+  - 「Shift を押さずに大文字を入力」「Shift を押したが小文字が出る」といった物理キーと文字の不一致を CLI では表現できない。Phase 0 の smoke test 範囲ではこの限界は問題にならない。
+
+### 選択肢 2: `--shift` / `--unshift` の明示引数で状態を渡す
+
+- 利点: 大文字と Shift 状態を独立に制御でき、理論上は任意の組み合わせを検証できる。
+- 欠点: spec §10 の「行単位で読み込み、行末を commit」という簡潔な CLI 設計から逸脱する。ユーザ操作の直感にも反し、pipe 駆動の smoke test が書きづらい。
+
+### 選択肢 3: エスケープシーケンスで raw キーコードを模擬する
+
+- 利点: Phase 3 の IBus engine と同じ抽象レベルで Shift を扱える。
+- 欠点: spec §10.4 で「キーコード模擬は Phase 3 で追加」と明示的に defer されている。Phase 0 のスコープを超える。
+
+## 決定
+
+**選択肢 1 (ASCII 大文字を Shift トリガとして扱う)** を採用する。具体的には:
+
+1. `kotoha-romaji` は stdin から受け取った行中の ASCII 大文字を、Shift が同時に押されたキー入力と等価に扱う。
+2. 本対応付けは Phase 0 CLI 限定であり、`InputContext::input_char` の仕様そのものは「`is_ascii_uppercase()` が true のとき Hiragana → Transient Direct へ遷移」のまま変更しない (ADR 0002 の §8.4 擬似コードと同一)。
+3. Phase 3 の IBus engine では本対応付けを使わず、物理 `KeyPress` イベントの `Shift` modifier 状態を直接観測する。
+
+## 影響
+
+### Phase 0 への影響
+
+- `scripts/phase0-smoke.sh` の Shift ケース (例: `echo "HELLO" | kotoha-romaji` が `HELLO` を出力) が本 ADR の対応付けを前提として成立する (M6 PR #53 で実装済み)。
+- CLI では「lowercase text with shift on」「uppercase text with shift off」を表現できない。Phase 0 の smoke test 要件 (spec §13.2) には含まれないため問題にならない。
+
+### Phase 3 以降への影響
+
+- Phase 3 の IBus engine 実装時に、本 ADR の対応付けを IBus の KeyPress ハンドラで置き換える。`InputContext::input_char(ch)` の呼び出しはそのままでよく、engine 層は「Shift modifier が立っている + 文字キー押下」を大文字 ASCII 文字に正規化して渡す責務を負う。
+- 物理 Shift の状態を観測できるため、「Shift を押しながら小文字を打つ」ような不自然な入力経路は engine 層で吸収され、`InputContext` に影響しない。
+
+## 参照
+
+- ADR 0002 — 本 ADR が前提とする Transient-by-default モード仕様。
+- Spec §8.4 — `InputContext::input_char` 擬似コード (line 352 で `is_ascii_uppercase` を Shift 相当として判定)。
+- Spec §8.5 — Karukan との差分 (Shift 由来モードの扱い)。
+- Spec §10.2 — Phase 0 CLI 動作仕様 (「大文字入力は Shift トリガ扱い」)。
+- Spec §10.4 — Phase 0 で実装しないもの (キーコード模擬は Phase 3 で追加)。
+- M6 PR #53 — `kotoha-romaji` CLI と `scripts/phase0-smoke.sh` の実装。
+- ISSUE #32 — M4 (入力モード管理) tracking ISSUE。

--- a/docs/adr/0004-cli-line-based-commit.md
+++ b/docs/adr/0004-cli-line-based-commit.md
@@ -1,0 +1,64 @@
+# 0004: Phase 0 CLI は stdin の改行境界で commit を発火する
+
+## ステータス
+
+承認 (2026-04-24)
+
+## コンテキスト
+
+Phase 0 CLI `kotoha-romaji` は、`InputContext::commit()` を呼び出す契機 (= ユーザが「確定」を意図するタイミング) を何らかの方法で定義する必要がある。IBus engine では物理 Enter キーの `KeyPress` イベントが commit の契機になるが、Phase 0 CLI は標準入力を受け取るだけなので、キーイベントに相当する signal を文字列表現から抽出しなければならない。
+
+spec §10.2 は「標準入力から行単位で読み込み、**行末を Enter (commit) として扱う**」と normative に定めており、本 ADR はこの「改行 = commit」という対応付けを記録する。改行を commit 契機に採用した結果、M6 の `scripts/phase0-smoke.sh` は `printf "line1\nline2\n" | kotoha-romaji` のようなパイプ入力で、commit を挟んだ複数行シーケンスを簡潔に表現できる (spec §13.2)。
+
+## 検討した選択肢
+
+### 選択肢 1: stdin の改行境界で commit する (採用)
+
+- 利点:
+  - spec §10.2 の normative 仕様と一致する。
+  - シェルの `echo` / `printf` と組み合わせるだけで commit を含むシーケンスを記述でき、smoke test スクリプトが簡潔になる。
+  - 「1 行 1 commit」という規則は読み手にとって予測しやすく、`--show-mode` の出力 (1 行 1 モード表示) とも自然に整合する。
+- 欠点:
+  - 「1 つの preedit を複数の Enter を挟んで構成する」ような複合シナリオは CLI では表現できない。Phase 0 の smoke test 範囲ではこの限界は問題にならない。
+
+### 選択肢 2: 句読点 / 空白境界で commit する
+
+- 利点: セマンティックに「語」単位で確定が走るため、出力が見やすくなる可能性がある。
+- 欠点:
+  - ローマ字入力文脈で「語」を境界付ける規則を別途定義する必要があり、仕様が肥大化する。
+  - 本物の IME (Mozc 等) は commit をユーザ操作 (Enter) で駆動しており、句読点で自動 commit する挙動は既存 IME 慣習と矛盾する。spec §8 の状態機械とも整合しない。
+
+### 選択肢 3: EOF まで一切 commit しない
+
+- 利点: Phase 0 CLI を「streaming input_char の単純なフィルタ」に留められ、実装が最小化される。
+- 欠点:
+  - commit を伴う挙動 (Transient Direct → Hiragana 自動復帰、direct_buffer の flush) を CLI 経由で検証できず、smoke test の価値が著しく下がる。spec §13.2 の assertion 要件を満たせない。
+
+## 決定
+
+**選択肢 1 (stdin の改行境界で commit する)** を採用する。具体的には:
+
+1. `kotoha-romaji` は stdin を `BufRead::lines()` で 1 行ずつ読み、各行について全文字を `InputContext::input_char` に順次渡したあと `InputContext::commit()` を呼ぶ。
+2. 本対応付けは Phase 0 CLI 限定であり、`InputContext::commit` の仕様 (spec §8.4) は変更しない。
+3. Phase 3 の IBus engine では本対応付けを使わず、ユーザの Enter `KeyPress` イベントで `commit` を呼ぶ。
+
+## 影響
+
+### Phase 0 への影響
+
+- M6 PR #53 で実装済みの `kotoha-romaji` 本体 (`crates/kotoha-cli/src/bin/kotoha-romaji.rs`) が本 ADR の契機モデルを実装している。本 ADR は当該実装の設計判断を事後的に normative 化する。
+- `scripts/phase0-smoke.sh` の assertion (spec §13.2) は全て改行 = commit の前提で書かれており、本 ADR により正当化される。
+
+### Phase 3 以降への影響
+
+- Phase 3 の IBus engine では、ユーザが押した物理 Enter キーイベントを `commit` 契機に使う。Phase 0 CLI の「改行 = commit」対応付けは CLI の外部インタフェース上の制約であり、コアエンジン (`InputContext`) の挙動には影響しない。
+- 行途中の明示トグル (spec §10.4 で Phase 0 非対応) を Phase 3 で導入する場合、本 ADR の「改行 = commit」規則は CLI 側のみの制約として維持され、IBus engine 側には持ち込まれない。
+
+## 参照
+
+- ADR 0002 — 本 ADR が前提とする Transient-by-default モード仕様 (commit が Transient → Hiragana 自動復帰の契機)。
+- Spec §10.2 — Phase 0 CLI 動作仕様 (「行末を Enter (commit) として扱う」)。
+- Spec §13.2 — smoke test アサーション (改行 = commit 前提で記述)。
+- Spec §8.4 — `InputContext::commit` 擬似コード。
+- M6 PR #53 — `kotoha-romaji` CLI と `scripts/phase0-smoke.sh` の実装。
+- ISSUE #49 — M6 tracking ISSUE。

--- a/docs/adr/0007-rust-toolchain-and-publishing-policy.md
+++ b/docs/adr/0007-rust-toolchain-and-publishing-policy.md
@@ -1,0 +1,73 @@
+# 0007: Rust toolchain と OSS publish ポリシー (M1 設計判断の事後記録)
+
+## ステータス
+
+承認 (2026-04-24)
+
+## コンテキスト
+
+M1 (Cargo workspace 立ち上げ, ISSUE #3 / PR #8) で採用された 4 件の設計判断は、当時の PR レビューで「ADR として記録するのが望ましい」と指摘されたものの、M1 merge 時点では ADR 化されなかった。M7 (Phase 0 finishing docs) で本 ADR を作成し、これら 4 件の事後記録を行う。
+
+対象となる 4 件:
+
+1. **MSRV 1.80 + Edition 2021 の採用** (`~/.claude/rules/lang-rust.md` が Edition 2024 を推奨しているにも関わらず Edition 2021 を選んだ)
+2. **M1 期間中の `cargo build` 検証例外** (empty virtual workspace に対して Cargo 1.94+ が `could not find Cargo.toml` エラーを出す事象により、M1 の pre-push gate では build 検証をスキップした)
+3. **LICENSE-MIT の copyright holder に GitHub handle `std-koh-hinooka` を採用** (本名を OSS 配布物に直接書き込むのを避け、GitHub account handle で識別する方針)
+4. **`Cargo.toml` の `authors` 欄に公開メール `koh.hinooka@student.it.com` を埋め込み** (crates.io への publish 時に露出する連絡先として採用)
+
+本 ADR はこれら 4 件を 1 つの文書にまとめる。各決定は単独で短い判断であり、独立した ADR に分割するほどの記述量がないため、「toolchain 運用と OSS publish ポリシー」という共通テーマの下で束ねる。
+
+## 検討した選択肢
+
+### 決定 1: MSRV 1.80 + Edition 2021 (採用)
+
+- 検討: Edition 2024 (let chain 安定版等を使える) vs Edition 2021 (対象ディストロの Rust バージョンでサポートされる最新)
+- 選択: Edition 2021, MSRV 1.80
+- 理由: 本プロジェクトの想定配布先である Ubuntu 24.04 LTS (Rust 1.75 標準) および Debian trixie でのビルド可能性を優先する。Phase 0 の実装範囲 (ローマ字変換、入力モード、CLI) で Edition 2024 の新機能は必要とされない。
+
+### 決定 2: M1 期間中の `cargo build` 検証例外 (採用)
+
+- 検討: `cargo build` を pre-push gate に含める vs M1 のみ例外とする
+- 選択: M1 のみ例外
+- 理由: M1 時点ではメンバー crate が未作成の virtual workspace であり、Cargo 1.94+ が `could not find Cargo.toml` エラーを返していた。M2 以降 (kotoha-core crate 追加以降) は当該エラーが発生しないため、通常の build gate に戻した。M2-M6 で本例外は既に解除済み。
+
+### 決定 3: LICENSE-MIT copyright holder に GitHub handle 採用 (採用)
+
+- 検討: 本名 vs GitHub handle (`std-koh-hinooka`)
+- 選択: GitHub handle
+- 理由: OSS 配布物 (LICENSE-MIT / Cargo.toml metadata) は公開される前提であり、本名の露出は不要。GitHub handle により、本プロジェクトが個人名義の学習プロジェクトであることを明示しつつ、legal copyright holder としての identifier の一意性を保てる。
+
+### 決定 4: `Cargo.toml` authors 欄に公開メール埋め込み (採用)
+
+- 検討: メール欄を空にする vs 公開メールを埋め込む
+- 選択: 公開メール `koh.hinooka@student.it.com` を埋め込む
+- 理由: crates.io publish 時に「authors 欄にメール記載」は一般的慣習であり、OSS 貢献者が連絡する窓口として機能する。spam 耐性は mail server 側の filter で担保し、メール公開そのものは受容する。
+
+## 影響
+
+### 決定 1 (MSRV 1.80) の影響
+
+- Edition 2024 特有の構文 (安定化された let chain 等) は本プロジェクトで使用しない。必要になった場合は MSRV 引き上げの別 ADR で判断する。
+- `rust-toolchain.toml` / `Cargo.toml` の `rust-version = "1.80"` pin により、古い toolchain でのビルド失敗を早期検出できる。
+
+### 決定 2 (cargo build 例外) の影響
+
+- M1 merge 後 (M2 の kotoha-core crate 追加後) は通常の `cargo build --workspace` を pre-push gate に含める状態に復帰済み。現時点 (M7) では本例外は履歴情報として残るのみ。
+
+### 決定 3 (copyright handle) の影響
+
+- 本プロジェクトに外部 contributor が参加した場合、各 contributor 自身の copyright notice は GitHub handle または本名のいずれを選んでも良い (各自の判断に委ねる)。プロジェクト全体の copyright は `std-koh-hinooka` (プロジェクト owner) の下に集約する。
+
+### 決定 4 (publish メール) の影響
+
+- crates.io に publish した場合、本メールは crates.io の package metadata ページに公開される。spam filter 側で抑制する前提とする。
+- メール変更が必要になった場合は `Cargo.toml` の `authors` 欄のみ変更すればよく、コードへの影響はない。
+
+## 参照
+
+- M1 PR #8 — 本 ADR の対象となる 4 件の設計判断が実装された PR。
+- M1 PR #8 review comments — 「ADR 化を推奨」という指摘の出処。
+- `~/.claude/rules/lang-rust.md` — Edition 2024 推奨ルール (決定 1 で意図的に逸脱)。
+- `Cargo.toml` — `rust-version = "1.80"`, `edition = "2021"`, `authors` 欄の実装。
+- `LICENSE-MIT` — copyright holder に `std-koh-hinooka` を採用した実装。
+- `rust-toolchain.toml` — toolchain pin の実装。


### PR DESCRIPTION
## Summary

Complete Phase 0 M7 milestone by recording the three remaining design decisions as ADRs and finalizing Phase 0 status documentation. Docs-only PR with zero code changes.

## Key decisions

- **ADR 0003 shift-via-uppercase-char**: Phase 0 CLI treats ASCII uppercase as the Shift trigger because stdin cannot observe physical Shift keycode events. Phase 3 IBus engine replaces this with real `KeyPress` modifier state.
- **ADR 0004 cli-line-based-commit**: `kotoha-romaji` commits on every stdin newline boundary, matching spec §10.2 and composing cleanly with pipe-based smoke testing.
- **ADR 0007 rust-toolchain-and-publishing-policy**: Records 4 M1 decisions flagged undocumented by M1 PR review — MSRV 1.80 + Edition 2021, M1-only `cargo build` verification exception, LICENSE-MIT copyright holder = GitHub handle, Cargo.toml authors = public email.

## Changes

- New: `docs/adr/0003-shift-via-uppercase-char.md` (64 lines)
- New: `docs/adr/0004-cli-line-based-commit.md` (64 lines)
- New: `docs/adr/0007-rust-toolchain-and-publishing-policy.md` (73 lines)
- Modified: `docs/ROADMAP.md` — Phase 0 status `実装中` → `完了` (1 line)
- Modified: `README.md` — Phase 0 status `設計完了、実装未着手` → `完了` + new `kotoha-romaji CLI 使用例` section with 6 examples (spec §10.3), build instructions, and smoke-test pointer

Net diff: 271 insertions / 2 deletions across 5 files.

## Acceptance (from implementation plan M7)

- [x] 3 ADRs present under `docs/adr/` with required sections (ステータス / コンテキスト / 検討した選択肢 / 決定 / 影響 / 参照)
- [x] Total 8 ADRs now exist (0001 through 0008)
- [x] README contains 6 `kotoha-romaji` usage examples (≥ 5 required)
- [x] ROADMAP Phase 0 marked `完了`
- [x] Each new ADR between 50 and 80 lines (0003=64, 0004=64, 0007=73)
- [x] Total M7 diff ≤ 350 LOC (actual ~271)

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo test --workspace` — green (all unit / integration / doc / property tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] lefthook pre-commit passed (doc-naming self-test + doc-naming)
- [x] lefthook pre-push passed (build / clippy / manifest-check / test)
- [x] Sanity-checked 4 of 6 README CLI examples against `target/debug/kotoha-romaji` — outputs match documented values (こんにちは / HELLO / Konnichiwa+こんにちは / Hi [H]+こん [H])

Closes #54