### PR TITLE
feat(kanji): add kanji module skeleton + MockBackend (#65)

### DIFF
--- a/crates/kotoha-core/Cargo.toml
+++ b/crates/kotoha-core/Cargo.toml
@@ -14,3 +14,18 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+
+[features]
+default = []
+# `mock-backend` exposes the deterministic MockBackend to cross-crate integration tests.
+# Cannot be reduced to `#[cfg(test)]` because downstream test files live in a separate
+# crate (the `tests/` directory) and need the public surface.
+mock-backend = []
+# `zenz` gates ZenzBackend. In P1-1 this is an empty flag (no `dep:llama-cpp-2`) because
+# the real backend skeleton only contains todo!() stubs. P1-2 will replace this with
+# `zenz = ["dep:llama-cpp-2"]` once the llama-cpp-2 dependency is wired up.
+zenz = []
+# `zenz-smoke` is the opt-in gate for Layer 3 live-inference smoke tests (added in P1-2).
+# Kept separate from `zenz` so that lefthook pre-push, which only runs default features,
+# does not attempt to load a real GGUF model.
+zenz-smoke = ["zenz"]

--- a/crates/kotoha-core/src/kanji/backend.rs
+++ b/crates/kotoha-core/src/kanji/backend.rs
@@ -1,0 +1,282 @@
+//! Backend abstraction and shared helpers for the kanji subsystem.
+//!
+//! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §5.3, §5.6, §5.7.
+//!
+//! The [`KanjiBackend`] trait defines the central abstraction for pluggable
+//! conversion backends (Mock / Zenz / future). The `pub(crate)` helpers
+//! [`validate_input`] and [`score_sort_dedupe`] live here so that every
+//! backend implementation enforces the same input contract and output
+//! guarantees without reimplementing the logic.
+
+use crate::kanji::{Candidate, ConvertOptions, KanjiError};
+
+/// Abstraction for a kana-to-kanji conversion backend.
+///
+/// Implementations are not required to be `Send + Sync` in Phase 1
+/// (the CLI is single-threaded). Phase 3 may revisit this when wiring
+/// the backend into an IBus engine running on a separate thread.
+///
+/// # Contract (spec §5.3)
+///
+/// Implementations MUST:
+///
+/// - Reject non-hiragana input (hiragana block `U+3040..=U+309F` plus the
+///   prolonged-sound mark `ー U+30FC` is the only accepted alphabet) by
+///   returning [`KanjiError::InvalidInput`]. Use the shared
+///   [`validate_input`] helper to ensure a uniform error shape.
+/// - Reject input longer than 128 characters (counted by
+///   `str::chars().count()`) with [`KanjiError::InvalidInput`].
+/// - Return candidates sorted in descending `score` order.
+/// - Return candidates with unique `surface` (a surface that the model
+///   produces with multiple scores collapses to the one with the highest
+///   score).
+/// - Return at most `options.top_k` candidates.
+/// - Treat `options.top_k == 0` as a request for an empty `Vec`, not an
+///   error.
+///
+/// Use [`score_sort_dedupe`] to enforce the last four properties in a single
+/// call on the raw model output.
+///
+/// # Errors
+///
+/// - [`KanjiError::InvalidInput`] when input violates §5.6.
+/// - [`KanjiError::Backend`] when inference fails inside the backend.
+/// - [`KanjiError::ModelLoadFailed`] / [`KanjiError::ModelNotFound`] —
+///   typically surfaced only from the constructor, not from `convert`.
+pub trait KanjiBackend {
+    /// Returns a human-readable identifier for the active model.
+    ///
+    /// Examples: `"mock"`, `"zenz-v2.5-medium"`. Used for logging and
+    /// CLI diagnostics.
+    fn model_id(&self) -> &str;
+
+    /// Converts a hiragana string into top-`options.top_k` kanji candidates.
+    ///
+    /// # Contract
+    ///
+    /// See the trait-level `# Contract` section.
+    ///
+    /// # Errors
+    ///
+    /// See the trait-level `# Errors` section.
+    fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError>;
+}
+
+/// Validates that `input` satisfies the backend input contract (spec §5.6).
+///
+/// # Accepted characters
+///
+/// - Hiragana block: `U+3040..=U+309F`
+/// - Prolonged sound mark: `U+30FC` (ー)
+///
+/// Empty input is accepted (the backend returns an empty `Vec`).
+///
+/// # Errors
+///
+/// - [`KanjiError::InvalidInput`] if `input` contains any character outside
+///   the accepted ranges or if `input.chars().count() > 128`.
+// Consumed by `MockBackend` in P1-1-6 and by `ZenzBackend` in Phase B.
+#[allow(dead_code)]
+pub(crate) fn validate_input(input: &str) -> Result<(), KanjiError> {
+    let count = input.chars().count();
+    if count > 128 {
+        return Err(KanjiError::InvalidInput {
+            reason: format!("input length {count} exceeds the 128-character limit"),
+        });
+    }
+    for ch in input.chars() {
+        let ok = matches!(ch, '\u{3040}'..='\u{309F}' | '\u{30FC}');
+        if !ok {
+            return Err(KanjiError::InvalidInput {
+                reason: format!(
+                    "character {ch:?} is outside the hiragana block (U+3040..=U+309F) and is not the prolonged sound mark (U+30FC)"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Enforces the output ordering and deduplication contract from spec §5.7.
+///
+/// Steps:
+///
+/// 1. Sort `candidates` in descending `score` order (stable, NaN treated as equal).
+/// 2. Deduplicate by `surface`, keeping the first occurrence (which is the
+///    highest-score entry thanks to step 1).
+/// 3. Truncate to `top_k` entries. If `top_k == 0`, the returned `Vec` is empty.
+///
+/// # Postconditions
+///
+/// - `result.len() <= top_k`.
+/// - For every adjacent pair `(result[i], result[i+1])`, `result[i].score >= result[i+1].score`.
+/// - No two entries in `result` share the same `surface`.
+// Consumed by `MockBackend` in P1-1-6 and by `ZenzBackend` in Phase B.
+#[allow(dead_code)]
+pub(crate) fn score_sort_dedupe(mut candidates: Vec<Candidate>, top_k: usize) -> Vec<Candidate> {
+    if top_k == 0 {
+        return Vec::new();
+    }
+    candidates.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut seen: Vec<String> = Vec::with_capacity(candidates.len());
+    let mut out: Vec<Candidate> = Vec::with_capacity(top_k.min(candidates.len()));
+    for c in candidates {
+        if seen.iter().any(|s| s == &c.surface) {
+            continue;
+        }
+        seen.push(c.surface.clone());
+        out.push(c);
+        if out.len() >= top_k {
+            break;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ======================================================================
+    // validate_input
+    // ======================================================================
+
+    #[test]
+    fn validate_input_accepts_empty() {
+        assert!(validate_input("").is_ok());
+    }
+
+    #[test]
+    fn validate_input_accepts_hiragana() {
+        assert!(validate_input("にほんご").is_ok());
+    }
+
+    #[test]
+    fn validate_input_accepts_choonpu() {
+        assert!(validate_input("ばー").is_ok());
+    }
+
+    #[test]
+    fn validate_input_rejects_latin() {
+        let err = validate_input("abc").expect_err("latin input must be rejected");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn validate_input_rejects_kanji() {
+        let err = validate_input("日本").expect_err("kanji input must be rejected");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn validate_input_rejects_katakana() {
+        let err = validate_input("カタカナ").expect_err("katakana input must be rejected");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn validate_input_rejects_space() {
+        let err = validate_input(" ").expect_err("space input must be rejected");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn validate_input_rejects_digit() {
+        let err = validate_input("1").expect_err("digit input must be rejected");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn validate_input_rejects_over_128_chars() {
+        let s = "あ".repeat(129);
+        let err = validate_input(&s).expect_err("input of 129 chars must be rejected");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn validate_input_accepts_exactly_128_chars() {
+        let s = "あ".repeat(128);
+        assert!(validate_input(&s).is_ok());
+    }
+
+    // ======================================================================
+    // score_sort_dedupe
+    // ======================================================================
+
+    #[test]
+    fn score_sort_dedupe_empty_input_returns_empty() {
+        let out = score_sort_dedupe(Vec::new(), 5);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn score_sort_dedupe_top_k_zero_returns_empty() {
+        let input = vec![Candidate::new("日本語", 0.9)];
+        let out = score_sort_dedupe(input, 0);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn score_sort_dedupe_sorts_descending_by_score() {
+        let input = vec![
+            Candidate::new("二本後", 0.3),
+            Candidate::new("日本語", 0.9),
+            Candidate::new("日本後", 0.5),
+        ];
+        let out = score_sort_dedupe(input, 5);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].surface, "日本語");
+        assert_eq!(out[1].surface, "日本後");
+        assert_eq!(out[2].surface, "二本後");
+    }
+
+    #[test]
+    fn score_sort_dedupe_dedupes_surface_keeping_highest_score() {
+        let input = vec![
+            Candidate::new("日本語", 0.3),
+            Candidate::new("日本語", 0.9),
+            Candidate::new("二本後", 0.5),
+        ];
+        let out = score_sort_dedupe(input, 5);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].surface, "日本語");
+        assert!((out[0].score - 0.9).abs() < 1e-6);
+        assert_eq!(out[1].surface, "二本後");
+    }
+
+    #[test]
+    fn score_sort_dedupe_truncates_to_top_k() {
+        let input = vec![
+            Candidate::new("a", 0.9),
+            Candidate::new("b", 0.8),
+            Candidate::new("c", 0.7),
+            Candidate::new("d", 0.6),
+        ];
+        let out = score_sort_dedupe(input, 2);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].surface, "a");
+        assert_eq!(out[1].surface, "b");
+    }
+
+    #[test]
+    fn score_sort_dedupe_handles_single_candidate() {
+        let input = vec![Candidate::new("日本語", 0.9)];
+        let out = score_sort_dedupe(input, 5);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].surface, "日本語");
+    }
+
+    #[test]
+    fn score_sort_dedupe_stable_for_equal_scores() {
+        // Two candidates with identical score must retain input order.
+        let input = vec![Candidate::new("first", 0.5), Candidate::new("second", 0.5)];
+        let out = score_sort_dedupe(input, 5);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].surface, "first");
+        assert_eq!(out[1].surface, "second");
+    }
+}

--- a/crates/kotoha-core/src/kanji/backend.rs
+++ b/crates/kotoha-core/src/kanji/backend.rs
@@ -161,6 +161,38 @@ pub(crate) fn score_sort_dedupe(mut candidates: Vec<Candidate>, top_k: usize) ->
     out
 }
 
+/// Constructs the backend described by `config`.
+///
+/// Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §5.4.
+///
+/// # Errors
+///
+/// - [`KanjiError::FeatureDisabled`] if `config` names a backend whose Cargo
+///   feature was not enabled at build time.
+/// - Errors bubbled up from the backend's loader
+///   (for example [`KanjiError::ModelNotFound`] from `ZenzBackend::load`
+///   once P1-2 lands).
+#[allow(unused_variables)]
+pub fn load_backend(config: &BackendConfig) -> Result<Box<dyn KanjiBackend>, KanjiError> {
+    match config {
+        #[cfg(feature = "mock-backend")]
+        BackendConfig::Mock => Ok(Box::new(crate::kanji::MockBackend::new())),
+
+        #[cfg(not(feature = "mock-backend"))]
+        BackendConfig::Mock => Err(KanjiError::FeatureDisabled {
+            feature: "mock-backend",
+        }),
+
+        #[cfg(feature = "zenz")]
+        BackendConfig::Zenz { model_path } => {
+            Ok(Box::new(crate::kanji::ZenzBackend::load(model_path)?))
+        }
+
+        #[cfg(not(feature = "zenz"))]
+        BackendConfig::Zenz { .. } => Err(KanjiError::FeatureDisabled { feature: "zenz" }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,5 +367,43 @@ mod tests {
             msg.contains("Zenz"),
             "Debug for Zenz must contain \"Zenz\": {msg}"
         );
+    }
+
+    // ======================================================================
+    // load_backend
+    // ======================================================================
+
+    #[cfg(not(feature = "mock-backend"))]
+    #[test]
+    fn mock_config_without_feature_errors_feature_disabled() {
+        match load_backend(&BackendConfig::Mock) {
+            Err(KanjiError::FeatureDisabled { feature }) => {
+                assert_eq!(feature, "mock-backend");
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+            Ok(_) => panic!("Mock must error when mock-backend feature is off"),
+        }
+    }
+
+    #[cfg(not(feature = "zenz"))]
+    #[test]
+    fn zenz_config_without_feature_errors_feature_disabled() {
+        match load_backend(&BackendConfig::Zenz {
+            model_path: PathBuf::from("/tmp/zenz.gguf"),
+        }) {
+            Err(KanjiError::FeatureDisabled { feature }) => {
+                assert_eq!(feature, "zenz");
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+            Ok(_) => panic!("Zenz must error when zenz feature is off"),
+        }
+    }
+
+    #[cfg(feature = "mock-backend")]
+    #[test]
+    fn mock_config_with_feature_returns_box() {
+        let backend = load_backend(&BackendConfig::Mock)
+            .expect("Mock must construct when mock-backend feature is on");
+        assert_eq!(backend.model_id(), "mock");
     }
 }

--- a/crates/kotoha-core/src/kanji/backend.rs
+++ b/crates/kotoha-core/src/kanji/backend.rs
@@ -8,7 +8,31 @@
 //! backend implementation enforces the same input contract and output
 //! guarantees without reimplementing the logic.
 
+use std::path::PathBuf;
+
 use crate::kanji::{Candidate, ConvertOptions, KanjiError};
+
+/// Backend construction parameters.
+///
+/// Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §5.4.
+///
+/// Marked `#[non_exhaustive]` per ADR 0006 so Phase 2+ can add new backend
+/// kinds (system dictionary / remote HTTP / learning-cache hybrid) without
+/// breaking external match sites.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum BackendConfig {
+    /// Deterministic mock backend (for tests). Constructible only when the
+    /// `mock-backend` feature flag is enabled at build time.
+    Mock,
+
+    /// Zenz GGUF model backend (via llama-cpp-2). Constructible only when
+    /// the `zenz` feature flag is enabled at build time.
+    Zenz {
+        /// Absolute path to the GGUF file on disk.
+        model_path: PathBuf,
+    },
+}
 
 /// Abstraction for a kana-to-kanji conversion backend.
 ///
@@ -278,5 +302,38 @@ mod tests {
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].surface, "first");
         assert_eq!(out[1].surface, "second");
+    }
+
+    // ======================================================================
+    // BackendConfig
+    // ======================================================================
+
+    #[test]
+    fn backend_config_is_clone() {
+        let mock = BackendConfig::Mock;
+        let _ = mock.clone();
+        let zenz = BackendConfig::Zenz {
+            model_path: PathBuf::from("/tmp/zenz.gguf"),
+        };
+        let _ = zenz.clone();
+    }
+
+    #[test]
+    fn backend_config_debug_contains_variant_name() {
+        let mock = BackendConfig::Mock;
+        let msg = format!("{mock:?}");
+        assert!(
+            msg.contains("Mock"),
+            "Debug for Mock must contain \"Mock\": {msg}"
+        );
+
+        let zenz = BackendConfig::Zenz {
+            model_path: PathBuf::from("/tmp/zenz.gguf"),
+        };
+        let msg = format!("{zenz:?}");
+        assert!(
+            msg.contains("Zenz"),
+            "Debug for Zenz must contain \"Zenz\": {msg}"
+        );
     }
 }

--- a/crates/kotoha-core/src/kanji/candidate.rs
+++ b/crates/kotoha-core/src/kanji/candidate.rs
@@ -1,0 +1,111 @@
+//! Value types for kanji conversion results and options.
+//!
+//! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §5.1, §5.2.
+
+/// A single kanji conversion candidate.
+///
+/// Phase 2+ may add fields (for example confidence sources or tokenization metadata),
+/// so this type is marked `#[non_exhaustive]` per ADR 0006.
+///
+/// # Invariants
+///
+/// - `surface` is a UTF-8 string, typically containing kanji, hiragana, and/or katakana.
+/// - `score` is the aggregated log-probability of the candidate; larger is better.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Candidate {
+    /// Kanji-mixed surface form (UTF-8).
+    pub surface: String,
+    /// Candidate score (aggregated log-probability; larger is better).
+    pub score: f32,
+}
+
+impl Candidate {
+    /// Constructs a new [`Candidate`].
+    ///
+    /// # Postconditions
+    ///
+    /// - The returned value's `surface` equals `surface.into()`.
+    /// - The returned value's `score` equals the supplied `score` bit-for-bit.
+    pub fn new(surface: impl Into<String>, score: f32) -> Self {
+        Self {
+            surface: surface.into(),
+            score,
+        }
+    }
+}
+
+/// Tunable parameters for a single kanji conversion call.
+///
+/// Phase 2+ may add fields (for example sampling strategy or penalty knobs),
+/// so this type is marked `#[non_exhaustive]` per ADR 0006.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConvertOptions {
+    /// Maximum number of candidates to return. `0` yields an empty `Vec`.
+    pub top_k: usize,
+    /// Sampling temperature. `0.0` means greedy decoding.
+    pub temperature: f32,
+    /// Sampling seed. `Some(s)` pins deterministic output; `None` is non-deterministic.
+    pub seed: Option<u64>,
+}
+
+impl Default for ConvertOptions {
+    /// Default options: `top_k = 5`, `temperature = 0.0`, `seed = Some(0)`.
+    ///
+    /// Combined defaults yield deterministic greedy decoding, which is the
+    /// baseline Layer 3 smoke test and E2E smoke test use.
+    fn default() -> Self {
+        Self {
+            top_k: 5,
+            temperature: 0.0,
+            seed: Some(0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candidate_new_constructs_with_surface_and_score() {
+        let c = Candidate::new("日本語", 0.9);
+        assert_eq!(c.surface, "日本語");
+        assert!((c.score - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn candidate_is_clone_and_eq() {
+        let a = Candidate::new("漢字", 0.5);
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn convert_options_default_is_top_k_5_temp_0_seed_0() {
+        let opt = ConvertOptions::default();
+        assert_eq!(opt.top_k, 5);
+        assert_eq!(opt.temperature, 0.0);
+        assert_eq!(opt.seed, Some(0));
+    }
+
+    #[test]
+    fn convert_options_is_clone_and_eq() {
+        let a = ConvertOptions::default();
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn convert_options_custom_fields_round_trip() {
+        let opt = ConvertOptions {
+            top_k: 10,
+            temperature: 0.7,
+            seed: None,
+        };
+        assert_eq!(opt.top_k, 10);
+        assert_eq!(opt.temperature, 0.7);
+        assert!(opt.seed.is_none());
+    }
+}

--- a/crates/kotoha-core/src/kanji/candidate.rs
+++ b/crates/kotoha-core/src/kanji/candidate.rs
@@ -86,7 +86,7 @@ mod tests {
     fn convert_options_default_is_top_k_5_temp_0_seed_0() {
         let opt = ConvertOptions::default();
         assert_eq!(opt.top_k, 5);
-        assert_eq!(opt.temperature, 0.0);
+        assert!((opt.temperature - 0.0).abs() < 1e-6);
         assert_eq!(opt.seed, Some(0));
     }
 
@@ -105,7 +105,7 @@ mod tests {
             seed: None,
         };
         assert_eq!(opt.top_k, 10);
-        assert_eq!(opt.temperature, 0.7);
+        assert!((opt.temperature - 0.7).abs() < 1e-6);
         assert!(opt.seed.is_none());
     }
 }

--- a/crates/kotoha-core/src/kanji/error.rs
+++ b/crates/kotoha-core/src/kanji/error.rs
@@ -1,0 +1,113 @@
+//! Error type for the kanji subsystem.
+//!
+//! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §5.5.
+//!
+//! All error messages are in English per the project convention for backend-facing
+//! diagnostics.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Errors returned from the kanji subsystem.
+///
+/// Marked `#[non_exhaustive]` per ADR 0006 so that Phase 2+ can add variants
+/// (for example cache / learning failures) without breaking external match
+/// sites.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum KanjiError {
+    /// The caller supplied input that violates the contract (hiragana-only, max 128 chars).
+    #[error("input violates contract: {reason}")]
+    InvalidInput {
+        /// Human-readable reason for the rejection.
+        reason: String,
+    },
+
+    /// The requested model file does not exist at the given path.
+    #[error("model file not found: {}", path.display())]
+    ModelNotFound {
+        /// Absolute path that was probed.
+        path: PathBuf,
+    },
+
+    /// Loading the model file succeeded at the filesystem level but failed at
+    /// parse / initialization time (wrapped by the underlying backend library).
+    #[error("model load failed: {source}")]
+    ModelLoadFailed {
+        /// Underlying error reported by the backend library.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Inference failed inside the backend.
+    #[error("backend inference failed: {reason}")]
+    Backend {
+        /// Human-readable reason reported by the backend.
+        reason: String,
+    },
+
+    /// The caller asked for a backend whose feature flag is not enabled at build time.
+    #[error("required feature not enabled at build time: {feature}")]
+    FeatureDisabled {
+        /// Name of the Cargo feature that must be enabled.
+        feature: &'static str,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_input_display_contains_reason() {
+        let err = KanjiError::InvalidInput {
+            reason: "non-hiragana character".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("non-hiragana character"),
+            "display should include the reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn model_not_found_display_contains_path() {
+        let err = KanjiError::ModelNotFound {
+            path: PathBuf::from("/tmp/zenz.gguf"),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("/tmp/zenz.gguf"),
+            "display should include the path: {msg}"
+        );
+    }
+
+    #[test]
+    fn feature_disabled_display_contains_feature_name() {
+        let err = KanjiError::FeatureDisabled { feature: "zenz" };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("zenz"),
+            "display should include the feature name: {msg}"
+        );
+    }
+
+    #[test]
+    fn backend_display_contains_reason() {
+        let err = KanjiError::Backend {
+            reason: "token decode failed".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("token decode failed"),
+            "display should include the reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn kanji_error_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<KanjiError>();
+    }
+}

--- a/crates/kotoha-core/src/kanji/mock.rs
+++ b/crates/kotoha-core/src/kanji/mock.rs
@@ -1,0 +1,140 @@
+//! Deterministic mock backend for tests.
+//!
+//! Enabled by the `mock-backend` Cargo feature so that downstream integration
+//! tests (which live in a separate crate via `tests/`) can import it. A plain
+//! `#[cfg(test)]` would not expose the type across crates.
+//!
+//! # Fixture decision (spec §13 Q4 follow-up)
+//!
+//! The fixture is hard-coded (not externalized to TSV). Spec §13 Q4 accepts
+//! this for small fixture counts. Four known inputs (`"にほんご"`,
+//! `"かんじ"`, `"あした"`, `"にほん"`) produce candidates sufficient to
+//! exercise every contract property (score-descending sort, surface dedupe,
+//! top_k truncation, empty result, unknown-input empty result) in Layer 2
+//! integration tests. The `"にほん"` entry emits three raw candidates with
+//! one duplicate surface ("日本" at 0.9 and 0.3), so the dedupe path of
+//! `score_sort_dedupe` is actually exercised end-to-end.
+//!
+//! Any input not listed above returns an empty `Vec` rather than an error,
+//! matching the trait contract (spec §5.3, §5.7 bullet 4 "empty allowed").
+
+use crate::kanji::backend::{score_sort_dedupe, validate_input};
+use crate::kanji::{Candidate, ConvertOptions, KanjiBackend, KanjiError};
+
+/// Deterministic mock backend. Enabled by `feature = "mock-backend"`.
+///
+/// Construct with [`MockBackend::new`] or through
+/// [`crate::kanji::load_backend`] applied to [`crate::kanji::BackendConfig::Mock`].
+#[derive(Debug, Default)]
+pub struct MockBackend {
+    // Zero-sized placeholder; fields may be added in Phase 2+.
+    _private: (),
+}
+
+impl MockBackend {
+    /// Constructs a new [`MockBackend`].
+    ///
+    /// # Postconditions
+    ///
+    /// - The returned backend's `model_id()` equals `"mock"`.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl KanjiBackend for MockBackend {
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError> {
+        validate_input(input)?;
+        let fixture: Vec<Candidate> = match input {
+            "にほんご" => vec![Candidate::new("日本語", 0.9), Candidate::new("二本後", 0.3)],
+            "かんじ" => vec![Candidate::new("漢字", 0.85), Candidate::new("感じ", 0.45)],
+            "あした" => vec![Candidate::new("明日", 0.92), Candidate::new("足した", 0.25)],
+            // Dedupe fixture: two candidates share the same surface "日本" but
+            // with different scores; after score_sort_dedupe, only the higher
+            // (0.9) is retained. This is the one input that exercises the
+            // surface-dedupe property end-to-end in Layer 2.
+            "にほん" => vec![
+                Candidate::new("日本", 0.9),
+                Candidate::new("日本", 0.3),
+                Candidate::new("二本", 0.5),
+            ],
+            _ => Vec::new(),
+        };
+        Ok(score_sort_dedupe(fixture, options.top_k))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_model_id_is_mock() {
+        let b = MockBackend::new();
+        assert_eq!(b.model_id(), "mock");
+    }
+
+    #[test]
+    fn mock_known_input_returns_expected() {
+        let b = MockBackend::new();
+        let opts = ConvertOptions::default();
+        let out = b.convert("にほんご", &opts).expect("convert must succeed");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].surface, "日本語");
+        assert!((out[0].score - 0.9).abs() < 1e-6);
+        assert_eq!(out[1].surface, "二本後");
+    }
+
+    #[test]
+    fn mock_unknown_input_returns_empty() {
+        let b = MockBackend::new();
+        let opts = ConvertOptions::default();
+        let out = b
+            .convert("あいうえお", &opts)
+            .expect("convert must succeed");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn mock_respects_top_k_1() {
+        let b = MockBackend::new();
+        let opts = ConvertOptions {
+            top_k: 1,
+            temperature: 0.0,
+            seed: Some(0),
+        };
+        let out = b.convert("にほんご", &opts).expect("convert must succeed");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].surface, "日本語");
+    }
+
+    #[test]
+    fn mock_invalid_input_returns_invalid_input_error() {
+        let b = MockBackend::new();
+        let opts = ConvertOptions::default();
+        let err = b
+            .convert("abc", &opts)
+            .expect_err("latin input must be rejected");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn mock_dedupe_fixture_collapses_duplicate_surfaces() {
+        let backend = MockBackend::new();
+        let options = ConvertOptions {
+            top_k: 5,
+            ..ConvertOptions::default()
+        };
+        let result = backend.convert("にほん", &options).expect("valid input");
+
+        assert_eq!(result.len(), 2, "3 raw candidates dedupe to 2");
+        assert_eq!(result[0].surface, "日本");
+        assert!((result[0].score - 0.9).abs() < 1e-6);
+        assert_eq!(result[1].surface, "二本");
+        assert!((result[1].score - 0.5).abs() < 1e-6);
+    }
+}

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -5,8 +5,10 @@
 //!
 //! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §4-§8.
 
+mod backend;
 mod candidate;
 mod error;
 
+pub use backend::KanjiBackend;
 pub use candidate::{Candidate, ConvertOptions};
 pub use error::KanjiError;

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -1,0 +1,10 @@
+//! Kana-to-kanji conversion subsystem (Phase 1).
+//!
+//! This module is being populated incrementally in P1-1. Task P1-1-9 finalizes
+//! the `pub use` surface. Until then, only `candidate` is declared.
+//!
+//! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §4-§8.
+
+mod candidate;
+
+pub use candidate::{Candidate, ConvertOptions};

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -9,6 +9,6 @@ mod backend;
 mod candidate;
 mod error;
 
-pub use backend::KanjiBackend;
+pub use backend::{BackendConfig, KanjiBackend};
 pub use candidate::{Candidate, ConvertOptions};
 pub use error::KanjiError;

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -12,3 +12,8 @@ mod error;
 pub use backend::{BackendConfig, KanjiBackend};
 pub use candidate::{Candidate, ConvertOptions};
 pub use error::KanjiError;
+
+#[cfg(feature = "mock-backend")]
+mod mock;
+#[cfg(feature = "mock-backend")]
+pub use mock::MockBackend;

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -17,3 +17,8 @@ pub use error::KanjiError;
 mod mock;
 #[cfg(feature = "mock-backend")]
 pub use mock::MockBackend;
+
+#[cfg(feature = "zenz")]
+mod zenz;
+#[cfg(feature = "zenz")]
+pub use zenz::ZenzBackend;

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -9,7 +9,7 @@ mod backend;
 mod candidate;
 mod error;
 
-pub use backend::{BackendConfig, KanjiBackend};
+pub use backend::{load_backend, BackendConfig, KanjiBackend};
 pub use candidate::{Candidate, ConvertOptions};
 pub use error::KanjiError;
 

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -6,5 +6,7 @@
 //! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §4-§8.
 
 mod candidate;
+mod error;
 
 pub use candidate::{Candidate, ConvertOptions};
+pub use error::KanjiError;

--- a/crates/kotoha-core/src/kanji/zenz.rs
+++ b/crates/kotoha-core/src/kanji/zenz.rs
@@ -16,6 +16,7 @@ use crate::kanji::{Candidate, ConvertOptions, KanjiBackend, KanjiError};
 /// **P1-1: all methods panic via `todo!()`. P1-2 supplies the real
 /// implementation backed by llama-cpp-2.**
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct ZenzBackend {
     model_path: PathBuf,
     _placeholder: (),
@@ -24,9 +25,12 @@ pub struct ZenzBackend {
 impl ZenzBackend {
     /// Loads a Zenz GGUF model from `model_path`.
     ///
-    /// # P1-1
+    /// # P1-1 status
     ///
-    /// Panics with `todo!()` unconditionally.
+    /// Returns [`KanjiError::Backend`] with a "not yet implemented (P1-2)"
+    /// reason. This is a safe error — not a panic — so that callers going
+    /// through [`crate::kanji::load_backend`] with the `zenz` feature enabled
+    /// receive a typed error instead of a process abort.
     ///
     /// # P1-2 (planned)
     ///
@@ -35,13 +39,15 @@ impl ZenzBackend {
     ///
     /// # Errors
     ///
-    /// After P1-2 lands:
-    ///
-    /// - [`KanjiError::ModelNotFound`] if `model_path` does not exist.
-    /// - [`KanjiError::ModelLoadFailed`] if llama-cpp-2 rejects the file.
+    /// - P1-1: [`KanjiError::Backend`] unconditionally.
+    /// - P1-2 (planned): [`KanjiError::ModelNotFound`] if `model_path` does
+    ///   not exist; [`KanjiError::ModelLoadFailed`] if llama-cpp-2 rejects
+    ///   the file.
     #[allow(unused_variables)]
     pub fn load(model_path: &Path) -> Result<Self, KanjiError> {
-        todo!("P1-2: implement via llama-cpp-2")
+        Err(KanjiError::Backend {
+            reason: "ZenzBackend is a P1-1 skeleton; real implementation lands in Phase 1 milestone P1-2".to_string(),
+        })
     }
 }
 
@@ -53,5 +59,25 @@ impl KanjiBackend for ZenzBackend {
     #[allow(unused_variables)]
     fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError> {
         todo!("P1-2: implement via llama-cpp-2")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zenz_load_returns_backend_error_in_p1_1_skeleton() {
+        let err = ZenzBackend::load(Path::new("/tmp/nonexistent.gguf"))
+            .expect_err("ZenzBackend::load must error in P1-1 skeleton, not panic");
+        match err {
+            KanjiError::Backend { reason } => {
+                assert!(
+                    reason.contains("P1-2"),
+                    "reason should point to P1-2 implementation: {reason}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
     }
 }

--- a/crates/kotoha-core/src/kanji/zenz.rs
+++ b/crates/kotoha-core/src/kanji/zenz.rs
@@ -1,0 +1,57 @@
+//! Zenz GGUF model backend (via llama-cpp-2).
+//!
+//! **P1-1 status: SKELETON ONLY.** The real `load` / `convert` implementation
+//! ships in milestone P1-2, together with the `llama-cpp-2` dependency being
+//! added to `Cargo.toml` and wired to the `zenz` feature (which is currently
+//! an empty flag, not `["dep:llama-cpp-2"]`).
+//!
+//! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §3.1, §5.3.
+
+use std::path::{Path, PathBuf};
+
+use crate::kanji::{Candidate, ConvertOptions, KanjiBackend, KanjiError};
+
+/// Zenz model backend. Enabled by `feature = "zenz"`.
+///
+/// **P1-1: all methods panic via `todo!()`. P1-2 supplies the real
+/// implementation backed by llama-cpp-2.**
+#[allow(dead_code)]
+pub struct ZenzBackend {
+    model_path: PathBuf,
+    _placeholder: (),
+}
+
+impl ZenzBackend {
+    /// Loads a Zenz GGUF model from `model_path`.
+    ///
+    /// # P1-1
+    ///
+    /// Panics with `todo!()` unconditionally.
+    ///
+    /// # P1-2 (planned)
+    ///
+    /// Opens the GGUF file via llama-cpp-2, validates the architecture, and
+    /// caches the resulting context for subsequent `convert` calls.
+    ///
+    /// # Errors
+    ///
+    /// After P1-2 lands:
+    ///
+    /// - [`KanjiError::ModelNotFound`] if `model_path` does not exist.
+    /// - [`KanjiError::ModelLoadFailed`] if llama-cpp-2 rejects the file.
+    #[allow(unused_variables)]
+    pub fn load(model_path: &Path) -> Result<Self, KanjiError> {
+        todo!("P1-2: implement via llama-cpp-2")
+    }
+}
+
+impl KanjiBackend for ZenzBackend {
+    fn model_id(&self) -> &str {
+        todo!("P1-2: implement via llama-cpp-2")
+    }
+
+    #[allow(unused_variables)]
+    fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError> {
+        todo!("P1-2: implement via llama-cpp-2")
+    }
+}

--- a/crates/kotoha-core/src/lib.rs
+++ b/crates/kotoha-core/src/lib.rs
@@ -6,10 +6,12 @@
 pub mod error;
 pub mod input;
 pub mod kana;
+pub mod kanji;
 pub mod romaji;
 
 pub use error::{Error, Result};
 pub use input::{InputContext, InputMode, InputStep};
+pub use kanji::{Candidate, ConvertOptions};
 pub use romaji::{ConvertStep, RomajiConverter};
 
 /// Test-only accessor for the romaji rule table.

--- a/crates/kotoha-core/src/lib.rs
+++ b/crates/kotoha-core/src/lib.rs
@@ -11,7 +11,7 @@ pub mod romaji;
 
 pub use error::{Error, Result};
 pub use input::{InputContext, InputMode, InputStep};
-pub use kanji::{Candidate, ConvertOptions};
+pub use kanji::{load_backend, BackendConfig, Candidate, ConvertOptions, KanjiBackend, KanjiError};
 pub use romaji::{ConvertStep, RomajiConverter};
 
 /// Test-only accessor for the romaji rule table.

--- a/crates/kotoha-core/tests/kanji_mock.rs
+++ b/crates/kotoha-core/tests/kanji_mock.rs
@@ -1,0 +1,114 @@
+//! Layer 2 integration tests for the kanji subsystem.
+//!
+//! Enabled by the `mock-backend` feature. Covers the five properties that
+//! spec §5.3 (trait contract) and §5.7 (output guarantees) require every
+//! `KanjiBackend` implementation to honor, verified through a `Box<dyn
+//! KanjiBackend>` obtained from `load_backend(&BackendConfig::Mock)` rather
+//! than a direct `MockBackend::new()` — this guarantees the factory path and
+//! the trait object path are exercised end-to-end.
+//!
+//! Because `ConvertOptions` is `#[non_exhaustive]` per ADR 0006, an external
+//! crate cannot use struct-literal syntax. This file therefore constructs
+//! options via `ConvertOptions::default()` + field mutation, which is the
+//! forward-compatible idiom for `#[non_exhaustive]` types.
+
+#![cfg(feature = "mock-backend")]
+
+use kotoha_core::kanji::{load_backend, BackendConfig, ConvertOptions};
+
+#[test]
+fn mock_backend_model_id_exposed_via_trait() {
+    let backend = load_backend(&BackendConfig::Mock)
+        .expect("Mock must construct when mock-backend feature is on");
+    assert_eq!(backend.model_id(), "mock");
+}
+
+#[test]
+fn mock_backend_returns_score_descending() {
+    let backend = load_backend(&BackendConfig::Mock)
+        .expect("Mock must construct when mock-backend feature is on");
+    let mut opts = ConvertOptions::default();
+    opts.top_k = 5;
+    let out = backend
+        .convert("にほんご", &opts)
+        .expect("convert must succeed on known hiragana input");
+    assert!(
+        out.len() >= 2,
+        "fixture should produce at least 2 candidates"
+    );
+    for i in 0..out.len() - 1 {
+        assert!(
+            out[i].score >= out[i + 1].score,
+            "score at index {} ({}) must be >= score at index {} ({})",
+            i,
+            out[i].score,
+            i + 1,
+            out[i + 1].score
+        );
+    }
+}
+
+#[test]
+fn mock_backend_respects_top_k() {
+    let backend = load_backend(&BackendConfig::Mock)
+        .expect("Mock must construct when mock-backend feature is on");
+    let mut opts = ConvertOptions::default();
+    opts.top_k = 1;
+    let out = backend
+        .convert("にほんご", &opts)
+        .expect("convert must succeed");
+    assert_eq!(
+        out.len(),
+        1,
+        "top_k=1 must truncate output to a single candidate"
+    );
+}
+
+#[test]
+fn mock_backend_dedupes_identical_surface() {
+    let backend = load_backend(&BackendConfig::Mock).expect("mock backend should load");
+    let mut options = ConvertOptions::default();
+    options.top_k = 5;
+
+    // "にほん" fixture intentionally emits [(日本, 0.9), (日本, 0.3), (二本, 0.5)].
+    // After score-desc sort + surface dedupe, the lower-scored "日本" (0.3) is
+    // dropped; the output is [(日本, 0.9), (二本, 0.5)] — 2 candidates, no
+    // duplicate surfaces.
+    let result = backend
+        .convert("にほん", &options)
+        .expect("valid hiragana input should convert");
+
+    assert_eq!(
+        result.len(),
+        2,
+        "dedupe should collapse one duplicate surface"
+    );
+    assert_eq!(result[0].surface, "日本");
+    assert!((result[0].score - 0.9).abs() < 1e-6);
+    assert_eq!(result[1].surface, "二本");
+
+    let mut surfaces: Vec<&str> = result.iter().map(|c| c.surface.as_str()).collect();
+    surfaces.sort();
+    surfaces.dedup();
+    assert_eq!(
+        surfaces.len(),
+        result.len(),
+        "no duplicate surfaces permitted in backend output (spec §5.7 bullet 2)",
+    );
+}
+
+#[test]
+fn mock_backend_top_k_zero_returns_empty() {
+    let backend = load_backend(&BackendConfig::Mock)
+        .expect("Mock must construct when mock-backend feature is on");
+    let mut opts = ConvertOptions::default();
+    opts.top_k = 0;
+    let out = backend
+        .convert("にほんご", &opts)
+        .expect("top_k=0 must succeed with an empty Vec, not an error");
+    assert!(
+        out.is_empty(),
+        "top_k=0 must yield an empty Vec; got {} candidates",
+        out.len()
+    );
+}


### PR DESCRIPTION
## Summary

Phase 1 milestone P1-1: add the kotoha-core::kanji module skeleton with public API types (KanjiBackend trait, Candidate, ConvertOptions, BackendConfig, KanjiError, load_backend factory) and a deterministic MockBackend. ZenzBackend is introduced as a todo!() skeleton to be implemented in P1-2.

Closes #65.

## Changes

- New module `crates/kotoha-core/src/kanji/` (6 files):
  - `mod.rs` — public re-exports (feature-gated MockBackend / ZenzBackend)
  - `candidate.rs` — Candidate + ConvertOptions value types (`#[non_exhaustive]`, Default)
  - `error.rs` — KanjiError enum (`#[non_exhaustive]`, 5 variants via thiserror)
  - `backend.rs` — KanjiBackend trait, `pub(crate)` helpers `validate_input` + `score_sort_dedupe`, BackendConfig enum, `load_backend` factory
  - `mock.rs` — MockBackend (feature = "mock-backend"), deterministic fixture for 4 known inputs ("にほん" exercises surface dedupe end-to-end)
  - `zenz.rs` — ZenzBackend skeleton (feature = "zenz"), todo!() stubs for P1-2
- New feature flags in `crates/kotoha-core/Cargo.toml`: `default`, `mock-backend`, `zenz` (empty in P1-1), `zenz-smoke`
- Updated `crates/kotoha-core/src/lib.rs` to expose `pub mod kanji;` + re-exports
- New integration test `crates/kotoha-core/tests/kanji_mock.rs` (5 Layer 2 tests, file-level `#![cfg(feature = "mock-backend")]`)

## Verification

- `cargo check -p kotoha-core` passes under all 6 feature configurations (no-default-features / default / mock-backend / zenz / zenz-smoke / all-features).
- `cargo test --workspace`: 160 tests PASS (129 baseline + 31 new Layer 1 unit tests).
- `cargo test --workspace --features mock-backend`: 171 tests PASS (+ 5 Layer 2 integration + 6 MockBackend unit).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: zero warnings.
- `cargo fmt --all --check`: no diff.
- lefthook pre-push passes locally (manifest-check / build / clippy / test all green).

## Plan Deviations (for P1-4 bundle)

Two minor plan-level bugs were detected during implementation and fixed inline:

1. Task P1-1-8: plan used `.expect_err()` which requires `T: Debug`, but `Box<dyn KanjiBackend>` does not implement Debug. Changed to `match` on the full `Result`. Semantically equivalent.
2. Task P1-1-10: plan used struct-literal syntax for `ConvertOptions` in integration tests, but `#[non_exhaustive]` prevents this across crate boundaries (E0639). Switched to `ConvertOptions::default()` + field mutation (the forward-compatible idiom). Semantically equivalent.

Plan realignment will be folded into the existing P1-4 documentation pass (or a separate follow-up issue).

## Context

- Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §4.1 / §4.3 / §5 / §8.1 / §8.2
- Phase 1 overall plan: `docs/superpowers/plans/2026-04-24-kotoha-phase-1-implementation.md` §"PR #2 — P1-1"
- Detailed plan: `docs/superpowers/plans/2026-04-24-kotoha-phase-1-p1-1.md`
- ADR 0006 (`#[non_exhaustive]` policy): enforced on Candidate / ConvertOptions / BackendConfig / KanjiError.
- ADR 0008 (canonical romaji Phase 1 decision): orthogonal to this PR but referenced from spec §5.6.

## Test plan

- [x] `cargo test --workspace` passes on CI-equivalent local run (160 PASS)
- [x] `cargo test --workspace --features mock-backend` passes (171 PASS)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo check` clean under all 6 feature configurations listed above
- [x] MockBackend fixture produces deterministic output for "にほんご" / "かんじ" / "あした" / "にほん" and empty Vec for unknown inputs ("にほん" exercises surface dedupe end-to-end)
- [x] load_backend returns `KanjiError::FeatureDisabled` when the matching feature is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)