### PR TITLE
docs(phase-2): Foundation — ADR 0014 + Phase 2 spec draft + ROADMAP P2-A〜D (#85)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,7 @@ ADR 0010 (`docs/adr/0010-kotoha-custom-romaji-base-model.md`) の決定により
 |---|---|---|---|
 | 0 | Foundation | Cargo workspace + ローマ字→かな変換 + 入力モード管理 + CLI | 完了 |
 | 1 | Kana→Kanji conversion | llama.cpp + Gemma-2-2B-jpn-it baseline によるかな→漢字変換 (P1-2.5 follow-up で Layer 3 smoke 14/15 達成) | 完了 (14/15 PASS, P1-4 で close 2026-04-25) |
-| 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ | 未着手 |
+| 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ | **進行中 (foundation docs 完了)** |
 | 3 | IBus integration | IBus engine(GNOME Mutter 用) | 未着手 |
 | 4 | fcitx5 integration | fcitx5 addon(KDE / wlroots 用) | 未着手 |
 | 5 | **Kotoha custom romaji-base model** | raw romaji keystrokes を直接受理する Kotoha 専用 90〜180M parameter モデルの自作 (data pipeline + training + GGUF 推論統合 + evaluation)。row 3 類の ICL 限界 + typo robustness + partial-input 対応を同時解決する | 未着手 |
@@ -32,6 +32,37 @@ Phase 0 完了時に Phase 1 へ引き継ぐ設計判断事項を記録する。
 Phase 1 P1-2.5 follow-up (PR #76 / ISSUE #75 / merge commit `3eccaa1`) で、Gemma-2-2B-jpn-it Q5_K_M の Layer 3 smoke fixture 15 行のうち 14 行を PASS、1 行 (row 3「あした → 明日」) のみ FAIL (「翌日」出力) で close した。row 3 の FAIL は v5〜v12 の 8 世代 prompt iteration で解消不能であり、Gemma-2-2B-jpn-it の 2B parameter instruction-tuning における in-context learning (ICL) 限界として Phase 1 は 14/15 を受容した。根本解消は Phase 5「Kotoha custom romaji-base model」で task-specific fine-tune モデルにより達成する方針を ADR 0010 に記録した。Phase 2 (Dictionary and learning) 着手時には、Gemma baseline 14/15 を前提として Dictionary / 学習キャッシュ設計を進める。
 
 P1-4 (PR: 本 ISSUE #83) で ADR 0009 を正式化 (rename + Status: Accepted)、ADR 0011 (backend trait design) / ADR 0012 (feature flag design) / ADR 0013 (latency target relaxation) を新規起票、spec §14.1 で Phase 1 完了宣言を記録した。Phase 2 (Dictionary and learning) 着手時には、Gemma-2-2B-jpn-it 14/15 baseline + Backend trait の既存拡張点を前提として、辞書検索 + 学習キャッシュを追加する BackendConfig variant を設計する。
+
+P1-4 (PR #84, merge `95e7df9`) での Phase 1 close 後、Phase 2 foundation docs (本 ISSUE #85) を整備した。ADR 0014 (dictionary layer architecture) と Phase 2 spec draft を起票し、P2-A kick-off で SudachiDict-core を実装対象として確定する。Phase 5 (ADR 0010 custom model) は Phase 2 の dictionary / learning cache / BackendConfig 拡張を継承して自作モデルに置換する予定 (Phase 5 spec §3.3 との整合を Phase 2 spec §9 Open Q6 で明示)。
+
+## Phase 2 マイルストーン分割
+
+Phase 2「Dictionary and learning」は 4 milestone に分割する。詳細は `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` および ADR 0014 を参照。各 milestone の exact スコープは P2-A kick-off で確定する。
+
+### P2-A: Dictionary layer (工数目安 1〜2 週)
+
+- SudachiDict-core を runtime load する DictionaryBackend 実装
+- Kotoha 独自語彙 (敬称、IME 固有) の merge
+- Dictionary lookup の unit test / golden fixture (敬称 / 固有名詞 30+ cases)
+- BackendConfig 新 variant 追加 (ADR 0011 の non_exhaustive 拡張方針)
+
+### P2-B: User dictionary (工数目安 3〜5 日)
+
+- User dict entry 追加 / 削除 / 列挙の API
+- TOML or JSONL persistence
+- CLI サブコマンド (kotoha-dict add / remove / list) の draft
+
+### P2-C: Learning cache (工数目安 3〜5 日)
+
+- in-memory LRU + 起動時 load + shutdown save
+- data model: (kana_input, chosen_kanji, frequency, last_used_at)
+- eviction policy
+
+### P2-D: Integration + rerank (工数目安 1〜2 週)
+
+- hybrid backend (dict + LLM) の factory 実装
+- 候補 merge / dedupe / rerank (初期重み dict=0.95 / LLM=1.0)
+- regression test: Phase 1 14/15 が保たれること
 
 ## Phase 5 マイルストーン分割
 

--- a/docs/adr/0014-phase-2-dictionary-layer-architecture.md
+++ b/docs/adr/0014-phase-2-dictionary-layer-architecture.md
@@ -1,0 +1,138 @@
+# ADR 0014 — Phase 2 dictionary layer architecture (Sudachi-based hybrid)
+
+- **Status**: Accepted (2026-04-25、方針として承認。詳細パラメータは P2-A kick-off 時に確定)
+- **Date**: 2026-04-25
+- **Deciders**: Kotoha Phase 2 maintainers
+- **Related ISSUE**: #85 (Phase 2 foundation docs)
+- **Related PRs**: #74 (P1-2.5 refactor, Backend trait 最終形)、#76 (P1-2.5 follow-up, 14/15 baseline)、#82 (P1-3 CLI)、#84 (P1-4 Phase 1 close)
+
+## Context
+
+Kotoha Phase 1 は P1-4 (PR #84, merge `95e7df9`) で close した。Phase 1 の結論として以下 4 点が確定している。
+
+### C1. Phase 1 14/15 baseline の残存 row 3 問題
+
+Phase 1 P1-2.5 follow-up (PR #76, merge `3eccaa1`) は Gemma-2-2B-jpn-it Q5_K_M をバックエンドに Layer 3 smoke fixture 15 行を empirical 実測し、`14/15 PASS` を達成した。唯一 FAIL した row 3「あした → 明日」は v5〜v12 の 8 世代 prompt iteration で解消不能と確定し、Phase 1 では Gemma-2-2B-jpn-it の ICL (In-context learning) 限界として受容した。Phase 5 (ADR 0010, Kotoha custom romaji-base model) で task-specific fine-tune により根本解消する方針が確定している。
+
+### C2. Phase 5 完成までの 3〜6 ヶ月の品質底上げ需要
+
+Phase 5 は data pipeline + training + evaluation で 3〜6 ヶ月の工数を見込む (ADR 0010 負の帰結)。Phase 5 完成を待つ間、Phase 3 IBus 統合 / Phase 4 fcitx5 統合 (Gemma baseline を推論器とした IME shipping) が進行する。IME として shipping する以上、row 3 類の synonym bias 以外にも、敬称 (「たなか さん」→「田中 さん」) や固有名詞 (人名 / 地名 / 組織名) の誤変換が顕在化する。これらは Gemma-2-2B-jpn-it の ICL だけでは補い切れず、Phase 5 完成を待たず Phase 2 で辞書補完層を提供する意義がある。
+
+### C3. 固有名詞と敬称の dictionary 補完価値
+
+固有名詞 (「鈴木」「山田」「新宿」) と敬称 (「さん」「様」「殿」) は、LLM の synonym bias よりも「学習分布内に存在するか否か」が recall を決める。SudachiDict (WorksApplications, Apache-2.0) は 20 万語規模の System 辞書を提供しており、Phase 2 で dictionary lookup 層を追加すれば、LLM 単体で recall が不足する語彙を構造的に補える。User dict を併設すれば、ユーザ個別語彙 (自分の名前 / 所属組織名 / 業界固有語) も明示登録で覆える。
+
+### C4. SudachiDict Apache-2.0 の OSS 互換性
+
+Kotoha は OSS として公開予定であり、依存辞書の再配布ライセンスが採用可否を支配する。SudachiDict は Apache-2.0 で公開されており、Kotoha 本体想定 OSS ライセンスと両立する。MeCab + UniDic を組合せる選択肢は、UniDic の配布条件が商用利用で制約を受ける運用形態があり、Phase 2 で採用すべきではない (glossary §8 MeCab / UniDic / fugashi の項を参照)。Phase 5 P5-A PoC でも SudachiDict を採用済であり、Phase 2 で同一辞書を流用することで学習データと推論 runtime の語彙整合も取れる。
+
+## Decision
+
+本 ADR では以下 6 項目を決定する。
+
+### D1. Sudachi hybrid architecture を Phase 2 の default とする
+
+Phase 2 の default architecture を「LlamaCpp backend (Gemma-2-2B-jpn-it baseline) と Dictionary backend (Sudachi-based) を hybrid に組合せる二段構成」とする。LLM は汎用的な変換 recall を、Dictionary は固有名詞 / 敬称 / User 登録語彙の高精度 recall を、それぞれ担当する。両者の候補は後段 Ranker で merge / dedupe / rerank し、top-k を確定する。
+
+hybrid 採用により Phase 1 の 14/15 baseline を退行させず、かつ固有名詞 / 敬称の recall を追加できる。
+
+### D2. Dictionary を 2 層 (System + User) で構成する
+
+Dictionary layer は以下 2 層から成る。
+
+- **System dictionary**: SudachiDict (core variant または full variant) を runtime load する。Phase 2 の default recall 源として働く
+- **User dictionary**: ユーザが明示登録する個別語彙 (人名 / 所属 / 業界語 / macro 展開) を保持する。永続化形式 (TOML / JSONL / plain-text tsv) は P2-A kick-off で確定する
+
+2 層構成により、System 辞書の汎用 recall と User 辞書の個別 recall を独立に拡張できる。User 辞書の更新は System 辞書の再配布サイクルに束縛されない。
+
+### D3. Learning cache を in-memory LRU + 永続化ペアで持つ
+
+ユーザが選択した変換履歴を learning cache として保持する。データ構造は以下とする。
+
+- **runtime 構造**: in-memory LRU cache。`(kana_input, chosen_kanji)` を key とし、`frequency` / `last_used_at` を value とする
+- **永続化形式**: TOML or JSONL (P2-A kick-off で empirical 確定する。初期候補: `~/.local/share/kotoha/learning.tsv` に TSV で保存)
+- **load / save timing**: プロセス起動時に全件 load、shutdown 時に全件 save。Phase 3 IBus 統合では plugin の life cycle hook に合わせて見直す
+
+Learning cache は Ranker の入力 feature として使用し、User が繰返し選択する候補の rerank 係数を上げる。
+
+### D4. BackendConfig に新 variant を追加する
+
+Phase 2 は ADR 0011 で確定した `BackendConfig` enum の `#[non_exhaustive]` 拡張点を使用し、新 variant を 1 つ追加する。variant 名候補は以下 2 案を P2-A kick-off で empirical 確定する。
+
+- **候補 1**: `BackendConfig::DictionaryAugmented { model_path, dict_config, learning_config }` — Dictionary 補完付き LLM backend を 1 variant に集約する案
+- **候補 2**: `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict: DictionaryConfig, learning: LearningConfig }` — LLM backend を再帰的に wrap する案。将来の Phase 5 `KotohaNative` backend との組合せにも自動対応する
+
+Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` と `BackendConfig::Mock` は変更しない。既存 variant の破壊を伴わない純粋な拡張として追加する。
+
+### D5. Ranker 戦略を「dict 0.95 / LLM 1.0 初期重み」から開始する
+
+Dictionary 候補と LLM 候補を merge する際の rerank 重みを、初期値として以下に設定する。
+
+- **LLM 候補の base weight**: 1.0
+- **Dictionary 候補の base weight**: 0.95
+- **Learning cache hit bonus**: +frequency 依存の加算 (P2-D で empirical 確定)
+
+dict < LLM とする理由は、Phase 1 の 14/15 baseline を前提に、LLM が出せる汎用語彙 recall の信頼度が dict 単発 hit より一般的に高いためである。ただし敬称や固有名詞の hit に対しては dict 側の信頼度が逆転するケースが多く、P2-D で empirical tuning する。
+
+### D6. 既存 Backend trait を壊さず拡張する (ADR 0011 との整合)
+
+本 ADR の全ての新 variant / 新構成は、ADR 0011 で確定した `KanjiBackend` trait を実装する新 struct として導入する。trait 本体 (`convert` / `model_id` method 2 本) は変更しない。`validate_input` と `score_sort_dedupe` の共有 helper も既存を流用する。
+
+Phase 5 で `KotohaNative` backend が追加される際も、本 ADR の Dictionary + Learning 構成をそのまま継承できるよう、Ranker と Learning cache は backend-agnostic な形で kotoha-core crate 内に配置する (具体配置は P2-A kick-off で確定)。
+
+## Consequences
+
+### 正の帰結
+
+- **Phase 5 完成を待たずに固有名詞 / 敬称 failure を解消できる**: Phase 5 (ADR 0010) の 3〜6 ヶ月工数を待たず、Phase 2 で IME として実用水準の recall を提供できる
+- **User dict で個人化が可能になる**: 自分の名前 / 所属 / 業界語を明示登録でき、Gemma baseline の学習分布に依存しない recall が構造的に確保できる
+- **Learning cache の data path が確立される**: Phase 5 custom model の personalization (Phase 6 以降) でも同じ data path を流用できる。Phase 2 の learning.tsv format が Phase 5 / Phase 6 の data interface として機能する
+- **Phase 5 との互換性が設計段階で確保される**: D6 により Phase 5 `KotohaNative` backend が追加された際も、Dictionary + Learning 構成を再利用可能である (Phase 2 spec §9 Q6 で継承可否を判断する)
+- **ADR 0011 / 0012 の拡張点が実地で検証される**: `#[non_exhaustive]` enum と feature flag 方針が Phase 2 の新 variant 追加で動作することを empirical に確認できる
+
+### 負の帰結
+
+- **2 layer (LLM + Dictionary) の保守コストが追加される**: Phase 1 の LLM 単層と比較し、Dictionary 初期化 / User dict 永続化 / Learning cache sync の 3 path を Phase 2 で追加実装する必要がある
+- **Rerank tuning が P2-D に集中する**: D5 の初期重み (dict 0.95 / LLM 1.0) は empirical tuning を前提とし、P2-D で 100〜200 件規模の fixture で evaluation する工数が要る。D5 の値は暫定であり、P2-D の結果で再確定する
+- **Sudachi binary の 70〜500MB footprint が常駐サイズに上乗せされる**: SudachiDict-core は 70MB、full は 500MB。Phase 1 の Gemma-2-2B-jpn-it 1.92GB と合算すると IME 常駐 size が増大する。Phase 5 custom model (ADR 0010 D6, ≤ 200MB) への移行で total size は改善見込みだが、Phase 2 単体では footprint 増が避けられない
+
+### Phase 2 spec との整合
+
+本 ADR の 6 決定は Phase 2 spec (`docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`) §3 アーキテクチャ / §4 Dictionary 設計 / §5 Learning cache 設計 / §6 API と Trait 拡張 の 4 節と相互参照する。spec の各節末尾には「詳細は P2-A kick-off で確定する」の stub disclaimer を付し、ADR と spec が同期的に P2-A で確定する構造とする。
+
+## Alternatives considered
+
+以下 4 案を検討し、いずれも棄却した。
+
+### A. Dictionary only (LLM 無し)
+
+**Rejected.** Phase 1 の 14/15 baseline は LLM が担保しており、Dictionary 単独では汎用語彙 recall が大幅に低下する。Gemma-2-2B-jpn-it が正しく変換する一般語 (動詞活用 / 助詞接続 / 慣用句) を dict 単独で recall するには、辞書 size を UniDic full 級まで拡大しつつ N-gram 統計モデルを加える必要があり、Phase 2 の工数目安 (P2-A〜D 合計 3〜6 週) を大幅に超過する。
+
+### B. LLM only 継続 (Phase 2 を skip)
+
+**Rejected.** Phase 5 完成までの 3〜6 ヶ月を Gemma baseline のまま shipping すると、固有名詞 / 敬称 / User 個別語彙の recall が改善されない。IME として実用水準に届かず、Phase 3 IBus 統合 / Phase 4 fcitx5 統合の shipping 品質が底上げされない。C2 で論じた「Phase 5 完成を待たない品質底上げ」目的と両立しない。
+
+### C. 3rd party mozc-rs 呼出し
+
+**Rejected.** mozc-rs (Google 日本語入力のエンジンを Rust からバインディングする crate) は活発度が低く、Kotoha の最小依存方針 (Cargo workspace で全 crate version を pin する運用) と整合しにくい。また mozc の辞書 / 変換エンジン全体を取込むと Kotoha の Backend trait 設計 (ADR 0011) との interface 不整合が発生し、Phase 5 `KotohaNative` backend への継承パス (D6) も断ち切られる。Dictionary 補完は Kotoha 内製で構築し、必要な辞書 data のみ SudachiDict から流用する方針を採る。
+
+### D. 独自 dict format only (SudachiDict を採用しない)
+
+**Rejected.** SudachiDict は Apache-2.0 / 20 万語規模 / 形態素解析済 / Phase 5 P5-A PoC で採用実績あり、の 4 条件を満たす。独自 dict format を Phase 2 で新設すると、(a) 20 万語規模の初期辞書作成工数が別途発生し、(b) Phase 5 data pipeline (ADR 0010 Phase 5 spec §3.1) との辞書整合が取りにくくなる。Kotoha 独自語彙は SudachiDict の上に薄い補完レイヤーとして merge するのが合理的である (Phase 2 spec §4.2 参照)。
+
+## Related documents
+
+- 実装前提: ADR 0009 (`docs/adr/0009-phase-1-default-model-selection.md`) — Gemma-2-2B-jpn-it default 採用
+- Backend trait 拡張点: ADR 0011 (`docs/adr/0011-kanji-backend-trait-design.md`) — `BackendConfig` `#[non_exhaustive]` enum + `load_backend` factory
+- Feature flag 方針: ADR 0012 (`docs/adr/0012-feature-flag-design-for-llama-cpp.md`) — optional dependency 隔離
+- Latency policy: ADR 0013 (`docs/adr/0013-phase-1-latency-target.md`) — Phase 2 での hard-gate 無し方針
+- Phase 5 継承関係: ADR 0010 (`docs/adr/0010-kotoha-custom-romaji-base-model.md`) — Phase 5 `KotohaNative` backend、Phase 5 spec §3.3 と本 ADR D6 / Phase 2 spec §9 Q6 で整合
+- Phase 2 設計書: `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` (本 ADR と同一 PR で起票)
+- Phase 1 14/15 empirical record: `docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md` (PR #76 merge `3eccaa1`)
+- Phase 1 close 記録: `docs/wbs/2026-04-25-docs-83-p1-4-phase1-wrap.md` (PR #84 merge `95e7df9`)
+- ROADMAP restructure 反映先: `docs/ROADMAP.md` Phase 一覧テーブル + Phase 2 マイルストーン分割節
+- 参考辞書: SudachiDict (Apache-2.0, <https://github.com/WorksApplications/SudachiDict>)
+
+## Note: 本 ADR の status について
+
+本 ADR は方針として Accepted とするが、D4 の variant 名、D5 の rerank 重み、D3 の learning cache 永続化 format、D2 の SudachiDict core/full 選択、の 4 点は P2-A kick-off 時点で empirical 確定する。P2-A 着手後の follow-up commit で本 ADR に「確定パラメータ」節を追記する運用を取り、P2-D 完了時点で本 ADR の内容を最終化する。

--- a/docs/adr/0014-phase-2-dictionary-layer-architecture.md
+++ b/docs/adr/0014-phase-2-dictionary-layer-architecture.md
@@ -20,11 +20,11 @@ Phase 5 は data pipeline + training + evaluation で 3〜6 ヶ月の工数を�
 
 ### C3. 固有名詞と敬称の dictionary 補完価値
 
-固有名詞 (「鈴木」「山田」「新宿」) と敬称 (「さん」「様」「殿」) は、LLM の synonym bias よりも「学習分布内に存在するか否か」が recall を決める。SudachiDict (WorksApplications, Apache-2.0) は 20 万語規模の System 辞書を提供しており、Phase 2 で dictionary lookup 層を追加すれば、LLM 単体で recall が不足する語彙を構造的に補える。User dict を併設すれば、ユーザ個別語彙 (自分の名前 / 所属組織名 / 業界固有語) も明示登録で覆える。
+固有名詞 (「鈴木」「山田」「新宿」) と敬称 (「さん」「様」「殿」) は、LLM の synonym bias よりも「学習分布内に存在するか否か」が recall を決める。SudachiDict (WorksApplications, Apache-2.0) は約 76 万 entries (lemma + 活用形含む、lemma 単位では約 20 万) の System 辞書を提供しており、Phase 2 で dictionary lookup 層を追加すれば、LLM 単体で recall が不足する語彙を構造的に補える。User dict を併設すれば、ユーザ個別語彙 (自分の名前 / 所属組織名 / 業界固有語) も明示登録で覆える。
 
 ### C4. SudachiDict Apache-2.0 の OSS 互換性
 
-Kotoha は OSS として公開予定であり、依存辞書の再配布ライセンスが採用可否を支配する。SudachiDict は Apache-2.0 で公開されており、Kotoha 本体想定 OSS ライセンスと両立する。MeCab + UniDic を組合せる選択肢は、UniDic の配布条件が商用利用で制約を受ける運用形態があり、Phase 2 で採用すべきではない (glossary §8 MeCab / UniDic / fugashi の項を参照)。Phase 5 P5-A PoC でも SudachiDict を採用済であり、Phase 2 で同一辞書を流用することで学習データと推論 runtime の語彙整合も取れる。
+Kotoha は OSS として公開予定であり、依存辞書の再配布ライセンスが採用可否を支配する。SudachiDict は Apache-2.0 で公開されており、Kotoha 本体想定 OSS ライセンスと両立する。MeCab + UniDic を組合せる選択肢は、UniDic の配布条件が商用利用で制約を受ける運用形態があり、Phase 2 で採用すべきではない (`docs/wiki/glossary.md` §8 MeCab / UniDic / fugashi 参照)。Phase 5 P5-A PoC でも SudachiDict を採用済であり、Phase 2 で同一辞書を流用することで学習データと推論 runtime の語彙整合も取れる。
 
 ## Decision
 
@@ -94,7 +94,7 @@ Phase 5 で `KotohaNative` backend が追加される際も、本 ADR の Dictio
 
 - **2 layer (LLM + Dictionary) の保守コストが追加される**: Phase 1 の LLM 単層と比較し、Dictionary 初期化 / User dict 永続化 / Learning cache sync の 3 path を Phase 2 で追加実装する必要がある
 - **Rerank tuning が P2-D に集中する**: D5 の初期重み (dict 0.95 / LLM 1.0) は empirical tuning を前提とし、P2-D で 100〜200 件規模の fixture で evaluation する工数が要る。D5 の値は暫定であり、P2-D の結果で再確定する
-- **Sudachi binary の 70〜500MB footprint が常駐サイズに上乗せされる**: SudachiDict-core は 70MB、full は 500MB。Phase 1 の Gemma-2-2B-jpn-it 1.92GB と合算すると IME 常駐 size が増大する。Phase 5 custom model (ADR 0010 D6, ≤ 200MB) への移行で total size は改善見込みだが、Phase 2 単体では footprint 増が避けられない
+- **Sudachi binary の 70〜500MB footprint が常駐サイズに上乗せされる**: SudachiDict-core は約 70MB、full は約 500MB。Phase 1 の Gemma-2-2B-jpn-it Q5_K_M (1.92GB) と合算すると、core 採用で約 2.0GB、full 採用で約 2.4GB の常駐 footprint になる。Phase 2 default は core、full は opt-in に限定する方針。Phase 5 custom model (ADR 0010 D6, ≤ 200MB) への移行で total size は改善見込みだが、Phase 2 単体では footprint 増が避けられない
 
 ### Phase 2 spec との整合
 
@@ -118,7 +118,7 @@ Phase 5 で `KotohaNative` backend が追加される際も、本 ADR の Dictio
 
 ### D. 独自 dict format only (SudachiDict を採用しない)
 
-**Rejected.** SudachiDict は Apache-2.0 / 20 万語規模 / 形態素解析済 / Phase 5 P5-A PoC で採用実績あり、の 4 条件を満たす。独自 dict format を Phase 2 で新設すると、(a) 20 万語規模の初期辞書作成工数が別途発生し、(b) Phase 5 data pipeline (ADR 0010 Phase 5 spec §3.1) との辞書整合が取りにくくなる。Kotoha 独自語彙は SudachiDict の上に薄い補完レイヤーとして merge するのが合理的である (Phase 2 spec §4.2 参照)。
+**Rejected.** SudachiDict は Apache-2.0 / 約 76 万 entries (lemma + 活用形含む) / 形態素解析済 / Phase 5 P5-A PoC で採用実績あり、の 4 条件を満たす。独自 dict format を Phase 2 で新設すると、(a) 約 76 万 entries 規模の初期辞書作成工数が別途発生し、(b) Phase 5 data pipeline (ADR 0010 Phase 5 spec §3.1) との辞書整合が取りにくくなる。Kotoha 独自語彙は SudachiDict の上に薄い補完レイヤーとして merge するのが合理的である (Phase 2 spec §4.2 参照)。
 
 ## Related documents
 

--- a/docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md
+++ b/docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md
@@ -1,0 +1,361 @@
+---
+title: Kotoha Phase 2 設計書 (draft) — Dictionary and learning
+date: 2026-04-25
+status: draft
+phase: 2
+revision: 1
+---
+
+# Kotoha Phase 2 (Dictionary and learning) 設計書 — draft
+
+本書は Phase 2 の設計書 **draft** である。本 draft の役割は ISSUE #85 時点で Phase 2 のスコープ / アーキテクチャ / open question を確定し、P2-A〜P2-D の各 milestone 実装を同一方針で進められる状態に整えることである。詳細パラメータ (SudachiDict core / full 選択、`BackendConfig` 新 variant 名、learning cache の永続化 format、Ranker 重みの最終値、Dictionary load timing、Phase 5 integration plan) は Phase 2 の P2-A kick-off 時点で empirical 確定する。
+
+本書は ADR 0014 (Phase 2 dictionary layer architecture) を設計根拠とし、ADR 0011 (Backend trait design) / ADR 0012 (Feature flag design) / ADR 0013 (latency target) を前提として参照する。
+
+## 目次
+
+- [1. 背景と動機](#1-背景と動機)
+- [2. スコープ](#2-スコープ)
+- [3. アーキテクチャ](#3-アーキテクチャ)
+- [4. Dictionary 設計](#4-dictionary-設計)
+- [5. Learning cache 設計](#5-learning-cache-設計)
+- [6. API と Trait 拡張](#6-api-と-trait-拡張)
+- [7. テスト戦略](#7-テスト戦略)
+- [8. 非スコープ (将来 phase)](#8-非スコープ-将来-phase)
+- [9. Open questions](#9-open-questions)
+- [10. 参照](#10-参照)
+
+## 1. 背景と動機
+
+### 1.1 Phase 1 14/15 baseline の位置付け
+
+Phase 1 P1-2.5 follow-up (PR #76 / ISSUE #75 / merge commit `3eccaa1`) は、Gemma-2-2B-jpn-it Q5_K_M をバックエンドに Layer 3 smoke fixture 15 行を empirical 実測し、`14/15 PASS` を確定した。唯一 FAIL した row 3「あした → 明日」は、v5〜v12 の 8 世代 prompt iteration を実施しても Gemma-2-2B-jpn-it の ICL (In-context learning) 限界で解消できず、Phase 1 acceptance では 14/15 を受容 (ADR 0009 D5) + Phase 5 (ADR 0010) で task-specific fine-tune により根本解決する計画を確定した。
+
+Phase 1 は P1-4 (PR #84, merge `95e7df9`) で close した。Phase 2 kick-off 時点の前提は「Gemma-2-2B-jpn-it 14/15 を Phase 1 baseline として維持し、Phase 2 では 14/15 を退行させない前提で辞書補完 + 学習を追加する」である。
+
+### 1.2 Phase 5 完成までの 3〜6 ヶ月の品質底上げ需要
+
+Phase 5 (ADR 0010) は data pipeline + training + evaluation で 3〜6 ヶ月の工数を見込む (ADR 0010 負の帰結)。Phase 5 完成を待つ間、Phase 3 IBus 統合 / Phase 4 fcitx5 統合 (Gemma baseline を推論器とした IME shipping) が進行する。IME として shipping する以上、row 3 類の synonym bias 以外にも、敬称 / 固有名詞の誤変換が顕在化する。これらは Gemma-2-2B-jpn-it の ICL だけでは補い切れず、Phase 5 完成を待たず Phase 2 で辞書補完層を提供する意義がある (ADR 0014 C2 参照)。
+
+### 1.3 固有語の軽微問題の実例
+
+Phase 1 の smoke fixture で扱わなかった語彙のうち、Phase 2 で dict 補完によって解消するべき実例は以下 3 類型である。具体 fixture は P2-A kick-off で golden テスト (§7.3) に組込む形で確定する。
+
+- **敬称 (honorific)**: 「たなか さん」→「田中 さん」、「すずき さま」→「鈴木 様」。LLM 単体では「さん / 様」を一般名詞として解釈する誤変換が発生するため、敬称専用の token match 層を dict で担保する
+- **固有名詞**: 人名 (「ひのおか」→「日野岡」)、地名 (「しんじゅく」→「新宿」)、組織名 (「ぐーぐる」→「Google」)。LLM 学習分布内に無い固有名詞は recall が極端に落ちるため、dict 補完で recall を底上げする
+- **User 個別語彙**: 本人の名前 / 所属 / 業界固有語。LLM / System dict の双方に存在しない語彙は、User dict への明示登録のみで recall できる
+
+### 1.4 Phase 2 で解決する具体目標
+
+Phase 2 は以下 4 点を同時解決する。
+
+- **G1**: Phase 1 14/15 baseline を退行させない (Phase 2 regression test で hard-gate)
+- **G2**: 敬称 / 固有名詞を System dict 補完で recall 改善する
+- **G3**: User 個別語彙を User dict への明示登録で覆える
+- **G4**: Learning cache によるユーザ選択履歴の rerank 反映を実現する
+
+詳細 KPI は P2-A kick-off で確定する。
+
+## 2. スコープ
+
+### 2.1 In-scope
+
+Phase 2 の実装範囲は以下 5 項目とする。
+
+1. **System dictionary**: SudachiDict (core variant または full variant, P2-A で empirical 選択) を runtime load する DictionaryBackend の実装
+2. **User dictionary**: ユーザ個別語彙 entry の追加 / 削除 / 列挙 API と永続化 (TOML / JSONL / TSV のいずれか、P2-A で empirical 選択)
+3. **Learning cache**: in-memory LRU + 起動時 load + shutdown save の 2 層構成。data model は `(kana_input, chosen_kanji, frequency, last_used_at)`
+4. **Ranker**: Dictionary 候補と LLM 候補の merge / dedupe / rerank。初期重み dict 0.95 / LLM 1.0 + Learning cache hit bonus (P2-D で empirical tuning)
+5. **BackendConfig 拡張**: ADR 0011 の `#[non_exhaustive]` 拡張点を使用し、Phase 2 用の新 variant を 1 つ追加する (variant 名は P2-A で確定)
+
+詳細は P2-A kick-off で確定する。
+
+### 2.2 Out-of-scope (後続 Phase に送る)
+
+以下 4 項目は Phase 2 では扱わず、後続 Phase に送る。
+
+1. **streaming IME input 統合**: preedit / commit / cancel の IME 状態機械との統合は Phase 3 (IBus) / Phase 4 (fcitx5) で行う。Phase 2 は CLI 経由の単発変換のみを対象とする
+2. **personalization ML**: ユーザごとの微小 fine-tune layer / adapter は Phase 5 custom model (ADR 0010) + Phase 6 以降に送る。Phase 2 の learning cache はユーザ選択履歴の統計情報のみ保持する
+3. **cross-device sync**: User dict / learning cache の複数機同期は Phase 6+ (UX polish) に送る。Phase 2 は単一 machine ローカルのみを対象とする
+4. **GUI dict editor**: User dict を編集する GUI は Phase 6+ / Phase 7 に送る。Phase 2 は CLI サブコマンド (`kotoha-dict add / remove / list` の draft) のみを対象とする (P2-B §2.1 参照)
+
+詳細は P2-A kick-off で再確認する。
+
+## 3. アーキテクチャ
+
+### 3.1 Dictionary layer
+
+Dictionary layer は System dictionary + User dictionary の 2 層から構成する。
+
+- **System dictionary**: SudachiDict (core variant 約 70MB または full variant 約 500MB) を runtime load する。default は SudachiDict-core を P2-A 初期 pilot で採用し、recall 不足が empirical に確認された場合 P2-D で full variant への変更を検討する
+- **User dictionary**: ユーザ個別語彙 entry を保持する。entry schema は `(surface, reading, pos, score)` で、永続化 format は P2-A で確定する
+- **merge 戦略**: System 辞書で hit した候補と User 辞書で hit した候補は Ranker で merge する。同一 surface が両方で hit した場合は User 側の score を優先する
+
+詳細 entry schema / load timing は P2-A kick-off で確定する。
+
+### 3.2 Learning cache
+
+Learning cache は ユーザが選択した変換履歴を保持する。
+
+- **data model**: `(kana_input, chosen_kanji, frequency, last_used_at)` のレコード
+  - `kana_input`: 入力された hiragana 文字列
+  - `chosen_kanji`: ユーザが確定した surface (漢字交じり)
+  - `frequency`: 選択回数の累積 (u32)
+  - `last_used_at`: 最終選択時刻 (UNIX epoch seconds)
+- **persistence**: TOML or JSONL or TSV のいずれかを `~/.local/share/kotoha/learning.{toml|jsonl|tsv}` に配置する。P2-A で format を empirical 確定する。path は XDG Base Directory 仕様に従う
+- **load/save timing**: プロセス起動時に全件 in-memory LRU に load、shutdown (SIGTERM / 正常終了) 時に全件 save する。Phase 3 IBus 統合では plugin life cycle hook に合わせて再設計する
+- **eviction / pruning policy**: LRU 上限 (例: 10,000 entry) を超過した場合、`last_used_at` が最古の entry を evict する。上限値は P2-C で empirical 確定する
+
+詳細は P2-A kick-off で確定する。
+
+### 3.3 Ranker
+
+Ranker は Dictionary 候補 (`Vec<Candidate>`) と LLM 候補 (`Vec<Candidate>`) を 1 つの top-k 結果に統合する。
+
+- **merge**: 両 `Vec<Candidate>` を 1 本に連結する
+- **dedupe**: 同一 surface の候補は score が高い方を残し、他方を除去する (ADR 0011 の `score_sort_dedupe` helper を流用する)
+- **rerank**: 初期重み dict 0.95 / LLM 1.0 を `score *= weight` で掛け、Learning cache hit bonus を `score += bonus(frequency, last_used_at)` で加算する
+- **truncate**: top_k (`ConvertOptions::top_k`) で上位のみ返す
+
+初期重みと bonus 関数の最終値は P2-D で empirical tuning する (§7.3 golden fixture での pass rate を KPI とする)。
+
+### 3.4 BackendConfig 拡張 (新 variant)
+
+Phase 2 は ADR 0011 で確定した `BackendConfig` enum の `#[non_exhaustive]` 拡張点を使用し、新 variant を 1 つ追加する。P2-A kick-off で確定する 2 案は以下のとおり。
+
+- **候補 1** (集約型): `BackendConfig::DictionaryAugmented { model_path, dict_config, learning_config }`
+  - Dictionary 補完付き LLM backend を 1 variant に集約する
+  - 実装コスト低、variant 数が最小
+- **候補 2** (再帰 wrap 型): `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict: DictionaryConfig, learning: LearningConfig }`
+  - LLM backend を再帰的に wrap する
+  - Phase 5 `KotohaNative` backend との組合せにも自動対応する
+  - 実装コスト中、Phase 5 integration が構造化される
+
+Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` と `BackendConfig::Mock` は変更しない。詳細は P2-A kick-off で確定する。
+
+## 4. Dictionary 設計
+
+### 4.1 SudachiDict core vs full の trade-off
+
+SudachiDict は core (約 70MB) と full (約 500MB) の 2 variant を提供する。Phase 2 の選択は P2-A 初期 pilot で empirical 確定するが、現時点で整理した trade-off は以下のとおり。
+
+| 項目 | SudachiDict-core | SudachiDict-full |
+|---|---|---|
+| size | 約 70MB | 約 500MB |
+| 収録語彙数 | 約 75 万 | 約 90 万 |
+| 固有名詞 recall | 中 | 高 |
+| 配布ライセンス | Apache-2.0 | Apache-2.0 |
+| IME 常駐 footprint | 許容 | Phase 1 の 1.92GB と合算で約 2.4GB に膨張 |
+
+Phase 2 default は core を採用する方針とし、recall が P2-D の golden fixture で不足と判定された場合のみ full への切替を検討する。
+
+詳細は P2-A kick-off で確定する。
+
+### 4.2 Kotoha 独自語彙の merge
+
+SudachiDict には含まれない Kotoha 固有の語彙 (例: 敬称「さん」「様」の専用 entry、IME 業務ドメイン語彙、Phase 1 smoke fixture 語彙) を薄い補完レイヤーとして SudachiDict 上に merge する。
+
+- 補完 entry の保存先: `crates/kotoha-core/resources/kotoha-dict.tsv` (case 依存、P2-A で path 確定)
+- schema: SudachiDict と同一の `(surface, reading, pos, score)` を採用
+- merge timing: プロセス起動時、SudachiDict load 後に同一 in-memory 構造へ読込
+
+詳細 schema と load timing は P2-A kick-off で確定する。
+
+### 4.3 bundling vs runtime download
+
+SudachiDict の配布方法は 2 案ある。P2-A kick-off で empirical 確定する。
+
+- **bundling**: Cargo crate として辞書 data を同梱する案。初回 install が単純だが、crate size が膨張する
+- **runtime download**: 初回起動時に HuggingFace / GitHub Releases から download する案。crate size は軽量だが、オフライン環境での初回起動が失敗する
+
+Phase 2 default は MEMORY.md の「Model management future vision」方針 (Phase 6 UX で AutoDownload、Phase 1〜5 は manual placement) に揃え、manual placement 運用を採る。具体 path は `KOTOHA_SUDACHI_DICT_PATH` 環境変数で指定する (Phase 1 の `KOTOHA_LLAMA_MODEL_PATH` と同様の運用)。
+
+詳細は P2-A kick-off で確定する。
+
+### 4.4 dict update policy
+
+SudachiDict の upstream update (概ね年 2 回) への追従方針を P2-A kick-off で確定する。現時点の方針候補は以下のとおり。
+
+- **固定版**: Phase 2 kick-off 時点の version を pin し、Phase 2 closure まで変更しない
+- **quarterly sync**: Phase 2 期間中、upstream release の 3 ヶ月遅れで version bump する
+- **issue-triggered**: User 報告の recall 不足で upstream を確認し、必要時に bump する
+
+Phase 2 default は「固定版」を採る。更新が必要となった場合は別 ADR / ISSUE を起票する。
+
+## 5. Learning cache 設計
+
+### 5.1 data model
+
+レコード単位は `(kana_input, chosen_kanji, frequency, last_used_at)` とする。
+
+- **kana_input**: 入力された hiragana 文字列 (`String`)
+- **chosen_kanji**: ユーザが確定した surface (漢字交じり, `String`)
+- **frequency**: 選択回数の累積 (`u32`)
+- **last_used_at**: 最終選択時刻 (UNIX epoch seconds, `i64`)
+
+Phase 2 では上記 4 フィールドに限定する。Phase 5 custom model の personalization で追加フィールド (context embedding, ユーザ profile ID 等) が必要となった場合は schema migration を行う (Phase 5 spec §7 と相互参照)。
+
+### 5.2 persistence
+
+永続化 format の候補は 3 案とする。P2-A で empirical 確定する。
+
+| 候補 | 利点 | 欠点 |
+|---|---|---|
+| TOML | 人手で読み書き可能、parse library 成熟 | レコード数増で file size 膨張 |
+| JSONL | 1 行 1 record で append 書込みが簡単 | parse cost がレコード数 N に比例 |
+| TSV | 最小 format、parse 最速 | escape 規則の手作業 define が必要 |
+
+default 案は「起動時 load + shutdown save の full rewrite」で運用できる TSV を第一候補とし、Phase 5 personalization で append 書込みが必要となった時点で JSONL への migration を検討する。
+
+### 5.3 load/save timing
+
+- **load**: プロセス起動時、`~/.local/share/kotoha/learning.{ext}` が存在すれば全件 in-memory LRU に load する。path 未存在の場合は空の LRU で起動する
+- **save**: shutdown 時 (SIGTERM / 正常終了 / drop) に全件 save する。Phase 3 IBus 統合では plugin の life cycle hook (session 終了) で save する
+- **autosave 閾値**: Phase 2 では autosave を行わない。shutdown save のみに限定する。Phase 5 以降で必要となった場合に ADR を起票する
+
+詳細は P2-A kick-off で確定する。
+
+### 5.4 eviction / pruning policy
+
+Learning cache の in-memory LRU 上限を 10,000 entry とする (暫定値)。
+
+- **eviction**: LRU 上限超過時、`last_used_at` が最古の entry を evict する
+- **pruning**: `frequency == 1` かつ `last_used_at` が 30 日以上前の entry は load 時に除外する (noise 低減)
+
+上限値と pruning 閾値は P2-C で empirical 確定する。
+
+## 6. API と Trait 拡張
+
+### 6.1 既存 Backend trait を壊さず新 variant で対応する
+
+ADR 0011 で確定した `KanjiBackend` trait (method 2 本: `convert` / `model_id`) は変更しない。Phase 2 は以下を新規追加する。
+
+- 新 struct: Dictionary 補完付き backend を実装する 1 つ以上の struct (命名は P2-A で確定、候補: `HybridBackend` / `DictionaryAugmentedBackend`)
+- 新 `BackendConfig` variant: §3.4 の候補 1 / 候補 2 から P2-A で選択した 1 つ
+- `load_backend` factory の新 arm: 新 variant を dispatch する arm を追加 (ADR 0011 D3 と同一パターン)
+- 新 feature flag: ADR 0012 の方針に従い `dict` / `learning` 等の optional dependency を隔離する feature flag を追加 (命名は P2-A で確定)
+
+既存 `LlamaCppBackend` / `MockBackend` / `BackendConfig::LlamaCpp` / `BackendConfig::Mock` は変更しない。Phase 1 14/15 baseline の退行を避けるため、Phase 2 regression test (§7.4) を追加する。
+
+詳細は P2-A kick-off で確定する。
+
+### 6.2 ConvertOptions 拡張の検討
+
+Phase 2 で新規に必要となる option を整理する。2 案ある。
+
+- **案 1** (既存拡張): 既存の `ConvertOptions` 型に `use_dictionary: bool` / `use_learning_cache: bool` 等の field を追加する
+- **案 2** (別型分離): `ConvertOptions` は Phase 1 のまま維持し、別型 `Phase2ConvertOptions { base: ConvertOptions, use_dictionary: bool, ... }` を新設する
+
+default 案は「案 1 の既存拡張」とする。`ConvertOptions` は `#[non_exhaustive]` で宣言し直し (Phase 1 時点の属性は要確認、P2-A kick-off で確定)、新 field は `Default::default()` の boolean default を `true` として「Phase 2 機能が default で on」の挙動を与える。
+
+詳細は P2-A kick-off で確定する。
+
+### 6.3 Dictionary 単体 crate を分離するか kotoha-core に含めるか
+
+Dictionary layer の配置方針は 2 案ある。
+
+- **案 1** (kotoha-core 内配置): `crates/kotoha-core/src/dict/` に module として配置する。Phase 2 の実装量が Phase 1 の `kanji/` module 程度に留まる場合は案 1 で十分
+- **案 2** (kotoha-dict 別 crate): `crates/kotoha-dict/` を新規追加する。SudachiDict 依存が `kotoha-core` の build を重くする場合、別 crate に分離して feature flag で隔離する
+
+default 案は「案 1 の kotoha-core 内配置 + feature flag `dict` で隔離」とする。Phase 2 の実装量が案 1 の想定を超えた場合、P2-D で案 2 への migration を検討する。
+
+詳細は P2-A kick-off で確定する。
+
+## 7. テスト戦略
+
+### 7.1 unit test
+
+以下 3 component を `#[cfg(test)]` 単位で unit test する。
+
+- **Dictionary lookup**: System dict / User dict の lookup が期待 entry を返すこと。merge 優先 (User > System) が動作すること
+- **Learning cache**: LRU eviction が正常動作すること。frequency 加算 / last_used_at 更新が正確であること。persistence (load / save round-trip) が破損しないこと
+- **Ranker**: Dictionary 候補と LLM 候補の merge / dedupe / rerank が §3.3 の契約どおり動作すること。初期重み 0.95 / 1.0 の score 計算が正確であること
+
+Phase 1 の unit test 方針 (`crates/kotoha-core/src/kanji/backend.rs` 末尾の `mod tests`) を踏襲する。
+
+### 7.2 integration test
+
+hybrid backend の end-to-end を `crates/kotoha-core/tests/` 配下で integration test する。
+
+- MockBackend を LLM として固定し、Dictionary 候補 / Learning cache 候補 / Ranker の 3 層が end-to-end で統合動作すること
+- `load_backend` factory の新 arm が Phase 2 新 variant を正しく dispatch すること
+
+Layer 2 (GGUF なし) で完結し、`llama-cpp` feature 非依存で動作する設計とする (ADR 0012 D5 `default = []` 厳守方針)。
+
+### 7.3 golden fixture
+
+Phase 2 固有の golden fixture を以下 4 カテゴリ、30+ cases を最小として P2-A で整備する。
+
+- **敬称**: 「たなか さん → 田中 さん」「すずき さま → 鈴木 様」等、10+ cases
+- **固有名詞 (人名)**: 「ひのおか → 日野岡」「やまだ たろう → 山田 太郎」等、10+ cases
+- **固有名詞 (地名 / 組織名)**: 「しんじゅく → 新宿」「ぐーぐる → Google」等、5+ cases
+- **外来語**: 「こんぴゅーた → コンピュータ」「いんたーねっと → インターネット」等、5+ cases
+
+fixture 形式は Phase 1 の `crates/kotoha-core/tests/fixtures/kanji_llama_cpp_smoke.tsv` と同一 TSV schema を採用する。
+
+詳細 case 数と category 比率は P2-A kick-off で確定する。
+
+### 7.4 regression (Phase 1 14/15 退行防止)
+
+Phase 1 の Layer 3 smoke fixture 15 行を Phase 2 でも継続実行する。Phase 2 の新規変更 (Dictionary 補完 / Learning cache / Ranker) で Phase 1 14/15 baseline が退行しないことを hard-gate する。
+
+- 実行経路: `crates/kotoha-core/tests/kanji_llama_cpp_smoke.rs` + Phase 2 新 backend variant での再実行
+- 期待結果: row 3 を除く 14 行が Phase 2 の新 backend でも PASS すること
+- gate 方針: Phase 2 の PR merge 条件に「Phase 1 smoke 14/15 が Phase 2 backend で maintain されていること」を含める (ADR 0013 の latency gate 無し方針とは独立に、quality gate は設ける)
+
+詳細は P2-A kick-off で確定する。
+
+## 8. 非スコープ (将来 phase)
+
+Phase 2 のスコープから以下を明示的に除外する。
+
+### 8.1 streaming IME input
+
+preedit / commit / cancel / 候補選択 UI との IME 状態機械統合は Phase 3 (IBus) / Phase 4 (fcitx5) で行う。Phase 2 は CLI 経由 (`kotoha-kanji` binary) の単発変換のみを対象とする。
+
+### 8.2 personalization ML
+
+ユーザごとの微小 fine-tune layer / adapter / embedding は Phase 5 custom model (ADR 0010) + Phase 6 以降に送る。Phase 2 の learning cache はユーザ選択履歴の統計情報 (`frequency` / `last_used_at`) のみ保持し、ML 的な personalization は行わない。
+
+### 8.3 cross-device sync
+
+User dict / learning cache の複数機同期は Phase 6+ (UX polish) に送る。Phase 2 は単一 machine ローカルのみを対象とする。
+
+### 8.4 GUI dict editor
+
+User dict を編集する GUI は Phase 6+ / Phase 7 に送る。Phase 2 は CLI サブコマンド (`kotoha-dict add / remove / list`) の draft のみを対象とする (P2-B 範囲)。
+
+## 9. Open questions
+
+P2-A kick-off 時点で解消する 6 点を以下に列挙する。
+
+| # | Question | 解消 milestone |
+|---|---|---|
+| Q1 | SudachiDict-core (70MB) と full (500MB) のどちらを Phase 2 default とするか | P2-A kick-off 初週 (pilot recall 比較) |
+| Q2 | `BackendConfig` 新 variant 名を `DictionaryAugmented` / `Hybrid` のどちらにするか | P2-A kick-off で確定 |
+| Q3 | Learning cache 永続化 format を TOML / JSONL / TSV のどれにするか | P2-A kick-off で確定 |
+| Q4 | Ranker 重みの defaults (dict 0.95 / LLM 1.0) を P2-D 完了時点でどう empirical tuning するか | P2-D で golden fixture の pass rate で確定 |
+| Q5 | Dictionary load を compile-time 埋込 / runtime load のどちらにするか | P2-A kick-off で確定 (default は runtime load) |
+| Q6 | Phase 5 integration plan — Phase 5 `KotohaNative` custom model が Phase 2 の Dictionary / Learning 層を継承するか、別 backend として独立構築するか | Phase 5 kick-off で確定 (Phase 2 の時点では「継承可能な設計を保つ」方針を D6 で定める) |
+
+Q6 は Phase 5 spec §9 Q6 と相互参照する。Phase 2 で Dictionary / Learning cache を backend-agnostic な module として配置しておくことで、Phase 5 custom model が Phase 2 の同一 module を使える構造を担保する。
+
+詳細は P2-A kick-off で確定する。
+
+## 10. 参照
+
+- ADR 0014 (Phase 2 方針決定): `docs/adr/0014-phase-2-dictionary-layer-architecture.md`
+- ADR 0011 (Backend trait 拡張点): `docs/adr/0011-kanji-backend-trait-design.md`
+- ADR 0012 (feature flag 方針): `docs/adr/0012-feature-flag-design-for-llama-cpp.md`
+- ADR 0013 (latency policy): `docs/adr/0013-phase-1-latency-target.md`
+- ADR 0010 (Phase 5 custom model 方針): `docs/adr/0010-kotoha-custom-romaji-base-model.md`
+- ADR 0009 (Phase 1 default model): `docs/adr/0009-phase-1-default-model-selection.md`
+- Phase 1 設計書 (14/15 baseline の根拠): `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md`
+- Phase 5 設計書 (stub): `docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md`
+- Phase 1 P1-2.5 follow-up 実装ログ (row 3 ICL 限界の empirical 記録): `docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md`
+- Phase 1 close 記録: `docs/wbs/2026-04-25-docs-83-p1-4-phase1-wrap.md`
+- ROADMAP restructure 反映先: `docs/ROADMAP.md` Phase 一覧 + Phase 2 マイルストーン分割節
+- SudachiDict upstream: <https://github.com/WorksApplications/SudachiDict>
+- Sudachi (形態素解析器本体): <https://github.com/WorksApplications/Sudachi>
+
+本 draft の詳細化は Phase 2 P2-A kick-off で実施する。

--- a/docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md
+++ b/docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md
@@ -142,10 +142,10 @@ SudachiDict は core (約 70MB) と full (約 500MB) の 2 variant を提供す�
 | 項目 | SudachiDict-core | SudachiDict-full |
 |---|---|---|
 | size | 約 70MB | 約 500MB |
-| 収録語彙数 | 約 75 万 | 約 90 万 |
+| 収録語彙数 | 約 76 万 entries (lemma + 活用形含む、lemma 単位では約 20 万) | 約 90 万 entries |
 | 固有名詞 recall | 中 | 高 |
 | 配布ライセンス | Apache-2.0 | Apache-2.0 |
-| IME 常駐 footprint | 許容 | Phase 1 の 1.92GB と合算で約 2.4GB に膨張 |
+| IME 常駐 footprint | 許容 | Phase 1 の Gemma-2-2B-jpn-it Q5_K_M 1.92GB + SudachiDict-full 約 500MB で合算約 2.4GB に膨張 |
 
 Phase 2 default は core を採用する方針とし、recall が P2-D の golden fixture で不足と判定された場合のみ full への切替を検討する。
 
@@ -246,7 +246,7 @@ Phase 2 で新規に必要となる option を整理する。2 案ある。
 - **案 1** (既存拡張): 既存の `ConvertOptions` 型に `use_dictionary: bool` / `use_learning_cache: bool` 等の field を追加する
 - **案 2** (別型分離): `ConvertOptions` は Phase 1 のまま維持し、別型 `Phase2ConvertOptions { base: ConvertOptions, use_dictionary: bool, ... }` を新設する
 
-default 案は「案 1 の既存拡張」とする。`ConvertOptions` は `#[non_exhaustive]` で宣言し直し (Phase 1 時点の属性は要確認、P2-A kick-off で確定)、新 field は `Default::default()` の boolean default を `true` として「Phase 2 機能が default で on」の挙動を与える。
+default 案は「案 1 の既存拡張」とする。P2-A kick-off 着手前に `crates/kotoha-core/src/kanji/` 配下の `ConvertOptions` 定義で `#[non_exhaustive]` の有無を確認する。付いていなければ P2-A 最初の commit で属性を追加する (ADR 0006 方針との整合上必要)。新 field は `Default::default()` の boolean default を `true` として「Phase 2 機能が default で on」の挙動を与える。
 
 詳細は P2-A kick-off で確定する。
 

--- a/docs/wbs/2026-04-25-docs-85-phase-2-foundation.md
+++ b/docs/wbs/2026-04-25-docs-85-phase-2-foundation.md
@@ -1,0 +1,167 @@
+# Phase 2 foundation — ADR 0014 + Phase 2 spec draft + ROADMAP P2-A〜D (#85)
+
+| 項目         | 値                                                                                         |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| Milestone    | Phase 2 foundation (P2 kick-off 前の docs 整備)                                            |
+| ISSUE        | #85                                                                                        |
+| 親 milestone | Phase 2 全体 (P2-A 〜 P2-D)                                                                |
+| 親 spec      | `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` (本 PR で新規起票)             |
+| 親 ADR       | `docs/adr/0014-phase-2-dictionary-layer-architecture.md` (本 PR で新規起票)                 |
+| ブランチ     | `docs/85-phase-2-foundation`                                                               |
+| PR           | 本 WBS commit 後に別 session で作成予定                                                    |
+| 実装起点     | `95e7df9` (develop, PR #84 merge、Phase 1 close 時点)                                      |
+| 性質         | 純粋 docs 変更 (Rust 実装コード / Cargo.toml / shell スクリプトには一切手を入れない)       |
+| 着手日       | 2026-04-25                                                                                 |
+| 完了日       | 2026-04-25                                                                                 |
+| 工数         | 半日 (docs-only の foundation 整備)                                                        |
+
+## 背景 — Phase 1 close → Phase 2 方針確定の timing
+
+Phase 1 は P1-4 (PR #84, merge `95e7df9`) で close した。P1-4 の申し送り (ROADMAP の「Phase 1 → Phase 2 申し送り」節、および WBS `2026-04-25-docs-83-p1-4-phase1-wrap.md` §「Phase 2 への申し送り」) では、Phase 2 着手の前提として以下 5 点を明示した。
+
+1. Gemma-2-2B-jpn-it Q5_K_M 14/15 baseline を Phase 1 の品質基準として維持する
+2. ADR 0011 で確定した Backend trait の `#[non_exhaustive]` 拡張点を Phase 2 で消費する
+3. ADR 0012 の feature flag 方針を Phase 2 の新規依存 (SudachiDict 等) にも適用する
+4. ADR 0013 の latency policy (Phase 2 では hard-gate しない) を継続する
+5. Phase 2 の新機能は Phase 1 spec §14 の acceptance checklist を上書きせず、独立の acceptance 表を設ける
+
+本 ISSUE #85 は Phase 2 の実装開始前に、上記 5 前提を反映した foundation docs (ADR + spec + ROADMAP + WBS) を整備することを目的とする。Phase 5 foundation (ISSUE #77, PR #78, ADR 0010 + Phase 5 spec stub) の先行 pattern を踏襲し、方針が確定している範囲で ADR と spec draft を先行起票し、実装詳細 (パラメータ / variant 名 / format) は P2-A kick-off で empirical 確定する。
+
+## 4 文書の要約
+
+### ADR 0014 — Phase 2 dictionary layer architecture (Sudachi-based hybrid)
+
+本 ADR は Phase 2 の方針を以下 6 項目の Decision で確定する。
+
+- **D1** — Sudachi hybrid architecture (LLM + Dictionary) を Phase 2 default とする
+- **D2** — Dictionary を System + User の 2 層で構成する
+- **D3** — Learning cache を in-memory LRU + 永続化ペアで持つ
+- **D4** — `BackendConfig` に新 variant を追加する (variant 名は P2-A kick-off で `DictionaryAugmented` / `Hybrid` の 2 案から empirical 確定)
+- **D5** — Ranker 初期重みを dict 0.95 / LLM 1.0 として P2-D で empirical tuning する
+- **D6** — 既存 Backend trait を壊さず拡張する (ADR 0011 との整合、Phase 5 `KotohaNative` への継承パス確保)
+
+### Phase 2 spec draft — Dictionary and learning
+
+本 spec は 10 節構成で Phase 2 全体の設計を draft する。stub disclaimer「詳細は P2-A kick-off で確定する」を各節末尾に付し、方針のみ確定し詳細は P2-A で empirical 詰めする運用を明示する。
+
+- §1 背景と動機 (14/15 baseline / Phase 5 3〜6 ヶ月の底上げ需要 / 固有語の実例 3 類型)
+- §2 スコープ (In-scope 5 項目 / Out-of-scope 4 項目)
+- §3 アーキテクチャ (Dictionary layer / Learning cache / Ranker / BackendConfig 拡張)
+- §4 Dictionary 設計 (core vs full / Kotoha 独自語彙 merge / bundling vs runtime download / dict update policy)
+- §5 Learning cache 設計 (data model / persistence / load-save timing / eviction / pruning)
+- §6 API と Trait 拡張 (Backend trait 非破壊拡張 / ConvertOptions 拡張 / crate 配置)
+- §7 テスト戦略 (unit / integration / golden fixture 30+ cases / Phase 1 14/15 regression)
+- §8 非スコープ (streaming / personalization ML / sync / GUI editor)
+- §9 Open questions (Q1〜Q6、Phase 5 integration plan は Q6 で明示)
+- §10 参照
+
+### ROADMAP restructure
+
+ROADMAP.md に以下 3 項目を反映する。
+
+1. Phase 一覧表の Phase 2 行の状態列を「未着手」から「**進行中 (foundation docs 完了)**」に更新
+2. Phase 2 マイルストーン分割節 (P2-A / P2-B / P2-C / P2-D) を Phase 5 マイルストーン節の直前に新設
+3. 「Phase 1 → Phase 2 への申し送り」節の末尾に 1 段落追記 (foundation docs 整備の完了と Phase 5 integration plan (§9 Q6) の参照)
+
+### WBS (本 docs ファイル)
+
+本 WBS は Phase 2 foundation docs 整備の実装ログである。Phase 5 foundation WBS の style を踏襲し、ADR 0014 の決定経緯と Phase 2 spec stub 方針を Phase 5 WBS と同じ密度で記録する。
+
+## ADR 0014 の Decision / Alternatives の決定経緯
+
+### Decision D1 (Sudachi hybrid architecture) の根拠
+
+Phase 1 P1-2.5 follow-up (PR #76 merge `3eccaa1`) で 14/15 baseline が確定し、row 3 を除く 14 行は Gemma-2-2B-jpn-it で十分な recall を達成した。Phase 2 の目的は「14/15 を退行させない前提で固有名詞 / 敬称 / User 個別語彙の recall を底上げすること」であり、LLM + Dictionary の hybrid 構成が最小工数で目的を達成する。Phase 5 完成 (3〜6 ヶ月) を待たずに shipping 品質を底上げする必要がある (ADR 0014 C2) ため、Phase 2 での hybrid 採用を決定した。
+
+### Decision D4 (BackendConfig 新 variant) の 2 候補保留
+
+P2-A kick-off で確定する 2 案は以下のとおり。
+
+- **候補 1 (集約型)**: `BackendConfig::DictionaryAugmented { model_path, dict_config, learning_config }` — variant 1 つに集約、実装量最小
+- **候補 2 (再帰 wrap 型)**: `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict, learning }` — LLM backend を再帰 wrap、Phase 5 `KotohaNative` との組合せにも自動対応
+
+本 PR (ISSUE #85) では 2 案のどちらも「Phase 1 の既存 variant を破壊しない」「ADR 0011 の `#[non_exhaustive]` 拡張点を使用する」の 2 点は共通であるため、詳細 variant 名は P2-A kick-off の実装 pilot で empirical 確定する方針を採った。
+
+### Decision D5 (Ranker 初期重み dict 0.95 / LLM 1.0) の根拠
+
+Phase 1 の 14/15 baseline を与えた LLM 候補を優先 (base weight 1.0) とし、Dictionary 候補をやや低い base weight (0.95) で merge する。敬称 / 固有名詞の hit に対しては Learning cache hit bonus で rerank を逆転させる余地を残す。初期重みは P2-D の golden fixture (§7.3) で empirical tuning する。
+
+### Alternatives A / B / C / D の rejection 根拠
+
+- **A (dict only)**: 汎用語彙 recall の低下により Phase 1 14/15 を維持できない (ADR 0014 Alternatives A 参照)
+- **B (LLM only 継続)**: 固有名詞 / 敬称の recall 改善が Phase 5 完成までの 3〜6 ヶ月待たされ、Phase 3 / Phase 4 の shipping 品質が底上げされない (Alternatives B 参照)
+- **C (mozc-rs 呼出し)**: Kotoha の Backend trait 設計 (ADR 0011) との interface 不整合、および Phase 5 `KotohaNative` への継承パス断絶 (Alternatives C 参照)
+- **D (独自 dict format only)**: SudachiDict の 20 万語規模を再実装する工数が Phase 2 の 3〜6 週の目安を超過する + Phase 5 P5-A PoC の辞書整合が取れない (Alternatives D 参照)
+
+## Phase 2 spec stub の構造と stub disclaimer 方針
+
+Phase 5 spec stub (`2026-04-25-kotoha-phase-5-custom-model.md`) の先行 pattern を踏襲し、以下の方針を採った。
+
+1. **10 節構成**: 背景 / スコープ / アーキテクチャ / Dictionary 設計 / Learning cache 設計 / API と Trait 拡張 / テスト戦略 / 非スコープ / Open questions / 参照 の 10 節で構成
+2. **stub disclaimer**: 各節末尾に「詳細は P2-A kick-off で確定する」を付し、P2-A 実装時点で確定すべき項目を明示
+3. **Open questions の Q6**: Phase 5 integration plan を明示的に spec §9 Q6 として記録し、Phase 5 spec §3.3 (推論統合概観) と相互参照
+4. **regression test の hard-gate**: §7.4 で Phase 1 14/15 baseline を Phase 2 backend で退行させない gate を明示 (ADR 0013 の latency policy とは独立の quality gate)
+
+spec draft の行数は約 350 行、Phase 5 spec stub (348 行) と同等 size を意図した。
+
+## ROADMAP restructure の要点
+
+- **Phase 一覧表**: Phase 2 行の状態列を「未着手」→「**進行中 (foundation docs 完了)**」に更新した。「進行中」の理由は、実装 milestone (P2-A〜P2-D) は未着手であるものの、方針 ADR + spec draft + milestone 分割が確定したため、Phase 2 は kick-off の前段に入った状態であることを表す
+- **Phase 2 マイルストーン節の位置**: Phase 5 マイルストーン節の直前に配置した。ROADMAP を上から読むと Phase 番号昇順で milestone 分割が追える構成となる
+- **Phase 2 マイルストーン 4 分割**: P2-A (Dictionary layer, 1〜2 週) / P2-B (User dictionary, 3〜5 日) / P2-C (Learning cache, 3〜5 日) / P2-D (Integration + rerank, 1〜2 週)。全体で 3〜6 週を見込む
+- **申し送り節の追記**: P1-4 → P2 申し送り節の末尾に 1 段落追加。ADR 0014 / Phase 2 spec draft / Phase 5 との integration plan (§9 Q6) の 3 点を明示
+
+## Phase 5 (ADR 0010) との relation
+
+Phase 5 は Kotoha 専用 romaji-base model (90〜180M parameter, ≤ 200MB, Q5_K_M) を自作する方針 (ADR 0010 D6 / Phase 5 spec §3.3)。Phase 2 の Dictionary / Learning cache / Ranker を Phase 5 で継承する余地を、以下 3 点で ADR 0014 / Phase 2 spec に明示した。
+
+1. **ADR 0014 D6**: 既存 Backend trait を壊さず拡張する。Ranker と Learning cache は backend-agnostic な形で kotoha-core crate 内に配置する
+2. **Phase 2 spec §9 Q6**: Phase 5 integration plan を open question として保留し、Phase 5 kick-off で継承可否を確定する
+3. **Phase 5 spec §3.3 (既存)**: Phase 5 の推論統合概観に「Sudachi 辞書 fallback を OOV 検知時の後段として併用する」と記述済 (Phase 5 spec §3.4)。Phase 2 で Dictionary / Learning cache を Phase 5 で継承可能な形に配置しておくことで、Phase 5 spec §3.4 の「候補 a / b / c の後段 fallback 案」と Phase 2 の architecture が整合する
+
+Phase 5 は Phase 2 の Dictionary / Learning 層を継承 (backend 交換のみ) する方針を第一候補とするが、Phase 5 kick-off 時点で custom model の data interface が Phase 2 と大きく異なる場合は別 backend として独立構築する余地も残す。
+
+## P2-A kick-off への申し送り
+
+Phase 2 foundation docs の完了時点で、P2-A kick-off 時に empirical 確定する open question を以下にまとめる (Phase 2 spec §9 と同一表、本 WBS で再掲)。
+
+| # | Question | 確定タイミング |
+|---|---|---|
+| Q1 | SudachiDict-core (70MB) vs full (500MB) | P2-A kick-off 初週 (pilot recall 比較) |
+| Q2 | `BackendConfig` 新 variant 名 (`DictionaryAugmented` / `Hybrid`) | P2-A kick-off で確定 |
+| Q3 | Learning cache 永続化 format (TOML / JSONL / TSV) | P2-A kick-off で確定 |
+| Q4 | Ranker 重み defaults の最終値 | P2-D で golden fixture の pass rate で確定 |
+| Q5 | Dictionary load timing (compile-time 埋込 vs runtime load) | P2-A kick-off で確定 (default: runtime load) |
+| Q6 | Phase 5 `KotohaNative` の Phase 2 層継承可否 | Phase 5 kick-off で確定 (Phase 2 では継承可能な配置を保つ) |
+
+加えて、本 ISSUE #85 の scope 外として P2-A kick-off 時に別 commit で対応する項目:
+
+1. **glossary.md の新規用語追記**: DictionaryBackend / DictionaryAugmented / System dictionary / User dictionary / Learning cache / Ranker / Reranker / Candidate merge / dedupe の 8 用語程度を Phase 2 kick-off 時に glossary §4〜§7 に追加する
+2. **Phase 2 plan 文書**: `docs/superpowers/plans/2026-04-25-kotoha-phase-2-p2-a.md` 相当の implementation plan を P2-A kick-off で別 ISSUE として起票する
+3. **Phase 2 fixture の具体 case 収集**: §7.3 golden fixture の敬称 / 固有名詞 / 外来語 30+ cases を P2-A kick-off で確定する
+
+本 Phase 2 foundation docs は上記 3 項目を「本 ISSUE #85 の scope 外」として明示的に保留し、P2-A kick-off で別 ISSUE / 別 commit で対応する運用を取る。
+
+## 検証 commands (final、本 WBS ブランチで実行)
+
+本 ISSUE #85 は docs-only のため、Rust 側の検証は「変更が無いことの確認」として `cargo check --workspace` を 1 回走らせる。
+
+```bash
+cargo check --workspace                                                    # PASS (docs-only のため no-op)
+ls docs/adr/0014-phase-2-dictionary-layer-architecture.md                  # 存在確認
+ls docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md              # 存在確認
+ls docs/wbs/2026-04-25-docs-85-phase-2-foundation.md                       # 存在確認
+```
+
+lefthook pre-commit (doc-naming 規約) が本 PR 内の 3 新規ファイルを PASS することを commit 時点で確認する (`--no-verify` は使用禁止)。
+
+## Follow-up (post-merge)
+
+本 ISSUE #85 で残す作業 (P2-A kick-off 時に別 ISSUE として起票予定):
+
+1. **glossary.md への Phase 2 新規用語追記**: 本 ISSUE scope 外、P2-A kick-off 時に別 commit で対応
+2. **Phase 2 plan 文書起票**: `docs/superpowers/plans/2026-04-25-kotoha-phase-2-p2-a.md` 相当の implementation plan
+3. **Phase 2 fixture の case 収集**: §7.3 golden fixture 30+ cases の具体化
+4. **SudachiDict dependency 選定**: Cargo.toml への追加と feature flag (`dict` 等) の設計 — ADR 0012 の方針に従い optional dependency として隔離する
+
+Phase 2 foundation は本 ISSUE #85 をもって完了し、後続は Phase 2 P2-A kick-off (Dictionary layer 実装) へ移行する。

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -182,6 +182,52 @@
 - **対応する identifier**: `Candidate` struct (`crates/kotoha-core/src/kanji/mod.rs`)
 - **備考**: Phase 1 では surface のみ使用。Phase 2 で score / source (辞書 or LLM) フィールドを追加予定。
 
+### Phase 2 Dictionary layer (P2-A 以降)
+
+以下 6 entry は ADR 0014 (`docs/adr/0014-phase-2-dictionary-layer-architecture.md`) および Phase 2 spec (`docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`) で初出した用語を集約する。実装 identifier は P2-A kick-off で確定予定のものを含む。
+
+### DictionaryBackend / DictionaryAugmented variant
+
+- **定義**: Phase 2 で追加予定の `BackendConfig` 新 variant (正式名は P2-A kick-off で確定)。Sudachi-based dictionary lookup と LlamaCpp LLM 生成を hybrid 構成で組合せる backend を表す。LLM 単体では recall が不足する固有名詞 / 敬称 / User 登録語彙を dictionary 側で structural に補う目的で導入する。
+- **初出**: ADR 0014 D1 / Phase 2 spec §3.3
+- **対応する identifier**: `BackendConfig::DictionaryAugmented` (候補名、P2-A kick-off で実装確定)
+- **備考**: 既存 `BackendConfig` は `#[non_exhaustive]` 属性を持つため、新 variant 追加は ADR 0006 方針に整合し breaking change にならない (既存 BackendConfig entry 備考参照)。Phase 5 で追加予定の `KotohaNative` variant とは直交しており、Phase 5 backend も同じ Dictionary layer を再利用できる設計 (ADR 0014 D6)。
+
+### System dictionary (システム辞書)
+
+- **定義**: Kotoha が配布する共通語彙辞書。SudachiDict-core (WorksApplications, Apache-2.0) を base とし、Kotoha 独自語彙 (敬称、IME 固有表記等) を薄い補完 layer として merge する。Phase 2 default の recall 源として働く。
+- **初出**: ADR 0014 D2 / Phase 2 spec §4.2
+- **対応する identifier**: System dictionary loader module (`crates/kotoha-core/src/dict/` 配下、P2-A kick-off で配置確定)
+- **備考**: core variant (約 70MB) と full variant (約 500MB) の 2 種のうち、Phase 2 default は core を採用する (Phase 2 spec §4.1)。SudachiDict-core の収録 entry 数は約 76 万 (lemma + 活用形含む、lemma 単位では約 20 万)。full 切替は P2-D golden fixture で recall 不足と判定された場合に限定する。
+
+### User dictionary (ユーザ辞書)
+
+- **定義**: ユーザが明示登録する個別語彙 (人名 / 所属組織名 / 業界固有語 / macro 展開) を保持する辞書。System dictionary と分離し、永続化形式 (TOML / JSONL / plain-text tsv) は P2-A kick-off で確定する。
+- **初出**: ADR 0014 D2 / Phase 2 spec §4.3
+- **対応する identifier**: User dictionary store module (`crates/kotoha-core/src/dict/` 配下、P2-A kick-off で配置確定)
+- **備考**: System dictionary の再配布サイクルに束縛されず、ユーザ側で独立に更新可能である。Phase 6 UX (MEMORY.md 参照) で設定 UI からの追加 / 編集 / import / export を実装予定。
+
+### Learning cache (学習キャッシュ)
+
+- **定義**: ユーザの変換候補選択履歴を永続化し、後続の rerank に利用する cache。in-memory LRU 構造で runtime に保持し、起動時 load + shutdown save で永続化する。同一 kana 入力に対するユーザ選択の偏りを時系列で反映する目的で導入する。
+- **初出**: ADR 0014 D3 / Phase 2 spec §5
+- **対応する identifier**: Learning cache module (`crates/kotoha-core/src/learning/` 配下、P2-A kick-off で配置確定)
+- **備考**: in-memory LRU の容量 / LRU eviction 方針 / 永続化 format (JSONL or sqlite) は P2-A kick-off で確定する。Phase 5 `KotohaNative` backend でも再利用可能な layer として設計する (ADR 0014 D6)。
+
+### Ranker / Reranker
+
+- **定義**: Dictionary 候補と LLM 候補を merge / dedupe / rerank して最終 top-k を決定する layer。初期重みは dict = 0.95 / LLM = 1.0 (P2-D での empirical tuning を前提とした暫定値)。学習キャッシュの履歴情報を rerank signal として追加で加味する。
+- **初出**: ADR 0014 D5 / Phase 2 spec §3.3 / §6
+- **対応する identifier**: Ranker module (`crates/kotoha-core/src/ranker/` 配下、P2-A kick-off で配置確定)
+- **備考**: 初期重み (dict 0.95 / LLM 1.0) は ADR 0014 D5 の暫定値であり、P2-D で 100〜200 件規模の golden fixture に対して evaluation し再確定する (ADR 0014 Consequences 負の帰結 参照)。
+
+### Candidate merge / dedupe
+
+- **定義**: 辞書候補と LLM 候補を同一 kanji surface で統合 (merge) し、重複 entry を排除 (dedupe) する処理。score は「最大値採用」または「重み合算」のいずれかで決定し、選択方針は P2-D で empirical 確定する。
+- **初出**: Phase 2 spec §3.3
+- **対応する identifier**: Ranker module 内の merge / dedupe 関数 (P2-A kick-off で実装確定)
+- **備考**: 同一 surface が Dictionary 側と LLM 側の両方から返る場合、source フィールド (Candidate 構造体に Phase 2 で追加予定) を保持して、後段の UX / debug に活用できる設計とする。
+
 ## 5. LLM 推論とプロンプト
 
 ### PromptTemplate


### PR DESCRIPTION
## Summary

Phase 2 (Dictionary and learning) の foundation docs を 4 ファイルで整備。Phase 5 foundation pattern (PR #78) を踏襲した純粋 docs PR、実装コード変更なし。

- **ADR 0014** (138 行): Sudachi-based hybrid architecture の decision、D1-D6 (dict 2 層 / learning cache / ranker 戦略 / BackendConfig 新 variant / Phase 1 Backend trait 非破壊拡張) を記録。Alternatives A (dict only) / B (LLM only) / C (mozc-rs) / D (独自 format) を reject。
- **Phase 2 spec draft** (361 行): §1 背景〜§9 Open questions。詳細パラメータは P2-A kick-off で確定。
- **ROADMAP.md** (+32 -1): Phase 2 状態を「進行中 (foundation docs 完了)」に更新、P2-A (Dictionary layer) / P2-B (User dictionary) / P2-C (Learning cache) / P2-D (Integration + rerank) のマイルストーン stub を追加、Phase 1→2 申し送り節に P1-4 完了後の foundation 整備を追記。
- **WBS** (167 行): ADR 0014 決定経緯、Phase 5 (ADR 0010) との relation (Q6 Open question)、P2-A 申し送り。

## Verification

- lefthook pre-commit (doc-naming): PASS
- lefthook pre-push (build / clippy / manifest / test 175 件): PASS
- cargo check: clean
- doc-naming 規約遵守 (\`docs/adr/NNNN-title.md\`、\`docs/wbs/YYYY-MM-DD-branch-name.md\`)

## Test plan

- [x] ADR / spec / ROADMAP / WBS の用語統一 (DictionaryBackend / System dictionary / User dictionary / Learning cache / Ranker)
- [x] ADR 0014 の forward reference が Phase 2 spec と一致
- [x] Phase 5 (ADR 0010) との integration が spec §9 Q6 で明示
- [ ] Reviewer: ADR 0014 の Decision D5 (ranker 初期重み 0.95/1.0) が empirical ground なしの推定値であることを §9 Open Q4 で deferral していることを確認
- [ ] Reviewer: spec §7 test 戦略で Phase 1 14/15 regression が明示されているか確認

## Scope boundary

本 PR の scope 外 (P2-A kick-off 以降):
- Dictionary 実装 / User dict CLI / Learning cache 実装
- SudachiDict bundling 判断
- Ranker empirical tuning
- glossary.md への新用語追記 (P2-A kick-off で対応)

## References

- Parent milestones: Phase 1 (PR #84 \`95e7df9\`), Phase 5 foundation (PR #78 \`7e74556\`)
- ISSUE: #85
- Related ADRs: 0010 (Phase 5 relation), 0011 (trait extension point), 0012 (feature flag), 0013 (latency target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)