### PR TITLE
docs(adr): promote ADR 0008 to 承認 with 選択肢 1 (#56)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ Phase 0 の詳細マイルストーン分割は `docs/superpowers/plans/2026-04-
 
 Phase 0 完了時に Phase 1 へ引き継ぐ設計判断事項を記録する。
 
-- **canonical romaji ADR** (`docs/adr/0008-canonical-romaji-and-partial-invertibility.md`): Phase 0 の spec §11.3 revision 2 で除外した「可逆性」プロパティについて、canonical romaji を定義して部分的可逆性を回復する拡張を Phase 1 で検討する。本 ADR はステータス「提案」の placeholder であり、Phase 1 計画開始時に 3 選択肢 (現状維持 / canonical 定義 / configuration で選択) から決定して正式 ADR に昇格する。
+- **canonical romaji ADR 判定済み** (`docs/adr/0008-canonical-romaji-and-partial-invertibility.md`): 2026-04-24 の Phase 1 kick-off で選択肢 1 (canonical romaji を定義しない、現状維持) の採用を決定。本 ADR は「承認」ステータスに昇格済み。将来 canonical romaji が必要となる use case が発生した場合は、display layer で canonical 化するか、新 ADR を起こして選択肢 2 / 3 に移行する。
 
 ## 注記
 

--- a/docs/adr/0008-canonical-romaji-and-partial-invertibility.md
+++ b/docs/adr/0008-canonical-romaji-and-partial-invertibility.md
@@ -1,14 +1,16 @@
-# 0008: canonical romaji 定義と部分的可逆性の回復 (Phase 1 検討事項)
+# 0008: canonical romaji 定義と部分的可逆性の回復 — Phase 1 判断: 現状維持
 
 ## ステータス
 
-提案 (2026-04-23) — Phase 1 で最終決定する placeholder
+承認 (2026-04-24)
 
 ## コンテキスト
 
 Phase 0 の romaji 変換は多対一マッピングを採用している: `ji` / `zi` → じ、`tu` / `tsu` → つ、`si` / `shi` → し、`ti` / `chi` → ち などの異体ペアが複数存在する。strict な round-trip invertibility (`romaji → kana → romaji == romaji`) は数学的に定義不能なため、spec §11.3 revision 2 でプロパティテスト集合から除外した。
 
 §11.3 の該当段落は「canonical romaji を定義して部分的に可逆性を回復する拡張は Phase 1 以降で検討する(ADR 候補)」で結ばれている。本 ADR はその「ADR 候補」を placeholder として開設し、Phase 1 計画時に忘れず参照されることを保証する tracking hook の役割を果たす。
+
+2026-04-24 に Phase 1 kick-off のため本 ADR の 3 選択肢を再評価し、**選択肢 1 (canonical romaji を定義しない、現状維持)** を採用する判断を下した。本 ADR はその決定の最終版として「承認」ステータスに昇格する。
 
 ## 検討した選択肢 (Phase 1 で正式評価)
 
@@ -18,11 +20,30 @@ Phase 0 の romaji 変換は多対一マッピングを採用している: `ji` 
 
 ## 決定
 
-**保留 (Phase 1 で決定)**。本 ADR は tracking hook であり、Phase 1 計画開始時に本 ADR をレビューし上記 3 選択肢から決定する。決定が確定した時点で本 ADR のステータスを「承認」に更新し、必要に応じて別 ADR 番号として fork する。
+**選択肢 1 (現状維持 / canonical romaji を定義しない)** を採用する。
 
-## 影響 (決定後に記述)
+Phase 1 以降、romaji 変換層は多対一マッピング (`ji` / `zi` → じ、`tu` / `tsu` → つ、`si` / `shi` → し、`ti` / `chi` → ち など) を維持する。spec §11.3 のプロパティテスト集合から `canonicalize_then_invert` 系の不変条件は引き続き除外する。
 
-Phase 1 の計画で選択肢を決定した後に追記する。
+Phase 1 の Kana→Kanji 変換層は入力がひらがな (既に `じ` / `つ` / `し` / `ち` などに正規化された形) であり、romaji 側の多対一性とは独立レイヤーのため、本決定が Phase 1 実装に与える影響はない。
+
+## 影響
+
+### Phase 0 rule table への影響
+
+なし。現行の `crates/kotoha-core/src/romaji/rules.rs` (213 entries、207 rule keys) はそのまま維持する。
+
+### Phase 1 以降への影響
+
+- **多対一入力の継続**: romaji 入力は異体ペアの両方を受け付ける方針を維持する。例: `ji` / `zi` の両方が `じ` に変換される。
+- **将来の入力 convention 拡張は本決定と両立**: user の future vision として、記号マクロ変換 (例: `xl` → `→`、`->` → `→` のような typography 記号入力) や追加 convention 対応が想定される。これらは Phase 0 rule table に新 key を追加するだけで実装可能で、canonical romaji 経由を必要としない。本 ADR の決定と両立する。
+- **property test 集合**: spec §11.3 revision 2 の除外決定を維持する。`canonicalize_then_invert` 系の property は追加しない。
+
+### 将来の選択肢 2 / 3 への migration path
+
+選択肢 1 を採用しても、将来 canonical romaji が必要となる具体的 use case (例: kanji → reading の逆引き romaji 表示、ヘボン式 / 訓令式 configurability) が発生した場合は、以下のいずれかで対応する:
+
+- **display layer で canonical 化**: input 側の多対一を維持したまま、display 時に canonical form を pick する形で実装し、input と display の責務を分離する (選択肢 1 の拡張として扱う)。
+- **新 ADR で選択肢 2 / 3 を採用**: Phase 1 以降で必要性が実証された時点で、本 ADR を参照しながら新 ADR (番号は当時の canonical scheme に従う) を作成して判断を更新する。本 ADR は 2026-04-24 時点の判断記録として残す。
 
 ## 参照
 
@@ -30,3 +51,4 @@ Phase 1 の計画で選択肢を決定した後に追記する。
 - `docs/ROADMAP.md` Phase 1 carry-over セクション
 - ISSUE #16 (本 ADR 作成 tracking)
 - PR #14 architecture review (発見経緯)
+- Phase 1 kick-off review (2026-04-24): 本 ADR の 3 選択肢を再評価し、選択肢 1 採用を決定


### PR DESCRIPTION
## Summary

- Promote ADR 0008 from 提案 placeholder to 承認 (2026-04-24) with the decision to adopt 選択肢 1: do not define canonical romaji, keep the existing many-to-one input mapping.
- Rewrite the 決定 and 影響 sections with the concrete decision and its forward-looking migration paths; add Phase 1 kick-off review to 参照.
- Mark the ADR 0008 carry-over item in `docs/ROADMAP.md` 'Phase 1 への申し送り' as resolved.

## Decision rationale

- Phase 1 Kana→Kanji conversion takes already-normalized hiragana input, so romaji-side many-to-one is an independent layer; this decision does not affect Phase 1 implementation.
- Avoids reworking the Phase 0 rule table and prevents scope creep immediately after Phase 0 completion.
- Future input convention extensions (symbol macros such as `xl` → `→`, alternate conventions) remain compatible: they are implemented by adding new keys to the Phase 0 rule table, no canonical romaji layer required.
- If canonical romaji ever becomes genuinely necessary (e.g. kanji → reading romaji display), the 影響 section documents two migration paths: (a) canonicalize at the display layer while keeping input many-to-one, (b) raise a new ADR to adopt 選択肢 2 / 3.

## Acceptance

- [x] ADR 0008 Status line reads `承認 (2026-04-24)`
- [x] 決定 section states 選択肢 1 adoption with explicit rationale (Phase 1 independence)
- [x] 影響 section documents 4 impact areas (Phase 0 rule table / Phase 1 以降 / property test / migration paths)
- [x] ROADMAP Phase 1 申し送り item updated to '判定済み'
- [x] ISSUE #56 referenced via `Closes #56`

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (131 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] lefthook pre-commit (doc-naming) passes
- [x] lefthook pre-push (build / clippy / manifest-check / test) passes

Closes #56