### PR TITLE
docs(phase-5): ADR 0010 + ROADMAP restructure + Phase 5 spec draft (#77)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,7 +52,7 @@ Data pipeline は kana→kanji ペアの大規模コーパス構築を担う。�
 学習戦略候補 3 本の empirical 比較と default 決定を担う。
 
 - B1: scratch training (GPT-2 Small 90M、random init、RTX 4090 で 1〜3 GPU-day)
-- B2: LoRA fine-tune (Gemma-2-2B-jpn-it adapter、inference 時 base 必要のため候補から除外推奨)
+- B2: LoRA fine-tune (Gemma-2-2B-jpn-it adapter、inference 時 base 必要のため候補から除外推奨。offline batch 用途での再検討余地あり。詳細は Phase 5 spec §5.2)
 - B3: distillation (Gemma-4-31B-it 等を teacher、90〜180M student、数 GPU-day、**default 推奨**)
 - 比較計画: B1 と B3 を同一評価 fixture で走らせ、row 3 解消率 / typo robustness / latency の 3 軸で判定する
 
@@ -82,5 +82,5 @@ Data pipeline は kana→kanji ペアの大規模コーパス構築を担う。�
 ## 注記
 
 - Phase 5 への restructure (ADR 0010) により、旧 Phase 5 (Advanced features) は Phase 6 へ、旧 Phase 6 (UX polish) は Phase 7 へ後ろ倒しされた
-- 旧 Phase 5 の「Shift 挙動設定」は、設計書 revision 2 の判断により Phase 0 に前倒し済み。新 Phase 6 の内容は「タイポ訂正 + 文脈リランキング」のみ
+- 旧 Phase 5 の「Shift 挙動設定」は、Phase 0 設計書 (`docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md`) revision 2 の判断により Phase 0 に前倒し済み。新 Phase 6 の内容は「タイポ訂正 + 文脈リランキング」のみ
 - 各 Phase の設計書は `docs/superpowers/specs/` に配置する

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,27 +4,83 @@ Kotoha プロジェクトの開発フェーズと、各フェーズの到達目�
 
 ## Phase 一覧
 
+ADR 0010 (`docs/adr/0010-kotoha-custom-romaji-base-model.md`) の決定により、2026-04-25 に旧 Phase 5 (Advanced features) を Phase 6 に、旧 Phase 6 (UX polish) を Phase 7 に後ろ倒しし、新 Phase 5「Kotoha custom romaji-base model」を挿入した。
+
 | Phase | 名称 | 内容 | 状態 |
 |---|---|---|---|
 | 0 | Foundation | Cargo workspace + ローマ字→かな変換 + 入力モード管理 + CLI | 完了 |
-| 1 | Kana→Kanji conversion | llama.cpp + Gemma-2-2B-jpn-it によるかな→漢字変換 | 未着手 |
+| 1 | Kana→Kanji conversion | llama.cpp + Gemma-2-2B-jpn-it baseline によるかな→漢字変換 (P1-2.5 follow-up で Layer 3 smoke 14/15 達成) | 進行中 (P1-2.5 follow-up 完了) |
 | 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ | 未着手 |
 | 3 | IBus integration | IBus engine(GNOME Mutter 用) | 未着手 |
 | 4 | fcitx5 integration | fcitx5 addon(KDE / wlroots 用) | 未着手 |
-| 5 | Advanced features | タイポ訂正 + 文脈リランキング | 未着手 |
-| 6 | UX polish | 設定 UI + 辞書自動更新 + 同期 | 未着手 |
+| 5 | **Kotoha custom romaji-base model** | raw romaji keystrokes を直接受理する Kotoha 専用 90〜180M parameter モデルの自作 (data pipeline + training + GGUF 推論統合 + evaluation)。row 3 類の ICL 限界 + typo robustness + partial-input 対応を同時解決する | 未着手 |
+| 6 | Advanced features | タイポ訂正 + 文脈リランキング (Phase 5 の romaji-base モデルを技術基盤とする) | 未着手 |
+| 7 | UX polish | 設定 UI + 辞書自動更新 + 同期 | 未着手 |
 
 ## Phase 0 マイルストーン
 
 Phase 0 の詳細マイルストーン分割は `docs/superpowers/plans/2026-04-22-kotoha-phase-0-implementation.md` を参照。
 
-## Phase 1 への申し送り
+## Phase 0 → Phase 1 への申し送り
 
 Phase 0 完了時に Phase 1 へ引き継ぐ設計判断事項を記録する。
 
 - **canonical romaji ADR 判定済み** (`docs/adr/0008-canonical-romaji-and-partial-invertibility.md`): 2026-04-24 の Phase 1 kick-off で選択肢 1 (canonical romaji を定義しない、現状維持) の採用を決定。本 ADR は「承認」ステータスに昇格済み。将来 canonical romaji が必要となる use case が発生した場合は、display layer で canonical 化するか、新 ADR を起こして選択肢 2 / 3 に移行する。
 
+## Phase 1 → Phase 2 への申し送り
+
+Phase 1 P1-2.5 follow-up (PR #76 / ISSUE #75 / merge commit `3eccaa1`) で、Gemma-2-2B-jpn-it Q5_K_M の Layer 3 smoke fixture 15 行のうち 14 行を PASS、1 行 (row 3「あした → 明日」) のみ FAIL (「翌日」出力) で close した。row 3 の FAIL は v5〜v12 の 8 世代 prompt iteration で解消不能であり、Gemma-2-2B-jpn-it の 2B parameter instruction-tuning における in-context learning (ICL) 限界として Phase 1 は 14/15 を受容した。根本解消は Phase 5「Kotoha custom romaji-base model」で task-specific fine-tune モデルにより達成する方針を ADR 0010 に記録した。Phase 2 (Dictionary and learning) 着手時には、Gemma baseline 14/15 を前提として Dictionary / 学習キャッシュ設計を進める。
+
+## Phase 5 マイルストーン分割
+
+Phase 5「Kotoha custom romaji-base model」は 4 milestone に分割する。詳細は `docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md` および ADR 0010 を参照。各 milestone の exact スコープは Phase 4 完了時の Phase 5 kick-off で確定する。
+
+### P5-A: Data pipeline (工数目安 2〜4 週)
+
+Data pipeline は kana→kanji ペアの大規模コーパス構築を担う。以下を含む。
+
+- コーパス source からの日本語テキスト抽出 (LLM-JP Corpus / CC-100 Japanese / Wikipedia JP のライセンス確認 + 抽出スクリプト)
+- MeCab 形態素解析による kana→kanji ペア生成
+- kana→romaji 拡張 (Hepburn / Kunrei / waapuro の 3 方式並立展開)
+- typo 注入 (edit distance 1〜3、隣接キー置換 / 転倒 / 欠落 / 余剰)
+- partial-input 生成 (ランダム truncate による prefix 集合)
+- special tokens 設計確定 (`<ctx>` / `<romaji>` / `<out>` / `<eos>` + 拡張候補)
+- データ scale 目標: 1M〜10M ペア (B1 scratch では 10M+、B3 distillation では 1M〜3M)
+
+### P5-B: Training (工数目安 1〜2 週 + GPU 数日)
+
+学習戦略候補 3 本の empirical 比較と default 決定を担う。
+
+- B1: scratch training (GPT-2 Small 90M、random init、RTX 4090 で 1〜3 GPU-day)
+- B2: LoRA fine-tune (Gemma-2-2B-jpn-it adapter、inference 時 base 必要のため候補から除外推奨)
+- B3: distillation (Gemma-4-31B-it 等を teacher、90〜180M student、数 GPU-day、**default 推奨**)
+- 比較計画: B1 と B3 を同一評価 fixture で走らせ、row 3 解消率 / typo robustness / latency の 3 軸で判定する
+
+### P5-C: Integration (工数目安 1〜2 週)
+
+学習済みモデルの Kotoha 推論経路統合を担う。
+
+- GGUF Q5_K_M 量子化 (目標 size ≤ 200MB)
+- `BackendConfig::KotohaNative { model_path, tokenizer_path }` variant 追加 (Phase 1 `LlamaCpp` と並立)
+- 外部 HuggingFace tokenizer (`tokenizers` crate) の統合
+- partial-input 対応 beam search
+- typo 対応 top-k 候補生成
+- context 注入 (周辺テキスト)
+- Sudachi 辞書 fallback (OOV 語彙、後段併用)
+
+### P5-D: Evaluation and iteration (継続)
+
+以下の評価 set を実装し、継続的に iterate する。
+
+- Layer 3 smoke 15-row (Phase 1 fixture との regression 確認)
+- 200-row regression set (Phase 5 専用に拡張)
+- 10k-row golden set (BLEU / exact-match metric)
+- typo robustness set (意図的 typo 100 件、edit distance 1〜3)
+- partial-input set (prefix top-k 評価)
+- latency SLA (p50 ≤ 30ms, p99 ≤ 100ms on CPU)
+
 ## 注記
 
-- Phase 5 の「Shift 挙動設定」は、設計書 revision 2 の判断により Phase 0 に前倒しされた。Phase 5 は「タイポ訂正 + 文脈リランキング」のみ。
-- 各 Phase の設計書は `docs/superpowers/specs/` に配置する。
+- Phase 5 への restructure (ADR 0010) により、旧 Phase 5 (Advanced features) は Phase 6 へ、旧 Phase 6 (UX polish) は Phase 7 へ後ろ倒しされた
+- 旧 Phase 5 の「Shift 挙動設定」は、設計書 revision 2 の判断により Phase 0 に前倒し済み。新 Phase 6 の内容は「タイポ訂正 + 文脈リランキング」のみ
+- 各 Phase の設計書は `docs/superpowers/specs/` に配置する

--- a/docs/adr/0010-kotoha-custom-romaji-base-model.md
+++ b/docs/adr/0010-kotoha-custom-romaji-base-model.md
@@ -81,6 +81,8 @@ Phase 5 kick-off 時点で Karukan 踏襲 (PUA 領域 `\u{ee00}-\u{ee0F}`) か�
 
 Phase 5 の拡張 special tokens 候補として `<edit>` (編集履歴), `<partial>` (未確定 prefix), `<typo-hint>` (typo tolerance 強調) を検討する。
 
+PUA id は Phase 5 kick-off で empirical 確定する (Karukan 踏襲 `\u{ee02}=<ctx>` / `\u{ee00}=<romaji>` / `\u{ee01}=<out>` / `\u{ee03}=<eos>` を初期候補とする。詳細と追加 token は [Phase 5 spec §4.5](../superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md) を参照)。
+
 ### D5. 外部 HuggingFace tokenizer を必須とする
 
 Kotoha の推論コードは Rust の `tokenizers` crate で `tokenizer.json` を直接 load し、llama.cpp 内蔵 tokenizer はバイパスする。これにより以下を達成する。
@@ -131,6 +133,7 @@ Phase 3 (IBus) と Phase 4 (fcitx5) は Gemma baseline で先行リリースし�
 - **学習データ品質が最終性能を支配する**: romaji 拡張規則 (Hepburn / Kunrei / waapuro) と typo 注入規則 (edit distance 1-3) の設計品質が、Phase 5 完了時の accuracy を決める
 - **B3 distillation は teacher の Japanese quality に下限を制約される**: Gemma-4-31B-it 等の teacher が row 3 相当の synonym bias を持つ場合、student にも波及する可能性があり、evaluation で確認が必要
 - **Phase 6 完遂までの schedule が延びる**: Phase 5 の data pipeline + training + evaluation で 3〜6 ヶ月程度を見込む。Phase 6 (旧 Phase 5) の着手時期は Phase 5 完了に連動する
+- Phase 5 は手動 training を前提とし、CI-driven training pipeline の自動化は Phase 6 以降へ延期する (spec §7 参照)。
 
 ## Alternatives considered
 

--- a/docs/adr/0010-kotoha-custom-romaji-base-model.md
+++ b/docs/adr/0010-kotoha-custom-romaji-base-model.md
@@ -1,0 +1,165 @@
+# ADR 0010 — Phase 5 として Kotoha 専用 romaji-base かな→漢字モデルを自作する
+
+- **Status**: Accepted (Phase 5 方針として承認。詳細パラメータは Phase 4 完了時の Phase 5 kick-off で確定)
+- **Date**: 2026-04-25
+- **Deciders**: Kotoha Phase 1 maintainers
+- **Related ISSUE**: #77 (Phase 5 foundation docs)
+- **Related PRs**: #76 (P1-2.5 follow-up — 14/15 empirical basis)
+
+## Context
+
+Phase 1 P1-2.5 follow-up (PR #76 / ISSUE #75 / merge commit `3eccaa1`) の empirical verification で、以下 2 つの事実が確定した。
+
+### C1. Gemma-2-2B-jpn-it Q5_K_M の in-context learning (ICL) 限界
+
+Layer 3 smoke fixture 15 行の通算 pass rate は `14/15` であり、row 3「あした → 明日」のみが「翌日」を生成し、v5〜v12 の 8 世代に渡る prompt iteration で解消不能であった。試行した手法と結果を再掲する。
+
+| 手法 | 結果 |
+|---|---|
+| positive few-shot 13 pair に「あした → 明日」を含める | row 3 は「翌日」を出力 |
+| few-shot 末尾 (query 直前) に「あした → 明日」を配置 (隣接 bias 強化) | row 3 は「翌日」を出力 |
+| directive 内に「『あした』は『明日』であり『翌日』ではありません」を埋込 | row 3 は「翌日」を出力 |
+| 「翻訳・類義語置換・言い換え禁止」を directive 冒頭に明示 | row 3 は「翌日」を出力 |
+
+同種の negative example「ぎゅうにゅう → 牛乳 (not ミルク)」「りょうり → 料理 (not クッキング)」は v12 で解消した。row 3 のみ解消しない原因は、Gemma-2-2B-jpn-it 事前学習分布において「あした ↔ 翌日」の語彙意味的距離が他の synonym 対に比べ極めて小さく、2B parameter instruction-tuning で学習した pretrain 語彙バイアスが、prompt の 13 pair few-shot + 否定例 + 直接指示の信号強度を上回っているためと推定する。PR #76 WBS の「Gemma-2-2B-jpn-it の ICL 限界に関する分析」節に詳細を記録した。
+
+### C2. Karukan 調査で判明した成功要因
+
+Karukan (Linux 向け日本語 IME) は `jinen-v1-small` (90M parameter、GPT-2 base、Q5_K_M 量子化、約 80MB) を採用し、本問題を起こさない。Karukan を Kotoha と比較して観察した成功要因は以下 4 点である。
+
+1. **タスク専用 fine-tune モデル**: `jinen-v1-small` は kana→kanji 変換タスクに特化して fine-tune された GPT-2 系 decoder-only モデルである。汎用 instruction-following LLM ではない。「あした → 明日」は学習分布の内側に位置するため、ICL に依存しない。
+2. **学習済み PUA (Private Use Area) special tokens による構造指示**: tokenizer は `\u{ee02}` を `CONTEXT` として、`\u{ee00}` を `INPUT_START` として、`\u{ee01}` を `OUTPUT_START` として fine-tuning 時に学習している。推論時の prompt は `\u{ee02}今日は\u{ee00}コンニチハ\u{ee01}` の形式で構造的に渡す。Prompt injection 耐性と構造安定性の両方に寄与する。
+3. **外部 HuggingFace tokenizer の使用**: Karukan は Rust の `tokenizers` crate で `tokenizer.json` を直接 load し、llama.cpp の内蔵 tokenizer を完全バイパスする。P1-2-9 で Zenz GGUF が `gpt2-small-japanese-char` pre-tokenizer の allow-list 不対応により llama.cpp load 失敗した問題は、この方式で回避可能である。
+4. **context 情報の受理**: 推論関数 `build_jinen_prompt(katakana, context)` は周辺テキストを `CONTEXT` token 後に注入する。Phase 5 の Kotoha モデルも同様の context 注入をサポートする。
+
+### C3. Karukan にも残る前処理層起因の不便
+
+ユーザーが Karukan を利用中に観察した以下の現象は、モデルを大きくしても解消しない。これらは全て「モデル到達前の決定論的 romaji→katakana 変換層」の限界である。
+
+- 「s」単打: fcitx5 の前処理層が「未確定 prefix」として保留し、モデルに届かない
+- 「si」入力: Hepburn 規則の前処理層が「し」に変換せず、`si` のまま残留する
+- 「s<backspace>」: 前処理層の状態機械が中間状態で破綻する
+- 「まうｓ」(「ます」の typo): 前処理層は typo を解釈できず、モデルが「ます」に復元する機会を奪う
+
+## Decision
+
+Kotoha は Phase 5 として **Kotoha 専用 romaji-base かな→漢字変換モデル** を自作する。Decision の構成は 7 項目とする。
+
+### D1. Phase 5 として romaji-base 専用モデルを自作する
+
+Phase 5 を「Kotoha custom romaji-base model」と位置付け、kana→kanji 変換専用に fine-tune した 90M〜180M parameter decoder-only transformer を Kotoha 固有に構築する。Phase 5 の完了条件は「Phase 1 の 14/15 baseline を維持しつつ、row 3 相当の ICL 限界問題 + typo robustness + partial-input 対応を smoke / golden / typo robustness / latency SLA の 4 評価で PASS すること」とする。
+
+### D2. 入力境界を raw romaji keystrokes 直接とする
+
+従来 (Phase 1 baseline) の「fcitx5 前処理で確定した katakana/hiragana 列をモデルに渡す」方式を Phase 5 では採用しない。Phase 5 のモデルは **raw romaji keystrokes (ASCII 列)** を直接受理し、自身で romaji→kana 的な読み解きを行う。この境界変更により、以下が possible になる。
+
+- 部分入力 `s` / `sh` / `si` を文脈で統合解釈する
+- typo `maus` / `まうｓ` をモデル側で「ます」と認識する fine-tune が可能になる
+- `backspace` を含む編集履歴を special token で表現できる
+- 半角/全角モード切替などの境界問題が根本解消する
+
+### D3. 学習戦略は Phase 5 kick-off で empirical 比較して確定する
+
+学習戦略候補を 3 本洗い出した上で、default recommendation を **B3 distillation** とする。最終確定は Phase 5 kick-off 時点の empirical 比較で行う。
+
+| 候補 | 手法 | 推奨度 |
+|---|---|---|
+| **B1** | scratch training (GPT-2 Small アーキテクチャ 90M を random 初期化から学習) | 候補 |
+| **B2** | LoRA fine-tune (Gemma-2-2B-jpn-it の adapter 学習) | 除外推奨 |
+| **B3** | distillation (Gemma-4-31B-it 等を teacher、90〜180M student に転移学習) | **default** |
+
+B2 を除外推奨とする理由: inference 時に base model (2.6B) の load が必要で、IME 常駐用途の size budget (Phase 1 現状 1.92GB、目標 ≤ 200MB) を満たさない。
+
+### D4. Special tokens の役割を確定する
+
+Phase 5 kick-off 時点で Karukan 踏襲 (PUA 領域 `\u{ee00}-\u{ee0F}`) か新設 (別領域 / 別 id) かを empirical 判断するが、役割は事前に固定する。最低限学習させる special tokens の役割は以下 4 種。
+
+- `<ctx>` — 周辺テキスト (context) の開始
+- `<romaji>` — romaji 入力の開始
+- `<out>` — モデル出力の開始
+- `<eos>` — 生成終了
+
+Phase 5 の拡張 special tokens 候補として `<edit>` (編集履歴), `<partial>` (未確定 prefix), `<typo-hint>` (typo tolerance 強調) を検討する。
+
+### D5. 外部 HuggingFace tokenizer を必須とする
+
+Kotoha の推論コードは Rust の `tokenizers` crate で `tokenizer.json` を直接 load し、llama.cpp 内蔵 tokenizer はバイパスする。これにより以下を達成する。
+
+- Zenz family が遭遇した `gpt2-small-japanese-char` pre-tokenizer 不対応問題の構造的回避
+- special tokens の ID 管理を tokenizer 側に一元化
+- Phase 6 以降の pre-tokenizer 拡張 (編集履歴 / partial-input) を llama.cpp upstream から独立して実装可能にする
+
+### D6. 推論は GGUF Q5_K_M 量子化で IME 常駐とする
+
+推論パス構成は以下とする。
+
+- モデル size 目標: 90M〜180M parameter、GGUF Q5_K_M で **≤ 200MB**
+- latency 目標: CPU 推論で **p50 ≤ 30ms、p99 ≤ 100ms**
+- 量子化精度候補: Q5_K_M を default、Q4_K_M / Q8_0 を empirical 比較 (Phase 5 kick-off)
+- 実装統合: `BackendConfig::KotohaNative { model_path, tokenizer_path }` variant を Phase 5 で追加 (Phase 1 の `BackendConfig::LlamaCpp` と並立)
+
+### D7. ROADMAP restructure
+
+Phase 5 の位置付け変更に伴い、既存 ROADMAP を以下のように restructure する。
+
+| 旧 Phase | 新 Phase | 名称 |
+|---|---|---|
+| 0 | 0 | Foundation |
+| 1 | 1 | Kana→Kanji conversion (Gemma-2-2B-jpn-it baseline, 14/15) |
+| 2 | 2 | Dictionary and learning |
+| 3 | 3 | IBus integration |
+| 4 | 4 | fcitx5 integration |
+| — | **5 (new)** | **Kotoha custom romaji-base model** |
+| 5 | 6 | Advanced features (typo correction + context reranking) |
+| 6 | 7 | UX polish |
+
+Phase 3 (IBus) と Phase 4 (fcitx5) は Gemma baseline で先行リリースし、IME shipping を遅延させない。Phase 5 (custom model) が Phase 6 (旧 Phase 5、Advanced features) の技術基盤を提供する。
+
+## Consequences
+
+### 正の帰結
+
+- **row 3 類の ICL 限界問題を根本解決する**: task-specific fine-tune により、「あした → 明日」のような pretrain bias 起因の synonym 誤変換は学習分布内で解消する
+- **typo tolerance の native 実現**: 「まうｓ → ます」「maus → ます」の意図的 typo 注入データで fine-tune することで、モデル側で typo 吸収が可能になる
+- **partial-input の native 対応**: `s` / `sh` / `si` の部分入力から top-k 候補を即時算出でき、IME の逐次候補表示が実装可能になる
+- **Phase 6 (旧 Phase 5) の技術基盤になる**: typo correction + context reranking は romaji-base モデルの上でこそ自然に実装できる
+- **Size の大幅削減**: Gemma-2-2B-jpn-it の 2.6B / 1.92GB から 90〜180M / ≤ 200MB へ縮小する。IME 常駐用途に適合する
+
+### 負の帰結
+
+- **学習インフラ整備の工数**: GPU 環境、data pipeline (LLM-JP / CC-100 / Wikipedia JP 抽出 + MeCab 形態素解析 + romaji 拡張 + typo 注入)、eval harness (smoke / regression / golden / typo / latency) の全セットアップが必要であり、Phase 5 前半の工数が膨らむ
+- **学習データ品質が最終性能を支配する**: romaji 拡張規則 (Hepburn / Kunrei / waapuro) と typo 注入規則 (edit distance 1-3) の設計品質が、Phase 5 完了時の accuracy を決める
+- **B3 distillation は teacher の Japanese quality に下限を制約される**: Gemma-4-31B-it 等の teacher が row 3 相当の synonym bias を持つ場合、student にも波及する可能性があり、evaluation で確認が必要
+- **Phase 6 完遂までの schedule が延びる**: Phase 5 の data pipeline + training + evaluation で 3〜6 ヶ月程度を見込む。Phase 6 (旧 Phase 5) の着手時期は Phase 5 完了に連動する
+
+## Alternatives considered
+
+以下 4 案を検討し、いずれも棄却した。
+
+### A. jinen-v1-small (Karukan と同一モデル) 流用
+
+**Rejected.** Karukan で観察した前処理層起因の不便 (`s` / `sh` / `si` / backspace / typo) は jinen-v1-small を流用しても解消しない。romaji-base 境界への移行には再学習が必須であり、jinen 流用は fine-tune データ設計の自由度を奪う割に利得が少ない。
+
+### B. Gemma-2-2B-jpn-it の LoRA fine-tune
+
+**Rejected.** LoRA adapter 本体は小さいが、inference 時に base model (2.6B / 1.92GB) の同時 load が必要であり、IME 常駐用途の size budget を満たさない。
+
+### C. Gemma-4-31B-it の Japanese specialization
+
+**Rejected.** 31B parameter の GGUF は 18GB 前後であり、Phase 1 の size budget (1.92GB) の 9 倍を超える。IME 常駐不可能。Phase 5 の teacher 候補としては検討対象となる (D3 参照)。
+
+### D. row 3 類を長期既知制約として受容し、Phase 5 を旧 Phase 5 (Advanced features) 実装に使う
+
+**Rejected.** C1 で実証したように、汎用 instruction-following LLM の ICL では row 3 類の synonym bias を prompt だけで覆せない。Phase 6 (旧 Phase 5) の typo correction / context reranking を実装しても、根本の convert layer が Gemma のままでは「あした → 翌日」問題は残存する。
+
+## Related documents
+
+- Parent empirical record: `docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md` (PR #76 merge commit `3eccaa1`)
+- Phase 1 design spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §3.2 / §3.3 / §6 の Phase 1 acceptance 14/15 記述
+- Phase 5 design spec (stub): `docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md`
+- ROADMAP restructure 反映先: `docs/ROADMAP.md` Phase 一覧テーブル + Phase 5 マイルストーン分割節
+- 先行 ADR 0009 (Gemma-2-2B-jpn-it pivot prep note): `docs/adr/0009-kanji-backend-model-selection-prep.md`
+
+## Note: Phase 3 呼称訂正
+
+PR #76 で既に develop に merge 済みの WBS (`docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md`) 内には「Phase 3 への引き継ぎ」「Phase 3 deferral」等の記述が残存しているが、本 ADR の ROADMAP restructure 確定により、これら参照先は Phase 5 に訂正されるべきである。ISSUE #77 のスコープ外として、別 follow-up commit で訂正する。

--- a/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
+++ b/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
@@ -139,7 +139,7 @@ Phase 5 の実装範囲は以下 5 項目とする。
 
 - Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` に加え、Phase 5 で `BackendConfig::KotohaNative { model_path, tokenizer_path }` variant を追加する
 - 外部 HuggingFace tokenizer を `tokenizers` crate で load する
-- 推論本体は llama-cpp-2 を使用するが、tokenize / detokenize の I/O boundary は `tokenizers` に委譲する
+- 推論本体は llama-cpp-2 を使用する (Phase 5 kick-off で他 inference backend との比較を行い確定、stub 段階では default candidate として記述)。ただし tokenize / detokenize の I/O boundary は `tokenizers` に委譲する
 - beam search で partial-input 候補 top-k を算出する
 - Sudachi 辞書 fallback を OOV (Out-Of-Vocabulary) 検知時の後段として併用する
 

--- a/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
+++ b/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
@@ -1,0 +1,348 @@
+---
+title: Kotoha Phase 5 設計書 (stub) — Kotoha 専用 romaji-base かな→漢字モデル
+date: 2026-04-25
+status: stub
+phase: 5
+revision: 1
+---
+
+# Kotoha Phase 5 (Kotoha custom romaji-base model) 設計書 — stub
+
+本書は Phase 5 の設計書 **stub** である。詳細パラメータ (data pipeline の exact script、model hyperparameter、training schedule、量子化比較の empirical 数値) は Phase 4 完了時の Phase 5 kick-off で確定する。本書の役割は ISSUE #77 時点で Phase 5 のスコープ / 方針 / open question を確定し、Phase 2〜4 実装中に Phase 5 への影響を考慮可能にすることである。
+
+## 目次
+
+- [1. 背景と動機](#1-背景と動機)
+- [2. スコープ](#2-スコープ)
+- [3. アーキテクチャ](#3-アーキテクチャ)
+- [4. データ設計](#4-データ設計)
+- [5. 学習戦略](#5-学習戦略)
+- [6. 評価](#6-評価)
+- [7. 非スコープ (将来 phase)](#7-非スコープ-将来-phase)
+- [8. Open questions](#8-open-questions)
+- [9. 参照](#9-参照)
+
+## 1. 背景と動機
+
+### 1.1 Phase 1 baseline の ICL 限界 (定量)
+
+Phase 1 P1-2.5 follow-up (PR #76 / ISSUE #75 / merge commit `3eccaa1`) で、Gemma-2-2B-jpn-it Q5_K_M をバックエンドに Layer 3 smoke fixture 15 行を empirical 実測した。結果は `14/15 PASS` であった。
+
+唯一 FAIL した row 3 は「あした → 明日」(期待 substring `明日`) であり、モデルは `翌日` を生成した。v5〜v12 の 8 世代 prompt iteration の概要は以下のとおり。
+
+| version | pass rate | 主要変更 | row 3 状態 |
+|---|---|---|---|
+| v5 | 8/15 | `apply_chat_template` + 3 件 IME-style few-shot turn | 翌日 |
+| v6 | 9/15 | plain-text completion へ pivot、7 pair few-shot | 翌日 |
+| v7 | 10/15 | few-shot 11 pair (拗音・外来語・敬称網羅) | 翌日 |
+| v8 | 11/15 | few-shot 12 pair (助詞付き文例追加) | 翌日 |
+| v9 | 12/15 | few-shot 16 pair (情報量過多で特定 row が regress) | 翌日 |
+| v10 | 14/15 | few-shot 13 pair + directive を IME 業務ドメインに具体化 | 翌日 |
+| v11 | 14/15 | 「あした → 明日」を query 直前 (隣接位置) に配置 | 翌日 |
+| v12 | 14/15 | directive 内に「あした は 明日 であり 翌日 ではない」等の negative example 3 件を明示埋込 | 翌日 |
+
+同種の negative example「ぎゅうにゅう → 牛乳 (not ミルク)」「りょうり → 料理 (not クッキング)」は v12 で PASS した。row 3 のみ解消しない原因は Gemma-2-2B-jpn-it 事前学習分布における「あした ↔ 翌日」の語彙意味的距離が極めて小さく、2B parameter instruction-tuning の表層的な few-shot / directive 指示の信号強度が、pretrain 語彙バイアスを上書きできないためと推定する。
+
+### 1.2 Karukan 調査の要約
+
+Karukan (Linux 向け日本語 IME) は `jinen-v1-small` (90M parameter、GPT-2 base、Q5_K_M 量子化、約 80MB) を採用し、row 3 相当の問題を起こさない。観察した成功要因は以下 4 点である。
+
+1. **タスク専用 fine-tune モデル**: kana→kanji 変換専用に fine-tune された GPT-2 系 decoder-only モデルであり、汎用 instruction LLM ではない。「あした → 明日」は学習分布内に位置し、ICL に依存しない。
+2. **学習済み PUA special tokens による構造指示**: `\u{ee02}` (CONTEXT) / `\u{ee00}` (INPUT_START) / `\u{ee01}` (OUTPUT_START) を fine-tuning 時に学習させており、prompt は `\u{ee02}今日は\u{ee00}コンニチハ\u{ee01}` の構造で渡される。Prompt injection 耐性と構造安定性の両方に寄与する。
+3. **外部 HuggingFace tokenizer**: Rust の `tokenizers` crate で `tokenizer.json` を直接 load し、llama.cpp 内蔵 tokenizer を完全バイパスする。Phase 1 P1-2-9 で Zenz GGUF が `gpt2-small-japanese-char` pre-tokenizer 不対応により llama.cpp load 失敗した問題を構造的に回避できる。
+4. **context 情報の受理**: 推論関数 `build_jinen_prompt(katakana, context)` は周辺テキストを CONTEXT token 後に注入する。
+
+### 1.3 Karukan にも残る前処理層起因の不便
+
+以下の現象はモデルを大きくしても解消しない。モデル到達前の決定論的 romaji→katakana 変換層の限界である。
+
+- 「s」単打: fcitx5 前処理層が「未確定 prefix」として保留し、モデルに届かない
+- 「si」入力: Hepburn 規則前処理層が「し」に変換せず、`si` のまま残留する
+- 「s<backspace>」: 前処理層の状態機械が中間状態で破綻する
+- 「まうｓ」(「ます」の typo): 前処理層は typo を解釈できないため、モデルが「ます」に復元する機会を奪う
+
+### 1.4 Phase 5 で解決する具体目標
+
+Phase 5 は以下 4 点を同時解決する。
+
+- **G1**: row 3 類の synonym bias を task-specific fine-tune で根本解消し、Phase 1 の 14/15 を 15/15 以上に引き上げる
+- **G2**: typo tolerance を native に実現する (「まうｓ → ます」「maus → ます」の意図的 typo 注入データで fine-tune)
+- **G3**: partial-input 対応 (`s` / `sh` / `si` 等の prefix から top-k 候補を即時算出)
+- **G4**: context-aware 変換 (周辺テキストを special token で注入し同音異義の曖昧性を解決)
+
+詳細は Phase 5 kick-off で確定する。
+
+## 2. スコープ
+
+### 2.1 In-scope
+
+Phase 5 の実装範囲は以下 5 項目とする。
+
+1. **モデル本体**: romaji-base 90〜180M parameter decoder-only transformer (GPT-2-like) の Kotoha 固有構築
+2. **学習パイプライン**: data 抽出 + MeCab 形態素解析 + romaji 拡張 + typo 注入 + partial-input 生成 + special tokens 設計 + training loop + evaluation harness
+3. **推論統合**: GGUF Q5_K_M 量子化 + 外部 HuggingFace tokenizer + `BackendConfig::KotohaNative` variant + partial-input beam search + typo top-k + context 注入 + Sudachi 辞書 fallback
+4. **評価 set**: smoke 15-row / 200-row regression / 10k-row golden / typo robustness 100 件 / partial-input set / latency SLA
+5. **CLI 統合**: `kotoha-kanji` への `--backend kotoha-native` option 追加 (Phase 1 の `llama-cpp` backend と並立)
+
+### 2.2 Out-of-scope (Phase 6 以降)
+
+以下 3 項目は Phase 5 では扱わず、後続 Phase に送る。
+
+1. **Training infrastructure 自動化** (CI-driven training pipeline、data 差分再学習): Phase 6 以降
+2. **Personalization / user adapter** (ユーザごとの微小 fine-tune layer): Phase 6 以降
+3. **Multilingual extension** (英語 / 中国語 / 韓国語 入力対応): Phase 8 以降の別議論
+
+詳細は Phase 5 kick-off で再確認する。
+
+## 3. アーキテクチャ
+
+### 3.1 データパイプライン (概観)
+
+データパイプラインは以下の段階を直列に接続する。詳細スクリプト仕様は Phase 5 kick-off で確定する。
+
+```
+[コーパス source]
+  LLM-JP Corpus / CC-100 JP / Wikipedia JP
+        │ ライセンス確認 + 抽出
+        ▼
+[形態素解析 + kana→kanji ペア生成]
+  MeCab + 独自 filter (信頼性の低い読み / 多義語を排除)
+        │
+        ▼
+[kana → romaji 拡張]
+  Hepburn / Kunrei / waapuro 3 方式を並立展開
+        │
+        ▼
+[augmentation]
+  typo 注入 (edit distance 1〜3)
+  partial-input 生成 (ランダム truncate)
+        │
+        ▼
+[special tokens wrap]
+  <ctx> / <romaji> / <out> / <eos> + 拡張候補
+        │
+        ▼
+[tokenize]
+  HuggingFace tokenizers (tokenizer.json)
+        │
+        ▼
+[training 入力]
+```
+
+### 3.2 学習 (概観)
+
+学習戦略候補を 3 本洗い出し、default を B3 distillation とする。詳細は §5 学習戦略を参照。empirical 比較と最終確定は Phase 5 kick-off で行う。
+
+### 3.3 推論統合 (概観)
+
+推論経路は Phase 1 の `LlamaCppBackend` と並立させる。
+
+- Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` に加え、Phase 5 で `BackendConfig::KotohaNative { model_path, tokenizer_path }` variant を追加する
+- 外部 HuggingFace tokenizer を `tokenizers` crate で load する
+- 推論本体は llama-cpp-2 を使用するが、tokenize / detokenize の I/O boundary は `tokenizers` に委譲する
+- beam search で partial-input 候補 top-k を算出する
+- Sudachi 辞書 fallback を OOV (Out-Of-Vocabulary) 検知時の後段として併用する
+
+詳細 variant 定義と CLI option は Phase 5 kick-off で確定する。
+
+### 3.4 Sudachi 辞書 fallback
+
+モデル単独では人名 / 地名 / 新語など OOV 語彙の recall が不足するため、Sudachi 辞書 (`Sudachi-core-dict`) を後段 fallback として併用する。統合方式は以下 3 候補から empirical 比較 (Phase 5 kick-off) で確定する。
+
+- 候補 a: `kanji` module 側で convert 前に Sudachi lookup し、hit 時は model をスキップ
+- 候補 b: model の top-k 候補に Sudachi lookup 結果を後段 reranker として merge
+- 候補 c: model と Sudachi を並列実行し、score fusion で最終候補を決定
+
+詳細は Phase 5 kick-off で確定する。
+
+## 4. データ設計
+
+### 4.1 コーパス source とライセンス
+
+以下 3 source を候補とする。最終採用は Phase 5 kick-off で確定する。
+
+| Source | 想定 size | ライセンス | 特徴 |
+|---|---|---|---|
+| LLM-JP Corpus | 数百 GB 級 | CC BY 4.0 (一部) | 日本語 LLM 学習向けに整備済み、形態素解析済み版も存在 |
+| CC-100 Japanese | 数十 GB | Common Crawl 由来 | Web text 主体、noise fill が必要 |
+| Wikipedia JP | 数 GB | CC BY-SA 3.0 | 高品質だが size が不足、augmentation source として利用 |
+
+Kotoha は OSS として再配布予定のため、学習済みモデルの再配布ライセンスと source ライセンスの両立を Phase 5 kick-off 時点で再確認する。
+
+### 4.2 kana → romaji 拡張規則
+
+kana 1 つに対して複数の romaji 候補を並立展開する。以下は代表例であり、完全表は Phase 5 kick-off で確定する。
+
+| かな | Hepburn | Kunrei | waapuro |
+|---|---|---|---|
+| し | shi | si | si / shi |
+| ち | chi | ti | ti / chi |
+| つ | tsu | tu | tu / tsu |
+| ふ | fu | hu | hu / fu |
+| ぢ | ji | zi | di |
+| づ | zu | zu | du |
+| ん | n (母音前 n'), m (b/p 前) | n | nn / n |
+| 促音 っ + X | 子音重ね | 子音重ね | 子音重ね |
+| 長音符 ー | 直前母音重ね / `-` | 直前母音重ね | `-` |
+
+目的は「実ユーザが入力しうる全ての romaji 綴りを学習分布内に含める」ことである。
+
+### 4.3 typo 注入規則
+
+edit distance 1〜3 の範囲で以下 4 種類の typo を確率的に注入する。
+
+| 種類 | 例 | 注入確率 (目安) |
+|---|---|---|
+| 隣接キー置換 | `arigato` → `afigato` (r → f) | 0.3 |
+| 文字転倒 | `arigato` → `airgato` | 0.2 |
+| 文字欠落 | `arigato` → `arigto` | 0.3 |
+| 文字余剰 | `arigato` → `arigaato` | 0.2 |
+
+キーボードレイアウトは US 109 JIS として隣接 map を定義する。確率と edit distance 分布の最終値は Phase 5 kick-off で確定する。
+
+### 4.4 partial-input 生成規則
+
+完全な romaji 列 `arigato` から先頭切り出しで `a`, `ar`, `ari`, `arig`, `ariga`, `arigat`, `arigato` の 7 通り prefix を生成する。全 prefix に対して正解 kanji を教師信号として与えると「入力完了前に候補を出す」IME 挙動が native に学習される。
+
+prefix 切り出しの分布 (どの長さを何割選ぶか) は Phase 5 kick-off で empirical 確定する。
+
+### 4.5 special tokens
+
+PUA (Private Use Area) 領域 `\u{ee00}-\u{ee0F}` を Karukan 踏襲で採用する案と、新領域 / 新 id で設計する案を Phase 5 kick-off で empirical 判断する。最低限学習させる token の役割は以下 4 種。
+
+| Token 役割 | 例 PUA id | 意味 |
+|---|---|---|
+| `<ctx>` | `\u{ee02}` | 周辺テキスト (context) の開始 |
+| `<romaji>` | `\u{ee00}` | romaji 入力の開始 |
+| `<out>` | `\u{ee01}` | モデル出力の開始 |
+| `<eos>` | `\u{ee03}` | 生成終了 |
+
+Phase 5 の拡張 special tokens 候補は以下 3 種を検討する。
+
+- `<edit>`: `backspace` / 再変換の編集履歴を表現
+- `<partial>`: 未確定 prefix を明示
+- `<typo-hint>`: typo tolerance を強調する hint
+
+詳細 id 割り当ては Phase 5 kick-off で確定する。
+
+### 4.6 データ scale
+
+目標は 1M〜10M kana→kanji ペアである。B1 scratch training では 10M+ ペアが必要と推定し、B3 distillation では 1M〜3M ペアで teacher の soft label を引き継げる想定である。最終 scale は Phase 5 kick-off 時の empirical pilot で確定する。
+
+## 5. 学習戦略
+
+学習戦略候補 3 本を empirical 比較し、default を B3 distillation とする。
+
+### 5.1 B1 scratch
+
+GPT-2 Small (90M parameter) アーキテクチャを random 初期化から学習する。
+
+- 必要 data size: 10M+ kana→kanji ペア
+- 必要 compute: RTX 4090 で 1〜3 GPU-day
+- 利点: teacher に依存しない、Kotoha 固有の語彙傾向を直接学習できる
+- 欠点: data size が膨らむ、初期 loss が高く収束までの時間が長い
+
+### 5.2 B2 LoRA
+
+Gemma-2-2B-jpn-it の LoRA adapter を学習する。
+
+- 必要 data size: 100k〜1M ペア
+- 必要 compute: 数 GPU-hour
+- 利点: training cost が最小
+- 欠点: **inference 時に base model (2.6B / 1.92GB) の load が必要であり、IME 常駐 size budget (≤ 200MB) を満たさない**
+- 扱い: **候補から除外推奨**。ただし Phase 5 kick-off 時点で「offline batch 用途」の別 target として再検討する余地は残す
+
+### 5.3 B3 distillation (default 推奨)
+
+Gemma-4-31B-it 等の大規模 teacher モデルで soft label (top-k 確率分布) を生成し、90〜180M parameter student モデルに transfer する。
+
+- 必要 data size: 1M〜3M ペア
+- 必要 compute: teacher 推論 (数 GPU-day) + student 学習 (1〜2 GPU-day)
+- 利点: 高品質な soft label により、scratch より少ない data で収束する。teacher の Japanese 語彙知識を student に圧縮できる
+- 欠点: teacher の Japanese quality に下限が制約される。teacher が row 3 類の synonym bias を持つ場合、student にも波及する可能性があり、evaluation で確認が必要
+
+teacher 候補は以下 3 つを Phase 5 kick-off で empirical 比較する。
+
+- `Gemma-4-31B-it` (31B、Japanese 性能 high、size 18GB、inference に H100 級が必要)
+- `Llama-3.1-Nemotron-70B-Instruct` (70B、英語中心だが日本語も可、size 40GB)
+- `Qwen2.5-72B-Instruct` (72B、多言語、Apache 2.0、size 45GB)
+
+### 5.4 比較計画
+
+Phase 5 kick-off 初週に以下を実施する。
+
+1. 共通 evaluation fixture を §6 の smoke / typo / partial-input set で事前確定する
+2. B1 と B3 の両方で pilot training を走らせる (B1 は data 1M で short run、B3 は teacher soft label 100k で short run)
+3. 上記 pilot の結果で row 3 解消 / typo pass rate / latency / size の 4 軸を比較する
+4. default を最終確定する (想定: B3、B1 を fallback として残す)
+
+## 6. 評価
+
+### 6.1 Smoke / regression / golden の 3 層
+
+| 層 | 件数 | 用途 |
+|---|---|---|
+| Layer 3 smoke (Phase 1 と共通) | 15 | Phase 1 baseline との regression 確認 |
+| 200-row regression | 200 | 敬称 / 拗音 / 外来語 / 文章など Phase 5 固有に拡張 |
+| 10k-row golden | 10000 | BLEU / exact-match metric での統計的品質評価 |
+
+10k-row golden の作成方針は Phase 5 kick-off で確定する (人手校正 vs 自動抽出の比率、license 互換性)。
+
+### 6.2 typo robustness set
+
+意図的 typo 100 件を edit distance 1〜3 で作成し、Phase 5 モデルで pass rate を測定する。例: `arigat` (欠落) / `afigato` (隣接キー置換) / `airgato` (転倒) / `arigaato` (余剰) / `まうｓ` (半角/全角混在 + 欠落) を含む。
+
+### 6.3 partial-input set
+
+完全 romaji 列 100 件から各 prefix を抽出し、top-k 候補に正解 kanji が含まれる率を測定する。IME の逐次候補表示の品質指標とする。
+
+### 6.4 latency SLA
+
+- p50 ≤ 30ms (CPU 推論、RTX 不要 host)
+- p99 ≤ 100ms
+- 測定環境: Phase 5 kick-off で確定 (現状想定: Intel i7-12700 相当 + 16GB RAM)
+
+### 6.5 model size target
+
+- GGUF Q5_K_M で **≤ 200MB**
+- 量子化精度の empirical 比較候補: Q5_K_M default、Q4_K_M (size 縮小但し精度劣化確認)、Q8_0 (精度維持但し size 膨張)
+
+詳細な benchmark スクリプトは Phase 5 kick-off で確定する。
+
+## 7. 非スコープ (将来 phase)
+
+Phase 5 のスコープから以下を明示的に除外する。
+
+- **user adapter / personalization**: ユーザごとの微小 fine-tune layer は Phase 6 以降に延期する。Phase 5 は汎用モデル 1 本で完結させる
+- **multilingual extension**: 英語 / 中国語 / 韓国語 入力対応は Phase 8 以降の別議論とする
+- **streaming inference**: 現行 Phase 5 は single-shot 推論のみを扱う。streaming が必要となった場合は Phase 6 着手時点で別 ADR を起こして判断する
+- **training infrastructure の CI 化**: Phase 5 は手動 training を前提とする。CI-driven 差分再学習は Phase 6 以降
+
+## 8. Open questions
+
+Phase 5 kick-off 時点で解消する 6 点を以下に列挙する。
+
+| # | Question | 解消 milestone |
+|---|---|---|
+| Q1 | B1 scratch と B3 distillation のどちらを default とするか | Phase 5 kick-off 初週 (pilot 結果で判断) |
+| Q2 | special tokens を PUA 踏襲 (`\u{ee00}-\u{ee0F}`) とするか新設とするか | tokenizer 学習時に empirical 確定 |
+| Q3 | context window size を 256 / 512 / 1024 のいずれにするか | Phase 5 kick-off 初週 (Karukan は 256、Phase 5 は 512 / 1024 を検討) |
+| Q4 | 量子化精度を Q5_K_M default として Q4_K_M / Q8_0 をどう扱うか | Phase 5 P5-C で empirical 比較 |
+| Q5 | Sudachi 辞書 fallback の integration layer を §3.4 の候補 a / b / c のいずれにするか | Phase 5 P5-C で empirical 比較 |
+| Q6 | user learning cache (Karukan の `learning.tsv` 相当) を Phase 5 に含めるか Phase 6 に延期するか | Phase 5 kick-off 初週で scope 判断 |
+
+詳細は Phase 5 kick-off で確定する。
+
+## 9. 参照
+
+- ADR 0010 (Phase 5 方針決定): `docs/adr/0010-kotoha-custom-romaji-base-model.md`
+- ROADMAP restructure 反映先: `docs/ROADMAP.md` Phase 一覧 + Phase 5 マイルストーン分割節
+- Phase 1 設計書 (14/15 baseline の根拠): `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md`
+- Phase 1 P1-2.5 follow-up 実装ログ (row 3 ICL 限界の empirical 記録): `docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md`
+- ADR 0009 prep note (Gemma-2-2B-jpn-it pivot): `docs/adr/0009-kanji-backend-model-selection-prep.md`
+- Karukan (参照設計): <https://github.com/akaza-im/karukan> (jinen-v1-small の PUA special tokens + 外部 HuggingFace tokenizer 実装)
+- LLM-JP Corpus: <https://llm-jp.nii.ac.jp/>
+- CC-100 Japanese: <https://data.statmt.org/cc-100/>
+- Sudachi dictionary: <https://github.com/WorksApplications/Sudachi>
+
+本 stub の詳細化は Phase 4 完了時の Phase 5 kick-off で実施する。

--- a/docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md
+++ b/docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md
@@ -10,7 +10,7 @@
 | PR                  | 作成予定 (本 WBS commit 後に別 commit で issue/PR 作成する)                                      |
 | 実装起点            | `02cf035` (develop, #74 merge commit)                                                           |
 | 最終 pass rate      | 14/15 (row 3「あした → 明日」のみ FAIL)                                                          |
-| 受容判断            | 14/15 を Phase 1 受容。row 3 の根本解決は Phase 3 「Kotoha 専用 romaji-base モデル」へ繰越し   |
+| 受容判断            | 14/15 を Phase 1 受容。row 3 の根本解決は Phase 5 「Kotoha custom romaji-base model」へ繰越し (ADR 0010 で確定) |
 
 ## 概要
 
@@ -18,7 +18,7 @@
 
 本セッションでは v5 から v12 まで合計 8 世代の prompt を試行した結果、Gemma-2-2B-jpn-it Q5_K_M の in-context learning (ICL) で到達可能な上限は 14/15 であると実証的に判断した。具体的には row 3「あした → 明日」が、positive few-shot・negative few-shot・直接指示のいずれの誘導でも「翌日」から覆せなかった。
 
-本 follow-up は 14/15 を Phase 1 acceptance として受容し、row 3 の完全解消は Phase 3 の「Kotoha 専用 romaji-base モデル」(Karukan jinen-v1-small を参照する task-specific fine-tune) で根本解決する方針で close する。
+本 follow-up は 14/15 を Phase 1 acceptance として受容し、row 3 の完全解消は Phase 5 の「Kotoha custom romaji-base model」(Karukan jinen-v1-small を参照する task-specific fine-tune) で根本解決する方針で close する。
 
 ## 実装差分の要約
 
@@ -132,22 +132,22 @@ row 3「あした」だけが v5 から v12 まで一貫して「翌日」を出
 
 これは「汎用 instruction-tuned small LLM の ICL で kana→kanji IME タスクを完全に誘導することの限界」の実例である。参照として、Karukan の jinen-v1-small (90M parameter、GPT-2 ベース、kana→kanji 専用 fine-tune + PUA special tokens による構造的入力保証) は同類タスクで成功しているが、これは「学習分布内」での推論であり、ICL に依存していない点が本質的な違いである。
 
-## Phase 3 への引き継ぎ
+## Phase 5 への引き継ぎ
 
-row 3「あした → 翌日」問題は既知制約として Phase 3 に繰越し、以下の方針で根本解決する予定である (詳細仕様は本 WBS の範囲外で、別 PR で ADR 0010 および ROADMAP Phase 3 spec draft として起票される)。
+row 3「あした → 翌日」問題は既知制約として Phase 5 に繰越し、以下の方針で根本解決する予定である (詳細仕様は本 WBS の範囲外で、別 PR で ADR 0010 および ROADMAP Phase 5 spec draft として起票される)。
 
-- Phase 3 の採用予定方針: raw romaji (ASCII 列) 入力 → kanji 直接変換を担う、Kotoha 専用の task-specific 小型モデル (目標 90M 前後、distillation または scratch training)
+- Phase 5 の採用予定方針: raw romaji (ASCII 列) 入力 → kanji 直接変換を担う、Kotoha 専用の task-specific 小型モデル (目標 90M 前後、distillation または scratch training)
 - 参照設計: Karukan jinen-v1-small (90M GPT-2 base + PUA special tokens + kana→kanji 専用 fine-tune)
 - 学習データ: Kotoha fixture + 公開 IME コーパスからの synthetic pair
-- 位置づけ: Phase 1 の Gemma-2-2B-jpn-it backend は general-purpose fallback として残しつつ、Phase 3 model を primary dispatch とする
+- 位置づけ: Phase 1 の Gemma-2-2B-jpn-it backend は general-purpose fallback として残しつつ、Phase 5 model を primary dispatch とする
 
-本方針の記述: Phase 3 着手時に `docs/adr/0010-phase3-custom-romaji-base-model.md` および `docs/ROADMAP.md` Phase 3 section で詳細化する (本 follow-up の scope 外)。
+本方針の記述: Phase 5 着手時に `docs/adr/0010-kotoha-custom-romaji-base-model.md` および `docs/ROADMAP.md` Phase 5 section で詳細化する (本 follow-up の scope 外)。
 
 ## Open Question の close 宣言
 
 | Q                                                         | Close 判断                                                                                                         |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| ISSUE #75「15-row Layer 3 fixture で 15/15 PASS を達成する」 | **条件付き close**: 14/15 PASS を Phase 1 acceptance として受容し、row 3 の残 1 件は Phase 3 で解消する計画で合意 |
+| ISSUE #75「15-row Layer 3 fixture で 15/15 PASS を達成する」 | **条件付き close**: 14/15 PASS を Phase 1 acceptance として受容し、row 3 の残 1 件は Phase 5 で解消する計画で合意 |
 
 ## 検証 commands (final、本 follow-up ブランチで実行)
 
@@ -172,9 +172,9 @@ cargo test -p kotoha-core --features llama-cpp-smoke --test kanji_llama_cpp_smok
 
 本 follow-up で残る作業 (別 ISSUE として起票予定):
 
-1. **row 3 の意図的 ignore / skip**: 14/15 を Phase 1 smoke の goal として宣言する場合、row 3 を `#[ignore]` 扱いにするか、fixture から `# KNOWN_PHASE3` コメントでマーキングするかを決定する。現状は「FAIL を test failure として残し、Phase 3 で修正する」方針としており、本 follow-up ブランチでは対処しない
-2. **ADR 0010 起票**: Phase 3 「Kotoha 専用 romaji-base モデル」の正式 ADR を別 PR で起票する
-3. **ROADMAP Phase 3 section 詳細化**: `docs/ROADMAP.md` の Phase 3 section に本 follow-up の decision (14/15 acceptance + Phase 3 根本解決) を反映する
-4. **README.md の Phase 1 known limitation 記載**: README の Phase 1 セクションに「row 3 は Phase 3 で解消予定」の注記を追加する
+1. **row 3 の意図的 ignore / skip**: 14/15 を Phase 1 smoke の goal として宣言する場合、row 3 を `#[ignore]` 扱いにするか、fixture から `# KNOWN_PHASE5` コメントでマーキングするかを決定する。現状は「FAIL を test failure として残し、Phase 5 で修正する」方針としており、本 follow-up ブランチでは対処しない
+2. **ADR 0010 起票**: Phase 5 「Kotoha custom romaji-base model」の正式 ADR を別 PR で起票する
+3. **ROADMAP Phase 5 section 詳細化**: `docs/ROADMAP.md` の Phase 5 section に本 follow-up の decision (14/15 acceptance + Phase 5 根本解決) を反映する
+4. **README.md の Phase 1 known limitation 記載**: README の Phase 1 セクションに「row 3 は Phase 5 で解消予定」の注記を追加する
 
 Phase 1 残マイルストーン: P1-3 (CLI `kotoha-kanji` + Layer 4 E2E smoke) → P1-4 (ADR 0009 / 0010 / 0011 正式起票 + Phase 1 acceptance checklist 消化 + implementation WBS final log)


### PR DESCRIPTION
## Summary

Phase 5 (Kotoha custom romaji-base model) の foundation docs を 3 文書まとめて追加する純粋なドキュメント PR。実装コード変更なし。

- **ADR 0010** (`docs/adr/0010-kotoha-custom-romaji-base-model.md`, 165 lines): Phase 5 として Kotoha 専用 romaji-base かな→漢字モデルを自作する決定。Context (Gemma ICL 限界 + Karukan 調査知見 + Karukan 前処理層起因の s/sh/si/backspace/typo 問題), Decision D1-D7 (romaji-base 入力境界 / 学習戦略 / special tokens / 外部 tokenizer / GGUF 量子化 / ROADMAP restructure), Consequences, Alternatives (A: jinen 流用, B: Gemma LoRA, C: Gemma-4-31B, D: custom model 回避) を記録。
- **ROADMAP.md restructure** (31 → 86 lines): Phase 一覧を 7 → 8 phase (0〜7) に拡張。新 Phase 5 = Kotoha custom romaji-base model を挿入、旧 Phase 5 (Advanced) → Phase 6、旧 Phase 6 (UX polish) → Phase 7 に後ろ倒し。Phase 5 の P5-A (data pipeline) / P5-B (training) / P5-C (integration) / P5-D (evaluation) マイルストーン stub を追加。
- **Phase 5 spec draft** (`docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md`, 348 lines): 設計書 stub。§1 背景と動機, §2 スコープ, §3 アーキテクチャ, §4 データ設計 (kana→kanji コーパス / romaji 拡張 / typo 注入 / special tokens / データ scale), §5 学習戦略 (B1 scratch / B2 LoRA / B3 distillation), §6 評価 (smoke / regression / typo robustness / partial-input / latency / model size), §7 非スコープ, §8 Open questions (Q1-Q6)。詳細パラメータは Phase 4 完了後の Phase 5 kick-off で確定、と明示。

## 背景 (why Phase 5)

Phase 1 P1-2.5 follow-up (PR #76) で row 3「あした → 明日」が v5–v12 の prompt 反復で解消せず、Gemma-2-2B-jpn-it 2.6B の ICL 限界と結論。同時に Karukan 調査で判明:

1. jinen-v1-small (90M GPT-2) は kana→kanji 専用 fine-tune で成功 — 学習分布内だから
2. Karukan は学習済み PUA special tokens + 外部 HuggingFace tokenizer で task-specific 構造をモデルに伝達
3. ただし Karukan も fcitx5 前処理層に s/sh/si/backspace/typo 問題を抱える

Phase 5 は romaji keystroke 境界で直接推論することで両問題を根本解決する。Phase 6 (旧 Phase 5, 内容はタイポ訂正 + 文脈リランキング) の技術基盤にもなる。

## ROADMAP restructure 影響

| 番号 | 旧内容 | 新内容 |
|---|---|---|
| Phase 5 | Advanced features (typo + 文脈) | **Kotoha custom romaji-base model (新設)** |
| Phase 6 | UX polish | Advanced features (typo + 文脈、Phase 5 技術依存) |
| Phase 7 | (なし) | UX polish |

Phase 3 (IBus) / Phase 4 (fcitx5) は位置保持。IME shipping の優先度を崩さない。

## PR #76 WBS の「Phase 3 への引き継ぎ」文言について

PR #76 merged の WBS (`docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md`) は「Phase 3 への引き継ぎ」と書かれているが、本 ADR 0010 で **Phase 5** に確定した。本 PR merge 後、 develop 側で follow-up commit を 1 つ入れて WBS の「Phase 3」参照を「Phase 5」に訂正予定 (本 PR のスコープ外とした)。

## Verification

- lefthook pre-commit (fmt, doc-naming check): PASS
- lefthook pre-push (fmt + clippy + build + test 160 件): PASS
- 実装コード未変更 (ファイル名規約: ADR は \`NNNN-title.md\`, spec は \`YYYY-MM-DD-<branch-name>.md\` に準拠)

## Test plan

- [x] ADR 0010 と Phase 5 spec と ROADMAP 間で用語統一 (Kotoha custom romaji-base model / Phase 5 / B1/B2/B3 / P5-A/B/C/D / `BackendConfig::KotohaNative`)
- [x] ADR 0010 が PR #76 の empirical basis (Gemma ICL 限界) と Karukan 調査を両方引用している
- [x] ROADMAP restructure が Phase 0/1/2/3/4 の既存 phase 設計を壊していない
- [x] Phase 5 spec が stub として明示され、詳細確定が Phase 5 kick-off まで deferral されている
- [ ] Reviewer: ADR 0010 の Decision と Alternatives が spec §3/§5 と矛盾していないか確認
- [ ] Reviewer: ROADMAP の Phase 6 (旧 Phase 5) 項目が Phase 5 技術依存として整合しているか確認

## References

- Parent milestone: Phase 1 (PR #74, PR #76, merge commits `02cf035` / `3eccaa1`)
- ISSUE: #77
- Empirical basis: \`docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md\`
- Karukan (参考実装): \`togatoga/karukan\` の \`jinen-v1-small\` (90M GPT-2 kana→kanji fine-tune)

🤖 Generated with [Claude Code](https://claude.com/claude-code)