### PR TITLE
refactor(scripts): extract assert.sh and refactor phase0-smoke (#60)

### DIFF
--- a/scripts/lib/assert.sh
+++ b/scripts/lib/assert.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Common shell assertion library for Kotoha smoke scripts.
+#
+# Source this file from a smoke script and use:
+#   assert_equal    <desc> <actual> <expected>           # exact string match
+#   assert_contains <desc> <actual> <expected_substring> # substring match
+#   assert_summary  <phase_name>                         # print summary, exit 1 on any FAIL
+#
+# Example:
+#   #!/usr/bin/env bash
+#   set -euo pipefail
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/assert.sh"
+#   assert_equal "1. hello" "$(echo hello)" "hello"
+#   assert_summary "my-smoke"
+#
+# Counter state is held in ASSERT_PASS / ASSERT_FAIL. Both are initialized
+# to 0 on source and updated by assert_* functions. assert_summary inspects
+# them and exits non-zero if ASSERT_FAIL > 0.
+
+ASSERT_PASS=0
+ASSERT_FAIL=0
+
+# Exact string match. Prints PASS on success, FAIL with diff on failure.
+# Args:
+#   $1: description (free text, e.g., "1. konnnichiha -> こんにちは")
+#   $2: actual value (string)
+#   $3: expected value (string)
+assert_equal() {
+    local desc="$1"
+    local actual="$2"
+    local expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS  $desc"
+        ASSERT_PASS=$((ASSERT_PASS + 1))
+    else
+        echo "FAIL  $desc: expected '$expected', got '$actual'"
+        ASSERT_FAIL=$((ASSERT_FAIL + 1))
+    fi
+}
+
+# Substring containment match. Prints PASS on success, FAIL with detail on failure.
+# Used for stochastic model outputs where exact match is too brittle.
+# Args:
+#   $1: description
+#   $2: actual value (string)
+#   $3: expected substring
+assert_contains() {
+    local desc="$1"
+    local actual="$2"
+    local expected_substring="$3"
+    if [[ "$actual" == *"$expected_substring"* ]]; then
+        echo "PASS  $desc: contains '$expected_substring'"
+        ASSERT_PASS=$((ASSERT_PASS + 1))
+    else
+        echo "FAIL  $desc: '$actual' does not contain '$expected_substring'"
+        ASSERT_FAIL=$((ASSERT_FAIL + 1))
+    fi
+}
+
+# Print summary line and exit non-zero if any assertion failed.
+# Args:
+#   $1: phase name (free text, e.g., "phase0-smoke")
+assert_summary() {
+    local phase_name="$1"
+    local total=$((ASSERT_PASS + ASSERT_FAIL))
+    echo "=== $phase_name: $ASSERT_PASS/$total PASS, $ASSERT_FAIL/$total FAIL ==="
+    if [[ $ASSERT_FAIL -gt 0 ]]; then
+        exit 1
+    fi
+}

--- a/scripts/phase0-smoke.sh
+++ b/scripts/phase0-smoke.sh
@@ -19,11 +19,10 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/assert.sh"
 
-FAIL_COUNT=0
-PASS_COUNT=0
-TOTAL=10
+cd "$(dirname "$0")/.."
 
 # Pre-build once so per-assertion timings are uniform (the first
 # `cargo run` otherwise dominates the wall-clock of assertion #1).
@@ -32,69 +31,48 @@ cargo build -p kotoha-cli --quiet
 
 RUN=(cargo run --quiet -p kotoha-cli --bin kotoha-romaji --)
 
-assert_eq() {
-    local name="$1"
-    local expected="$2"
-    local actual="$3"
-    if [ "$actual" = "$expected" ]; then
-        PASS_COUNT=$((PASS_COUNT + 1))
-        printf 'PASS  %s\n' "$name"
-    else
-        FAIL_COUNT=$((FAIL_COUNT + 1))
-        printf 'FAIL  %s\n' "$name"
-        printf '      expected: %q\n' "$expected"
-        printf '      actual:   %q\n' "$actual"
-    fi
-}
-
-echo "=== phase0-smoke: running ${TOTAL} assertions ==="
+echo "=== phase0-smoke: running 10 assertions ==="
 
 # --- Romaji → kana (4 assertions, spec §13.2) -------------------------
 
 A1=$(printf 'konnnichiha\n' | "${RUN[@]}")
-assert_eq "1. konnnichiha → こんにちは"        "こんにちは" "$A1"
+assert_equal "1. konnnichiha → こんにちは"        "$A1" "こんにちは"
 
 A2=$(printf 'tsumugi\n'     | "${RUN[@]}")
-assert_eq "2. tsumugi → つむぎ"                  "つむぎ"     "$A2"
+assert_equal "2. tsumugi → つむぎ"                  "$A2" "つむぎ"
 
 A3=$(printf "n'ya\n"        | "${RUN[@]}")
-assert_eq "3. n'ya → んや"                       "んや"       "$A3"
+assert_equal "3. n'ya → んや"                       "$A3" "んや"
 
 A4=$(printf 'nya\n'         | "${RUN[@]}")
-assert_eq "4. nya → にゃ"                        "にゃ"       "$A4"
+assert_equal "4. nya → にゃ"                        "$A4" "にゃ"
 
 # --- Mode management (6 assertions, spec §13.2) -----------------------
 
 A5=$(printf 'HELLO\n'       | "${RUN[@]}")
-assert_eq "5. HELLO (Shift trigger) → HELLO"     "HELLO"      "$A5"
+assert_equal "5. HELLO (Shift trigger) → HELLO"     "$A5" "HELLO"
 
 EXPECTED6=$'Ko\nこんにちは'
 A6=$(printf 'Ko\nkonnnichiha\n' | "${RUN[@]}")
-assert_eq "6. Ko\\nkonnnichiha (Transient auto-return) → Ko\\nこんにちは" \
-          "$EXPECTED6" "$A6"
+assert_equal "6. Ko\\nkonnnichiha (Transient auto-return) → Ko\\nこんにちは" \
+          "$A6" "$EXPECTED6"
 
 EXPECTED7=$'hello\nworld'
 A7=$(printf 'hello\nworld\n' | "${RUN[@]}" --mode direct)
-assert_eq "7. hello\\nworld --mode direct (Sticky) → hello\\nworld" \
-          "$EXPECTED7" "$A7"
+assert_equal "7. hello\\nworld --mode direct (Sticky) → hello\\nworld" \
+          "$A7" "$EXPECTED7"
 
 EXPECTED8=$'Konnichiwa\nこんにちは'
 A8=$(printf 'Konnichiwa\nkonnnichiha\n' | "${RUN[@]}")
-assert_eq "8. Konnichiwa\\nkonnnichiha (mixed) → Konnichiwa\\nこんにちは" \
-          "$EXPECTED8" "$A8"
+assert_equal "8. Konnichiwa\\nkonnnichiha (mixed) → Konnichiwa\\nこんにちは" \
+          "$A8" "$EXPECTED8"
 
 A9=$(printf 'Hi\n'          | "${RUN[@]}" --show-mode)
-assert_eq "9. Hi --show-mode → Hi [H]"           "Hi [H]"     "$A9"
+assert_equal "9. Hi --show-mode → Hi [H]"           "$A9" "Hi [H]"
 
 A10=$(printf 'hi\n'         | "${RUN[@]}" --mode direct --show-mode)
-assert_eq "10. hi --mode direct --show-mode → hi [D]" "hi [D]" "$A10"
+assert_equal "10. hi --mode direct --show-mode → hi [D]" "$A10" "hi [D]"
 
 # --- Summary ----------------------------------------------------------
 
-echo "=== phase0-smoke: ${PASS_COUNT}/${TOTAL} PASS, ${FAIL_COUNT}/${TOTAL} FAIL ==="
-
-if [ "$FAIL_COUNT" -gt 0 ]; then
-    exit 1
-fi
-
-exit 0
+assert_summary "phase0-smoke"


### PR DESCRIPTION
## Summary

Extract the inline assert function from `scripts/phase0-smoke.sh` into a shared shell library `scripts/lib/assert.sh` for reuse by Phase 1+ smoke scripts.

## Changes

- **New**: `scripts/lib/assert.sh` with 3 public functions:
  - `assert_equal(desc, actual, expected)` — exact string match
  - `assert_contains(desc, actual, expected_substring)` — substring match (for stochastic outputs)
  - `assert_summary(phase_name)` — print summary and exit 1 on any FAIL
- **Refactored**: `scripts/phase0-smoke.sh` now sources `lib/assert.sh` instead of defining assert inline. All 10 assertions preserved verbatim (argument order updated from `desc/expected/actual` to `desc/actual/expected` to match the shared library's convention).

## Verification

- `bash scripts/phase0-smoke.sh` → 10/10 PASS (regression-free confirmed)
- Intentional-failure scratch test: `9/10 PASS, 1/10 FAIL, exit 1` (FAIL path works)
- `cargo build / test / clippy -D warnings / fmt --all --check` all green (unchanged baseline)
- lefthook pre-commit + pre-push all green

## Context

Phase 1 milestone **P1-0**: stepping-stone refactor PR before implementing Phase 1 kanji module. The new `assert.sh` will be consumed by the upcoming `scripts/phase1-smoke.sh` (P1-3 milestone) and by any future Phase N smoke scripts.

## Test plan

- [x] `bash scripts/phase0-smoke.sh` exits 0 with 10/10 PASS
- [x] cargo build/test/clippy/fmt all green
- [x] lefthook pre-commit + pre-push green

Closes #60