### PR TITLE
feat(cli,smoke): P1-3 — kotoha-kanji CLI + phase1-smoke.sh (#81)

### DIFF
--- a/crates/kotoha-cli/Cargo.toml
+++ b/crates/kotoha-cli/Cargo.toml
@@ -12,9 +12,27 @@ description = "Kotoha: command-line frontend for manual verification of the Koto
 kotoha-core = { path = "../kotoha-core" }
 clap = { workspace = true }
 
+[features]
+# Default feature set is empty so `cargo build -p kotoha-cli` remains fast
+# and does not trigger the llama.cpp C++ build. P1-3 adds an opt-in
+# `llama-cpp` feature that propagates to `kotoha-core/llama-cpp`, enabling
+# the `kotoha-kanji` binary to consume the Layer 3 backend.
+default = []
+llama-cpp = ["kotoha-core/llama-cpp"]
+
 [[bin]]
 name = "kotoha-romaji"
 path = "src/bin/romaji.rs"
 
-# src/lib.rs は process_line / format_line_output を unit-testable に切り出すために存在する。
-# binary 側は `use kotoha_cli::process_line;` 等でライブラリ層を参照する。
+# `kotoha-kanji` is gated on the `llama-cpp` feature so default builds
+# (including `cargo build --workspace` without features) do not attempt to
+# compile the llama.cpp C++ sources. Enable with
+# `cargo build -p kotoha-cli --bin kotoha-kanji --features llama-cpp`.
+[[bin]]
+name = "kotoha-kanji"
+path = "src/bin/kanji.rs"
+required-features = ["llama-cpp"]
+
+# src/lib.rs は process_line / format_line_output (Phase 0 romaji 用) と
+# kanji_cli module (P1-3 の kotoha-kanji 用 pure helper) を unit-testable
+# に切り出すために存在する。binary 側は `use kotoha_cli::...` で参照する。

--- a/crates/kotoha-cli/src/bin/kanji.rs
+++ b/crates/kotoha-cli/src/bin/kanji.rs
@@ -1,0 +1,128 @@
+//! `kotoha-kanji` — Phase 1 Layer 3 kanji-conversion CLI.
+//!
+//! Reads hiragana lines from stdin, feeds each line through a
+//! [`kotoha_core::kanji::KanjiBackend`] backed by llama.cpp loading a
+//! Gemma-2-2B-jpn-it (or Qwen2-Instruct) GGUF file, and emits the
+//! top-k kanji candidates to stdout — one surface per line, terminated
+//! with LF. An empty input line produces an empty line on stdout so
+//! that stdin/stdout line alignment is preserved.
+//!
+//! The pure parsing / formatting logic lives in
+//! [`kotoha_cli::kanji_cli`]; this binary is intentionally thin.
+//!
+//! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md`
+//! §8.3 (feature-gated smoke policy), §9.2 (CLI behavior), §14
+//! (input/output contract).
+
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use kotoha_cli::kanji_cli::{
+    build_options, format_candidates, parse_prompt_template, resolve_model_path, KanjiCliArgs,
+};
+use kotoha_core::kanji::{load_backend, BackendConfig};
+
+/// Phase 1 CLI for kana→kanji conversion via the llama.cpp backend.
+#[derive(Debug, Parser)]
+#[command(
+    name = "kotoha-kanji",
+    version,
+    about = "Phase 1 CLI for Kotoha's Layer 3 kana→kanji conversion (llama.cpp backend)"
+)]
+struct Cli {
+    /// Absolute path to a Gemma-2-2B-jpn-it (Q5_K_M recommended) or
+    /// Qwen2-Instruct GGUF file. Takes precedence over
+    /// `KOTOHA_LLAMA_MODEL_PATH`.
+    #[arg(long)]
+    model_path: Option<PathBuf>,
+
+    /// Prompt-template tag: `"gemma2-instruct-chat"` (default) or `"qwen2-chat"`.
+    #[arg(long, default_value = "gemma2-instruct-chat")]
+    prompt_template: String,
+
+    /// Maximum number of candidates to emit per input line.
+    #[arg(long, default_value_t = 1)]
+    top_k: usize,
+
+    /// Sampling temperature (`0.0` = greedy decoding).
+    #[arg(long, default_value_t = 0.0)]
+    temperature: f32,
+
+    /// RNG seed for reproducible sampling.
+    #[arg(long, default_value_t = 0)]
+    seed: u64,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(msg) => {
+            eprintln!("kotoha-kanji: {msg}");
+            // Exit code 2 is reserved by convention for usage / configuration
+            // errors (matches clap's own parse-error exit code). Runtime I/O
+            // and inference failures also route here in Phase 1 because the
+            // CLI is used only for manual verification and smoke scripts;
+            // spec §14 does not distinguish sub-exit-codes at this stage.
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Glue that wires `clap` output to the backend and stdin/stdout loop.
+///
+/// All string-level parsing lives in [`kotoha_cli::kanji_cli`]; this
+/// function only composes those helpers with the runtime `env::var`
+/// lookup and the actual `load_backend` call.
+fn run(cli: Cli) -> Result<(), String> {
+    let model_path = resolve_model_path(cli.model_path, || {
+        std::env::var("KOTOHA_LLAMA_MODEL_PATH").ok()
+    })?;
+    let prompt_template = parse_prompt_template(&cli.prompt_template)?;
+
+    let args = KanjiCliArgs {
+        model_path: model_path.clone(),
+        prompt_template: prompt_template.clone(),
+        top_k: cli.top_k,
+        temperature: cli.temperature,
+        seed: cli.seed,
+    };
+    let options = build_options(&args);
+
+    let backend = load_backend(&BackendConfig::LlamaCpp {
+        model_path,
+        prompt_template,
+    })
+    .map_err(|e| format!("backend load failed: {e}"))?;
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    for line_result in stdin.lock().lines() {
+        let line = line_result.map_err(|e| format!("failed to read from stdin: {e}"))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            // Preserve stdin/stdout line alignment: an empty input line
+            // yields a single empty stdout line.
+            writeln!(out).map_err(|e| format!("failed to write to stdout: {e}"))?;
+            continue;
+        }
+        let candidates = backend
+            .convert(trimmed, &options)
+            .map_err(|e| format!("convert failed for input {trimmed:?}: {e}"))?;
+        let formatted = format_candidates(&candidates);
+        if formatted.is_empty() {
+            // Backend returned zero candidates (top_k == 0, or model
+            // chose to emit nothing). Still emit an empty line so the
+            // caller can line-align input and output.
+            writeln!(out).map_err(|e| format!("failed to write to stdout: {e}"))?;
+        } else {
+            write!(out, "{formatted}").map_err(|e| format!("failed to write to stdout: {e}"))?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/kotoha-cli/src/kanji_cli.rs
+++ b/crates/kotoha-cli/src/kanji_cli.rs
@@ -1,0 +1,314 @@
+//! Pure helpers for the `kotoha-kanji` CLI binary.
+//!
+//! This module keeps the CLI binary (`src/bin/kanji.rs`) thin: the
+//! binary performs only `clap` parsing, stdin/stdout I/O, and backend
+//! construction. All string-level parsing and formatting logic lives
+//! here so that it can be exercised by unit tests without spawning a
+//! subprocess or loading a GGUF.
+//!
+//! # Responsibilities
+//!
+//! - Resolve the model path from either the `--model-path` CLI flag or
+//!   the `KOTOHA_LLAMA_MODEL_PATH` environment variable.
+//! - Parse the `--prompt-template` tag into a
+//!   [`kotoha_core::kanji::PromptTemplate`] variant. Only
+//!   `gemma2-instruct-chat` and `qwen2-chat` are accepted;
+//!   [`PromptTemplate::Custom`](kotoha_core::kanji::PromptTemplate::Custom)
+//!   stays programmatic-only per the P1-3 design decision.
+//! - Build a [`kotoha_core::kanji::ConvertOptions`] from the parsed CLI
+//!   arguments.
+//! - Format a candidate slice into stdout-ready text (one surface per
+//!   line, terminated with a newline).
+//!
+//! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md`
+//! §9.2 (CLI binary behavior) and §14 (input/output contract).
+
+use std::path::PathBuf;
+
+use kotoha_core::kanji::{Candidate, ConvertOptions, PromptTemplate};
+
+/// Parsed `kotoha-kanji` CLI arguments after `clap` conversion.
+///
+/// This struct exists so `build_options` and the binary's `run` glue
+/// can share one typed representation. `clap` constructs its own
+/// `#[derive(Parser)]` type in the binary; that type is converted into
+/// `KanjiCliArgs` exactly once at startup.
+///
+/// # Invariants
+///
+/// - `top_k >= 0` (guaranteed by `usize`).
+/// - `temperature >= 0.0` is recommended but NOT enforced here; the
+///   backend enforces its own domain constraint.
+///
+/// # Trait derivations
+///
+/// `PartialEq` is intentionally omitted because
+/// [`kotoha_core::kanji::PromptTemplate`] is `#[non_exhaustive]` and
+/// does not derive it. Unit tests that need field-level equality
+/// inspect individual fields instead.
+#[derive(Debug, Clone)]
+pub struct KanjiCliArgs {
+    /// Absolute path to a Gemma-2-2B-jpn-it (or Qwen2-Instruct) GGUF file.
+    pub model_path: PathBuf,
+    /// Prompt template variant selected via the CLI tag (no `Custom`).
+    pub prompt_template: PromptTemplate,
+    /// Number of candidates to emit per input line. `0` yields no output lines.
+    pub top_k: usize,
+    /// Sampling temperature. `0.0` selects greedy decoding.
+    pub temperature: f32,
+    /// RNG seed for reproducible sampling.
+    pub seed: u64,
+}
+
+/// Resolves the model path from either the `--model-path` CLI flag or
+/// the `KOTOHA_LLAMA_MODEL_PATH` environment variable.
+///
+/// The `env_getter` parameter is injected as a closure so unit tests
+/// can exercise the resolution logic without mutating process-wide
+/// environment variables. The binary passes
+/// `|| std::env::var("KOTOHA_LLAMA_MODEL_PATH").ok()` at runtime.
+///
+/// # Preconditions
+///
+/// None.
+///
+/// # Postconditions
+///
+/// - Returns `Ok(path)` if `cli_flag` is `Some(path)` (flag takes precedence).
+/// - Returns `Ok(PathBuf::from(v))` if `cli_flag` is `None` and
+///   `env_getter()` returns `Some(v)` with `v` non-empty after trim.
+/// - Returns `Err(_)` with a clear English message if both are absent
+///   or the environment value is empty.
+///
+/// # Errors
+///
+/// Returns `Err` when neither the flag nor the environment variable
+/// provides a usable path.
+pub fn resolve_model_path(
+    cli_flag: Option<PathBuf>,
+    env_getter: impl FnOnce() -> Option<String>,
+) -> Result<PathBuf, String> {
+    if let Some(path) = cli_flag {
+        return Ok(path);
+    }
+    match env_getter() {
+        Some(v) if !v.trim().is_empty() => Ok(PathBuf::from(v)),
+        _ => Err(
+            "--model-path not provided and KOTOHA_LLAMA_MODEL_PATH is unset or empty".to_string(),
+        ),
+    }
+}
+
+/// Parses a prompt-template tag string into a
+/// [`PromptTemplate`] variant.
+///
+/// Accepted tags:
+///
+/// - `"gemma2-instruct-chat"` → [`PromptTemplate::Gemma2InstructChat`]
+/// - `"qwen2-chat"`           → [`PromptTemplate::Qwen2Chat`]
+///
+/// [`PromptTemplate::Custom`] is intentionally not exposed through the
+/// CLI surface: hand-authored templates require a three-field structure
+/// (`system`, `user_wrapper`, `assistant_prefix`) that does not map
+/// cleanly to a single `--prompt-template` flag, and the Phase 1
+/// built-in tokenizers cover the two shipped models.
+///
+/// # Preconditions
+///
+/// None.
+///
+/// # Postconditions
+///
+/// - Returns `Ok(PromptTemplate::Gemma2InstructChat)` for the Gemma tag.
+/// - Returns `Ok(PromptTemplate::Qwen2Chat)` for the Qwen tag.
+/// - Returns `Err(_)` with an English message listing the accepted tags
+///   for any other input.
+///
+/// # Errors
+///
+/// Returns `Err` for unknown tags.
+pub fn parse_prompt_template(tag: &str) -> Result<PromptTemplate, String> {
+    match tag {
+        "gemma2-instruct-chat" => Ok(PromptTemplate::Gemma2InstructChat),
+        "qwen2-chat" => Ok(PromptTemplate::Qwen2Chat),
+        other => Err(format!(
+            "unknown --prompt-template tag {other:?}; accepted values are \"gemma2-instruct-chat\" or \"qwen2-chat\""
+        )),
+    }
+}
+
+/// Formats a candidate slice into stdout-ready text.
+///
+/// Each candidate's `surface` is emitted on its own line (LF terminator).
+/// An empty input slice produces an empty string — the caller may choose
+/// to still emit a separator newline to preserve stdin/stdout line
+/// alignment, but this helper does NOT add one.
+///
+/// # Preconditions
+///
+/// None.
+///
+/// # Postconditions
+///
+/// - Returns `""` for an empty slice.
+/// - Returns `"<surface>\n"` for a single candidate.
+/// - Returns `"<s0>\n<s1>\n...\n<sN-1>\n"` for N candidates, preserving
+///   the input order (the caller is responsible for sorting by score).
+///
+/// # Examples
+///
+/// ```
+/// use kotoha_cli::kanji_cli::format_candidates;
+/// use kotoha_core::kanji::Candidate;
+///
+/// let out = format_candidates(&[Candidate::new("日本語", 0.9)]);
+/// assert_eq!(out, "日本語\n");
+/// ```
+pub fn format_candidates(candidates: &[Candidate]) -> String {
+    let mut out = String::new();
+    for c in candidates {
+        out.push_str(&c.surface);
+        out.push('\n');
+    }
+    out
+}
+
+/// Constructs [`ConvertOptions`] from parsed CLI arguments.
+///
+/// Builds the options via `Default` + field mutation so the callsite
+/// survives future `#[non_exhaustive]` additions to `ConvertOptions`
+/// (spec §5.2 / ADR 0006). This matches the pattern used by
+/// `crates/kotoha-core/tests/kanji_llama_cpp_smoke.rs`.
+///
+/// # Preconditions
+///
+/// None.
+///
+/// # Postconditions
+///
+/// - The returned `ConvertOptions` has `top_k == args.top_k`,
+///   `temperature == args.temperature`, and `seed == Some(args.seed)`.
+#[allow(clippy::field_reassign_with_default)]
+pub fn build_options(args: &KanjiCliArgs) -> ConvertOptions {
+    let mut opt = ConvertOptions::default();
+    opt.top_k = args.top_k;
+    opt.temperature = args.temperature;
+    opt.seed = Some(args.seed);
+    opt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ======================================================================
+    // resolve_model_path
+    // ======================================================================
+
+    #[test]
+    fn resolve_model_path_prefers_cli_flag_over_env() {
+        let cli = Some(PathBuf::from("/flag/model.gguf"));
+        let got = resolve_model_path(cli, || Some("/env/model.gguf".to_string()))
+            .expect("flag path must resolve");
+        assert_eq!(got, PathBuf::from("/flag/model.gguf"));
+    }
+
+    #[test]
+    fn resolve_model_path_falls_back_to_env_when_flag_absent() {
+        let got = resolve_model_path(None, || Some("/env/model.gguf".to_string()))
+            .expect("env path must resolve when flag is None");
+        assert_eq!(got, PathBuf::from("/env/model.gguf"));
+    }
+
+    #[test]
+    fn resolve_model_path_errors_when_both_absent() {
+        let err = resolve_model_path(None, || None).expect_err("both absent must error");
+        assert!(
+            err.contains("KOTOHA_LLAMA_MODEL_PATH"),
+            "error must mention the env var name: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_model_path_errors_when_env_is_empty_string() {
+        // An exported-but-empty env var must be treated as "unset" so that
+        // operators who accidentally run `export KOTOHA_LLAMA_MODEL_PATH=`
+        // get a clear diagnostic instead of a "file not found" deep inside
+        // the backend loader.
+        let err =
+            resolve_model_path(None, || Some("   ".to_string())).expect_err("empty env must error");
+        assert!(err.contains("KOTOHA_LLAMA_MODEL_PATH"));
+    }
+
+    // ======================================================================
+    // parse_prompt_template
+    // ======================================================================
+
+    #[test]
+    fn parse_prompt_template_accepts_gemma2_tag() {
+        let t = parse_prompt_template("gemma2-instruct-chat").expect("gemma2 tag must be accepted");
+        assert!(matches!(t, PromptTemplate::Gemma2InstructChat));
+    }
+
+    #[test]
+    fn parse_prompt_template_accepts_qwen2_tag() {
+        let t = parse_prompt_template("qwen2-chat").expect("qwen2 tag must be accepted");
+        assert!(matches!(t, PromptTemplate::Qwen2Chat));
+    }
+
+    #[test]
+    fn parse_prompt_template_rejects_unknown_tag() {
+        let err = parse_prompt_template("phi4-instruct").expect_err("unknown tag must error");
+        assert!(
+            err.contains("gemma2-instruct-chat") && err.contains("qwen2-chat"),
+            "error must list both accepted tags: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_prompt_template_rejects_empty_tag() {
+        let err = parse_prompt_template("").expect_err("empty tag must error");
+        assert!(err.contains("gemma2-instruct-chat"));
+    }
+
+    // ======================================================================
+    // format_candidates
+    // ======================================================================
+
+    #[test]
+    fn format_candidates_empty_slice_returns_empty_string() {
+        assert_eq!(format_candidates(&[]), "");
+    }
+
+    #[test]
+    fn format_candidates_single_candidate_one_line() {
+        let out = format_candidates(&[Candidate::new("日本語", 0.9)]);
+        assert_eq!(out, "日本語\n");
+    }
+
+    #[test]
+    fn format_candidates_preserves_input_order() {
+        let out =
+            format_candidates(&[Candidate::new("日本語", 0.9), Candidate::new("二本後", 0.3)]);
+        assert_eq!(out, "日本語\n二本後\n");
+    }
+
+    // ======================================================================
+    // build_options
+    // ======================================================================
+
+    #[test]
+    fn build_options_round_trips_cli_values() {
+        let args = KanjiCliArgs {
+            model_path: PathBuf::from("/tmp/model.gguf"),
+            prompt_template: PromptTemplate::Gemma2InstructChat,
+            top_k: 3,
+            temperature: 0.7,
+            seed: 42,
+        };
+        let opt = build_options(&args);
+        assert_eq!(opt.top_k, 3);
+        assert!((opt.temperature - 0.7).abs() < 1e-6);
+        assert_eq!(opt.seed, Some(42));
+    }
+}

--- a/crates/kotoha-cli/src/kanji_cli.rs
+++ b/crates/kotoha-cli/src/kanji_cli.rs
@@ -75,8 +75,10 @@ pub struct KanjiCliArgs {
 /// # Postconditions
 ///
 /// - Returns `Ok(path)` if `cli_flag` is `Some(path)` (flag takes precedence).
-/// - Returns `Ok(PathBuf::from(v))` if `cli_flag` is `None` and
-///   `env_getter()` returns `Some(v)` with `v` non-empty after trim.
+/// - Returns `Ok(PathBuf::from(v.trim()))` if `cli_flag` is `None` and
+///   `env_getter()` returns `Some(v)` with `v` non-empty after trim
+///   (leading and trailing ASCII whitespace is trimmed before the
+///   `PathBuf` is constructed).
 /// - Returns `Err(_)` with a clear English message if both are absent
 ///   or the environment value is empty.
 ///
@@ -92,7 +94,7 @@ pub fn resolve_model_path(
         return Ok(path);
     }
     match env_getter() {
-        Some(v) if !v.trim().is_empty() => Ok(PathBuf::from(v)),
+        Some(v) if !v.trim().is_empty() => Ok(PathBuf::from(v.trim())),
         _ => Err(
             "--model-path not provided and KOTOHA_LLAMA_MODEL_PATH is unset or empty".to_string(),
         ),
@@ -188,6 +190,9 @@ pub fn format_candidates(candidates: &[Candidate]) -> String {
 ///
 /// - The returned `ConvertOptions` has `top_k == args.top_k`,
 ///   `temperature == args.temperature`, and `seed == Some(args.seed)`.
+// `ConvertOptions` is `#[non_exhaustive]`, so struct update syntax
+// (`..Default::default()`) is unavailable outside its defining crate.
+// We build via `Default::default()` and field mutation instead.
 #[allow(clippy::field_reassign_with_default)]
 pub fn build_options(args: &KanjiCliArgs) -> ConvertOptions {
     let mut opt = ConvertOptions::default();

--- a/crates/kotoha-cli/src/lib.rs
+++ b/crates/kotoha-cli/src/lib.rs
@@ -11,6 +11,12 @@
 //! - [`kanji_cli`] — Phase 1 kanji (`src/bin/kanji.rs`, gated on the
 //!   `llama-cpp` feature).
 //!
+//! The `kanji_cli` submodule is always compiled (no feature gate at the
+//! module level). The `[[bin]] kotoha-kanji` binary is gated with
+//! `required-features = ["llama-cpp"]` in `Cargo.toml`, so only the
+//! binary itself is opt-in; the pure helpers in `kanji_cli` remain
+//! available for unit testing regardless of feature selection.
+//!
 //! # Behavior pins (see plan M6 §『本 M6 plan 内で解決する既知の懸念』)
 //!
 //! - [`InputStep::Preedit`] is dropped silently (Phase 0 CLI is not a

--- a/crates/kotoha-cli/src/lib.rs
+++ b/crates/kotoha-cli/src/lib.rs
@@ -1,10 +1,15 @@
-//! Line-based helpers for the `kotoha-romaji` CLI binary.
+//! Line-based helpers for the Kotoha CLI binaries.
 //!
-//! This crate exposes two pure functions ([`process_line`] and
-//! [`format_line_output`]) that the binary entry point
-//! (`src/bin/romaji.rs`) calls. Keeping the logic pure keeps the
-//! binary thin and the behavior covered by unit tests without spawning
-//! a subprocess.
+//! This crate exposes pure functions that the binary entry points call
+//! so that the binaries themselves stay thin and the behavior is
+//! covered by unit tests without spawning a subprocess.
+//!
+//! # Module surface
+//!
+//! - [`process_line`] / [`format_line_output`] — Phase 0 romaji
+//!   (`src/bin/romaji.rs`).
+//! - [`kanji_cli`] — Phase 1 kanji (`src/bin/kanji.rs`, gated on the
+//!   `llama-cpp` feature).
 //!
 //! # Behavior pins (see plan M6 §『本 M6 plan 内で解決する既知の懸念』)
 //!
@@ -15,6 +20,8 @@
 //! - `--show-mode` suffix uses `[H]` for [`InputMode::Hiragana`] and
 //!   `[D]` for [`InputMode::Direct`] with no Transient / Sticky
 //!   distinction (`ModeOrigin` is `pub(crate)`).
+
+pub mod kanji_cli;
 
 use kotoha_core::{InputContext, InputMode, InputStep};
 

--- a/scripts/phase1-smoke.sh
+++ b/scripts/phase1-smoke.sh
@@ -70,4 +70,5 @@ while IFS=$'\t' read -r hiragana expected; do
   assert_contains "$row_num. $hiragana → contains '$expected'" "$actual" "$expected"
 done <"$FIXTURE"
 
+# fixture 15 rows, row 3 skipped = 14 assertions expected.
 assert_summary "phase1-smoke"

--- a/scripts/phase1-smoke.sh
+++ b/scripts/phase1-smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Phase 1 smoke test — runs the Layer 3 fixture rows against the
+# `kotoha-kanji` CLI binary (llama.cpp backend with Gemma-2-2B-jpn-it).
+#
+# Usage:
+#   scripts/phase1-smoke.sh
+#
+# Environment:
+#   KOTOHA_LLAMA_MODEL_PATH (required)
+#     Absolute path to a Gemma-2-2B-jpn-it Q5_K_M GGUF file.
+#     If unset, this script prints SKIPPED and exits 0 (Phase 1
+#     spec §8.3 opt-in policy, matches kanji_llama_cpp_smoke.rs).
+#
+# Exit codes:
+#   0   — all 14 assertions PASS (or SKIPPED)
+#   1   — at least one assertion FAILED
+#
+# Known limitation: row 3 (あした → 明日) is intentionally skipped.
+# Gemma-2-2B-jpn-it emits 翌日 for this input across v5–v12 prompt
+# iterations (see PR #76 WBS, ADR 0010). Root resolution is deferred
+# to Phase 5 (custom romaji-base model).
+#
+# References:
+#   - Fixture: crates/kotoha-core/tests/fixtures/kanji_smoke.tsv
+#   - Integration test: crates/kotoha-core/tests/kanji_llama_cpp_smoke.rs
+#   - ADR: docs/adr/0010-kotoha-custom-romaji-base-model.md (Phase 5 deferral)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+
+cd "$REPO_ROOT"
+
+if [[ -z "${KOTOHA_LLAMA_MODEL_PATH:-}" ]]; then
+  echo "SKIPPED: KOTOHA_LLAMA_MODEL_PATH not set"
+  exit 0
+fi
+
+if [[ ! -f "$KOTOHA_LLAMA_MODEL_PATH" ]]; then
+  echo "FAIL: KOTOHA_LLAMA_MODEL_PATH file does not exist: $KOTOHA_LLAMA_MODEL_PATH" >&2
+  exit 1
+fi
+
+echo "=== phase1-smoke: pre-building kotoha-kanji (debug, llama-cpp feature) ==="
+cargo build -p kotoha-cli --bin kotoha-kanji --features llama-cpp --quiet
+
+FIXTURE="$REPO_ROOT/crates/kotoha-core/tests/fixtures/kanji_smoke.tsv"
+if [[ ! -f "$FIXTURE" ]]; then
+  echo "FAIL: fixture not found: $FIXTURE" >&2
+  exit 1
+fi
+
+RUN=(cargo run --quiet -p kotoha-cli --bin kotoha-kanji --features llama-cpp --)
+
+echo "=== phase1-smoke: running fixture (row 3 あした SKIPPED per ADR 0010) ==="
+
+# Row number is 1-indexed, matching fixture row order and the
+# integration test function naming (llama_cpp_smoke_N_*).
+row_num=0
+while IFS=$'\t' read -r hiragana expected; do
+  row_num=$((row_num + 1))
+  if [[ "$row_num" -eq 3 ]]; then
+    echo "SKIP  $row_num. $hiragana → $expected (known limitation, Phase 5 deferral)"
+    continue
+  fi
+  actual=$(printf '%s\n' "$hiragana" | "${RUN[@]}")
+  assert_contains "$row_num. $hiragana → contains '$expected'" "$actual" "$expected"
+done <"$FIXTURE"
+
+assert_summary "phase1-smoke"


### PR DESCRIPTION
## Summary

Phase 1 残マイルストーン P1-3 を実装。Phase 1 正式 close の前提が整う。

- **\`kotoha-kanji\` CLI binary** を新規追加 (\`crates/kotoha-cli/src/bin/kanji.rs\` 128 行)
- lib module \`kotoha_cli::kanji_cli\` (314 行) で parse / format を切出し、unit test 12 件追加
- \`kotoha-cli\` に feature \`llama-cpp\` 新設、\`kotoha-core/llama-cpp\` に propagate
- \`[[bin]] kotoha-kanji\` に \`required-features = [\"llama-cpp\"]\` を設定 (default build では compile されない)
- **\`scripts/phase1-smoke.sh\`** (73 行) を \`scripts/lib/assert.sh\` 使用で新規作成。env 未設定で SKIPPED / 設定時は fixture 14 行検査 (row 3 \`あした → 明日\` は ADR 0010 Phase 5 deferral として意図的 skip)

## Design decisions

- **Feature-gated binary**: \`required-features = [\"llama-cpp\"]\` により default builds が軽量維持、llama-cpp feature のみで kotoha-kanji が compile 対象に
- **Logic 分離**: I/O 層 (\`bin/kanji.rs\`) は薄く、純粋 logic (\`kanji_cli.rs\`) は unit test 可能に切出し
- **Model path 解決**: \`--model-path\` flag → \`KOTOHA_LLAMA_MODEL_PATH\` env → error (exit 2)
- **Prompt template 露出**: CLI 表面は tag-based (\`gemma2-instruct-chat\` / \`qwen2-chat\`)、\`PromptTemplate::Custom\` は programmatic のみ
- **row 3 skip**: Phase 5 deferral 既知制約として smoke の summary は 14/14 PASS (skip は別行で可視化)

## Verification (pre-push PASS)

- cargo fmt --all -- --check: clean
- cargo clippy --workspace --all-targets --all-features -- -D warnings: clean
- cargo build --workspace (default features): clean
- cargo test --workspace: **175 tests PASS** (kotoha-cli: 9 → 21, +12 kanji_cli unit tests)
- cargo build --workspace --features kotoha-core/llama-cpp: clean
- cargo build --workspace --features kotoha-core/llama-cpp-smoke --tests: clean
- cargo build -p kotoha-cli --bin kotoha-kanji --features llama-cpp: clean
- shfmt -d -i 2 -ci scripts/phase1-smoke.sh: clean
- shellcheck (with \`# shellcheck source=lib/assert.sh\` directive): clean (repo-root run は SC1091 info、既存 phase0-smoke と同挙動)
- bash scripts/phase1-smoke.sh (env 未設定): \`SKIPPED: KOTOHA_LLAMA_MODEL_PATH not set\` + exit 0

## Known item (not blocking, documented)

\`KanjiCliArgs\` は \`PartialEq\` derive を削除。\`PromptTemplate\` が現在 \`PartialEq\` を derive していないため compile error 回避。必要なら \`PromptTemplate\` に \`PartialEq\` を追加する別 PR で復元可能。

## Test plan

- [x] fmt / clippy / build / test all PASS
- [x] default features で kotoha-kanji binary が compile されないこと
- [x] llama-cpp feature で kotoha-kanji binary が compile されること
- [x] unit tests (model-path resolution / prompt-template parse / candidate format / build_options) が 12 件 PASS
- [x] smoke script が env 未設定で SKIPPED + exit 0
- [x] shellcheck / shfmt 遵守 (lang-shell.md)
- [ ] Reviewer: kanji_cli.rs の契約記述 (rustdoc) が lang-rust.md 準拠か
- [ ] Reviewer: row 3 skip の smoke semantics が ADR 0010 / spec §8.3 と整合か

## References

- Parent milestone: Phase 1, after P1-2.5 (PR #74, #76)
- ISSUE: #81
- Plan reference: docs/superpowers/plans/2026-04-24-kotoha-phase-1-p1-2-5.md line 15 「後続 milestone: P1-3」
- Spec: docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md §8.3 / §9.2 / §14
- ADR 0010 (Phase 5 deferral for row 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)