### PR TITLE
docs(phase-5): add mixed JP/EN handling to ADR 0010 + Phase 5 spec (#88)

### DIFF
--- a/docs/adr/0010-kotoha-custom-romaji-base-model.md
+++ b/docs/adr/0010-kotoha-custom-romaji-base-model.md
@@ -41,6 +41,12 @@ Karukan (Linux 向け日本語 IME) は `jinen-v1-small` (90M parameter、GPT-2 
 - 「s<backspace>」: 前処理層の状態機械が中間状態で破綻する
 - 「まうｓ」(「ます」の typo): 前処理層は typo を解釈できず、モデルが「ます」に復元する機会を奪う
 
+### C4. プログラマ / 技術ライター use case における JP + EN 混在入力要件
+
+Kotoha の想定利用者はプログラマおよび技術ライターが主要セグメントである。このセグメントが日常入力する文面 (コミットメッセージの編集、GitHub issue / PR 本文、技術 blog、コード内コメント) では、日本語と英語が 1 行内で混在する形が常態化している。具体例として、romaji 入力 `tuginocommitwoshuuseisitepull requestwodasite` はユーザー意図として「次のcommitを修正してpull requestを出して」を表し、以下 3 条件を同時に満たす変換を期待する。(a) `commit` / `pull request` は英字列のまま出力する、(b) 2 語の間の空白 (`pull request` の中間) は word separator として保持され変換 trigger 扱いしない、(c) `tugi no` / `wo shuusei site` / `wo dasite` の JP 部分は既存の kana→kanji 経路を通って漢字仮名混じり表現に変換される。
+
+Phase 0 ADR 0002 は「Shift 起動で `InputMode::Direct` に一時遷移し Enter 確定で `InputMode::Hiragana` に自動復帰する Transient モード」を決定したが、当該 ADR が扱うのは「行末に短い英字列が入る」ケースであり、「行内に EN span が挟まる」ケースは扱っていない。従って C4 は ADR 0002 を前提として別問題と位置付ける。なお本要件は Phase 1 row 3 (C1) と同系統の LLM ICL 限界事例である。汎用 instruction-tuned LLM の prompt 指示では「context 依存の言語判定」を安定させるのは困難であり、Phase 5 task-specific fine-tune で学習分布内に mixed JP/EN 文面を含めることで根本解決する方が構造的に正しい。
+
 ## Decision
 
 Kotoha は Phase 5 として **Kotoha 専用 romaji-base かな→漢字変換モデル** を自作する。Decision の構成は 7 項目とする。
@@ -117,6 +123,21 @@ Phase 5 の位置付け変更に伴い、既存 ROADMAP を以下のように re
 
 Phase 3 (IBus) と Phase 4 (fcitx5) は Gemma baseline で先行リリースし、IME shipping を遅延させない。Phase 5 (custom model) が Phase 6 (旧 Phase 5、Advanced features) の技術基盤を提供する。
 
+### D8. Phase 5 custom model の primary goal に mixed JP/EN 自動判定を含める
+
+Context C4 を受け、Phase 5 custom model は kana→kanji 変換に加えて以下 3 機能を primary goal として学習する。
+
+1. **Language-context detection**: モデルは input romaji stream を prefix から逐次 consume し、各位置で「現在 EN span 中か JP 変換対象か」を decoder の hidden state に保持する。boundary の推定には空白 / punctuation / 語彙 plausibility を利用する。本機能は明示的 classifier ではなく暗黙学習で実現する方針とし、P5-A kick-off で empirical に妥当性を検証する。
+2. **Context-aware space handling**: モデルは space 文字を変換 trigger ではなく「EN 文脈では word separator、JP 文脈では区切り記号」として解釈する。training data 側で space を含む mixed sentence を十分 sampling することで学習分布に含める。
+3. **Mixed output generation**: 単一推論 pass で JP 部は kanji / kana surface、EN 部は ASCII 文字列として混在 decode する。special tokens ({ctx}, {romaji}, {out}, {eos}) に加えて {en-span} / {jp-span} の明示 marker を導入するか、暗黙で通すかは P5-A kick-off で empirical 判断する。
+
+training data は以下 2 源から構成する mixed コーパスで補強する (詳細は Phase 5 spec §4.7 を参照)。
+
+- Programming context: GitHub issues / commit messages / OSS README / 技術 blog (Zenn / Qiita 等) / 技術書 — Apache-2.0 / MIT 相当の再配布可能ライセンスのみを採用する
+- 一般 loanword context: Wikipedia JP の technology / IT / business / culture カテゴリ (CC BY-SA 3.0) および青空文庫 (Public Domain)
+
+データ比率は P5-A kick-off で empirical 確定する。初期案は「JP-only 60% / mixed (jp+en) 30% / EN-only 10%」とする。
+
 ## Consequences
 
 ### 正の帰結
@@ -126,6 +147,9 @@ Phase 3 (IBus) と Phase 4 (fcitx5) は Gemma baseline で先行リリースし�
 - **partial-input の native 対応**: `s` / `sh` / `si` の部分入力から top-k 候補を即時算出でき、IME の逐次候補表示が実装可能になる
 - **Phase 6 (旧 Phase 5) の技術基盤になる**: typo correction + context reranking は romaji-base モデルの上でこそ自然に実装できる
 - **Size の大幅削減**: Gemma-2-2B-jpn-it の 2.6B / 1.92GB から 90〜180M / ≤ 200MB へ縮小する。IME 常駐用途に適合する
+- **プログラマ / 技術ライター use case の IME 体験が根本改善する**: C4 で示した `tuginocommitwoshuuseisitepull requestwodasite` のような mixed JP/EN 入力が Tier 1 (モデル自動判定) で成立するため、ユーザは明示的モード切替を意識せずに混在文章を打鍵できる。
+- **Phase 5 完成後、Tier 2 / Tier 3 の明示 mode 切替 UX は不要になる**: Phase 5 モデルが context 判定を担うため、Alternatives E が想定する `InputMode::Latin` sticky mode を実装する必要が無くなる。結果として Phase 0 ADR 0002 が決定した 2 値 InputMode (Hiragana / Direct) を Phase 5 完了後も維持できる。
+- **row 3 類と mixed JP/EN の両方を単一モデルで解決する (投資集約)**: C1 の synonym bias と C4 の言語判定は別症状だが、いずれも「task-specific fine-tune で学習分布を制御する」ことで同時に解決可能である。Phase 5 の 1 本の training run で 2 要件を同時に満たせる。
 
 ### 負の帰結
 
@@ -134,10 +158,13 @@ Phase 3 (IBus) と Phase 4 (fcitx5) は Gemma baseline で先行リリースし�
 - **B3 distillation は teacher の Japanese quality に下限を制約される**: Gemma-4-31B-it 等の teacher が row 3 相当の synonym bias を持つ場合、student にも波及する可能性があり、evaluation で確認が必要
 - **Phase 6 完遂までの schedule が延びる**: Phase 5 の data pipeline + training + evaluation で 3〜6 ヶ月程度を見込む。Phase 6 (旧 Phase 5) の着手時期は Phase 5 完了に連動する
 - Phase 5 は手動 training を前提とし、CI-driven training pipeline の自動化は Phase 6 以降へ延期する (spec §7 参照)。
+- **training data の scope が Wikipedia JP 単独から多 source へ拡大する**: D8 で定義した programming context + 一般 loanword context の 2 追加源 (GitHub issues / OSS README / 技術 blog / Wikipedia JP IT カテゴリ / 青空文庫) を P5-A corpus に取り込む必要があり、ライセンス確認と抽出スクリプトの整備工数が増える。
+- **model complexity が増す (multi-language vocabulary + context span 管理)**: 単一言語 (JP) を想定した vocabulary から JP + EN 両対応の vocabulary へ拡張する必要があり、tokenizer 設計と special tokens 設計 (D4 + D8 で言及した `{en-span}` / `{jp-span}` marker) の empirical 検証工数が増える。
+- **評価 fixture に mixed ケースを追加する必要がある**: Phase 5 spec §6 の smoke / regression / golden / typo robustness の 4 fixture に加え、「row 3 系 synonym bias + commit / pull request 等 programming context + 一般 loanword context」の 3 カテゴリを mixed fixture として新設する。測定項目 (EN 単語の英字出力 F1 / JP span の変換精度 / space handling 正答率) も追加する。
 
 ## Alternatives considered
 
-以下 4 案を検討し、いずれも棄却した。
+以下 6 案を検討し、いずれも棄却または deferral とした。
 
 ### A. jinen-v1-small (Karukan と同一モデル) 流用
 
@@ -155,6 +182,18 @@ Phase 3 (IBus) と Phase 4 (fcitx5) は Gemma baseline で先行リリースし�
 
 **Rejected.** C1 で実証したように、汎用 instruction-following LLM の ICL では row 3 類の synonym bias を prompt だけで覆せない。Phase 6 (旧 Phase 5) の typo correction / context reranking を実装しても、根本の convert layer が Gemma のままでは「あした → 翌日」問題は残存する。
 
+### E. Tier 2 採用 (Shift → EN sticky mode) + Phase 0 ADR 0002 の InputMode 拡張
+
+Phase 5 custom model で Tier 1 (D8 の language-context detection) が empirical に達成困難と判明した場合の fallback として、新 variant `InputMode::Latin` を Phase 0 input state machine に追加する案である。ADR 0002 が決定した「Transient vs Sticky」の判断を拡張し、Shift 起動で Latin に入り明示的に Hiragana へ戻るまで EN 入力を継続する Sticky 挙動を採用する。行内 EN span (C4) と行末 Transient (ADR 0002) の両要件を共存させる必要から、Direct (Phase 0 で実装済、行末 Transient 専用) と Latin (新規、行内 Sticky 専用) は別モードとして分離する。
+
+**Status**: Tier 1 (Phase 5 model auto-detect) の empirical 検証後に判断する。Tier 1 成功なら本 Alternative E は不要、Tier 1 失敗なら本 Alternative E を ADR 0015 で正式採用する。**現時点では Rejected**、Phase 5 model の学習可能性を優先検証する。
+
+### F. Dictionary (Phase 2) のみで英語 loanword を辞書 lookup 解決
+
+Phase 2 (ADR 0014) の Sudachi-based dictionary に英語 loanword entry を追加し、`commit` / `pull request` 等を辞書 hit のみで EN 出力する案である。
+
+**Rejected.** 文脈判定が辞書単体では困難である。具体的には「commit」という romaji 入力は動詞の「コミット」(カタカナ) と区別できず、context 情報を持たない lookup では誤変換リスクが大きい。また「次の review を pull する」のような multi-word 英語表現は phrase-level の学習が必要であり、辞書 entry 量が組合せ爆発する。Phase 5 の context-aware model が本問題の正攻法である。ただし Phase 2 dictionary に高頻度 loanword (例: `api` / `commit` / `issue` / `pr` などプログラマ頻出 100 語規模) を限定的に登録することで、Phase 5 完成前の UX を部分改善する検討余地は残す (別 ISSUE で扱う)。
+
 ## Related documents
 
 - Parent empirical record: `docs/wbs/2026-04-24-feature-75-prompt-optimization-15-row-fixture.md` (PR #76 merge commit `3eccaa1`)
@@ -162,6 +201,8 @@ Phase 3 (IBus) と Phase 4 (fcitx5) は Gemma baseline で先行リリースし�
 - Phase 5 design spec (stub): `docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md`
 - ROADMAP restructure 反映先: `docs/ROADMAP.md` Phase 一覧テーブル + Phase 5 マイルストーン分割節
 - 先行 ADR 0009 (Gemma-2-2B-jpn-it pivot prep note): `docs/adr/0009-kanji-backend-model-selection-prep.md`
+- Phase 0 ADR 0002 (input mode Transient vs Sticky、Alternative E `InputMode::Latin` の基盤): `docs/adr/0002-input-mode-transient-vs-sticky.md`
+- Phase 5 spec の mixed JP/EN 対応節: `docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md` §1 / §3.5 / §4.7 / §9 Q7 (本 ADR C4 / D8 の spec 側対応)
 
 ## Note: Phase 3 呼称訂正
 

--- a/docs/adr/0010-kotoha-custom-romaji-base-model.md
+++ b/docs/adr/0010-kotoha-custom-romaji-base-model.md
@@ -202,7 +202,7 @@ Phase 2 (ADR 0014) の Sudachi-based dictionary に英語 loanword entry を追�
 - ROADMAP restructure 反映先: `docs/ROADMAP.md` Phase 一覧テーブル + Phase 5 マイルストーン分割節
 - 先行 ADR 0009 (Gemma-2-2B-jpn-it pivot prep note): `docs/adr/0009-kanji-backend-model-selection-prep.md`
 - Phase 0 ADR 0002 (input mode Transient vs Sticky、Alternative E `InputMode::Latin` の基盤): `docs/adr/0002-input-mode-transient-vs-sticky.md`
-- Phase 5 spec の mixed JP/EN 対応節: `docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md` §1 / §3.5 / §4.7 / §9 Q7 (本 ADR C4 / D8 の spec 側対応)
+- Phase 5 spec の mixed JP/EN 対応節: `docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md` §1.5 / §3.5 / §4.7 / §8 Q7 (本 ADR C4 / D8 の spec 側対応)
 
 ## Note: Phase 3 呼称訂正
 

--- a/docs/adr/0010-kotoha-custom-romaji-base-model.md
+++ b/docs/adr/0010-kotoha-custom-romaji-base-model.md
@@ -45,7 +45,7 @@ Karukan (Linux 向け日本語 IME) は `jinen-v1-small` (90M parameter、GPT-2 
 
 Kotoha の想定利用者はプログラマおよび技術ライターが主要セグメントである。このセグメントが日常入力する文面 (コミットメッセージの編集、GitHub issue / PR 本文、技術 blog、コード内コメント) では、日本語と英語が 1 行内で混在する形が常態化している。具体例として、romaji 入力 `tuginocommitwoshuuseisitepull requestwodasite` はユーザー意図として「次のcommitを修正してpull requestを出して」を表し、以下 3 条件を同時に満たす変換を期待する。(a) `commit` / `pull request` は英字列のまま出力する、(b) 2 語の間の空白 (`pull request` の中間) は word separator として保持され変換 trigger 扱いしない、(c) `tugi no` / `wo shuusei site` / `wo dasite` の JP 部分は既存の kana→kanji 経路を通って漢字仮名混じり表現に変換される。
 
-Phase 0 ADR 0002 は「Shift 起動で `InputMode::Direct` に一時遷移し Enter 確定で `InputMode::Hiragana` に自動復帰する Transient モード」を決定したが、当該 ADR が扱うのは「行末に短い英字列が入る」ケースであり、「行内に EN span が挟まる」ケースは扱っていない。従って C4 は ADR 0002 を前提として別問題と位置付ける。なお本要件は Phase 1 row 3 (C1) と同系統の LLM ICL 限界事例である。汎用 instruction-tuned LLM の prompt 指示では「context 依存の言語判定」を安定させるのは困難であり、Phase 5 task-specific fine-tune で学習分布内に mixed JP/EN 文面を含めることで根本解決する方が構造的に正しい。
+Phase 0 ADR 0002 は「Shift trigger 起動時に `InputMode::Direct` へ一時遷移し Enter 確定で `InputMode::Hiragana` へ自動復帰する Transient policy」を決定した。本 ADR の C4 が対象とするのは、Shift trigger 起動を伴わず行内に EN span (`commit` / `pull request` 等) が挟まる連続入力であり、ADR 0002 の Transient policy の scope とは別問題である。なお本要件は Phase 1 row 3 (C1) と同系統の LLM ICL 限界事例である。汎用 instruction-tuned LLM の prompt 指示では「context 依存の言語判定」を安定させるのは困難であり、Phase 5 task-specific fine-tune で学習分布内に mixed JP/EN 文面を含めることで根本解決する方が構造的に正しい。
 
 ## Decision
 
@@ -129,7 +129,7 @@ Context C4 を受け、Phase 5 custom model は kana→kanji 変換に加えて�
 
 1. **Language-context detection**: モデルは input romaji stream を prefix から逐次 consume し、各位置で「現在 EN span 中か JP 変換対象か」を decoder の hidden state に保持する。boundary の推定には空白 / punctuation / 語彙 plausibility を利用する。本機能は明示的 classifier ではなく暗黙学習で実現する方針とし、P5-A kick-off で empirical に妥当性を検証する。
 2. **Context-aware space handling**: モデルは space 文字を変換 trigger ではなく「EN 文脈では word separator、JP 文脈では区切り記号」として解釈する。training data 側で space を含む mixed sentence を十分 sampling することで学習分布に含める。
-3. **Mixed output generation**: 単一推論 pass で JP 部は kanji / kana surface、EN 部は ASCII 文字列として混在 decode する。special tokens ({ctx}, {romaji}, {out}, {eos}) に加えて {en-span} / {jp-span} の明示 marker を導入するか、暗黙で通すかは P5-A kick-off で empirical 判断する。
+3. **Mixed output generation**: 単一推論 pass で JP 部は kanji / kana surface、EN 部は ASCII 文字列として混在 decode する。special tokens (`<ctx>`, `<romaji>`, `<out>`, `<eos>`) に加えて `<en-span>` / `<jp-span>` の明示 marker を導入するか、暗黙で通すかは P5-A kick-off で empirical 判断する。
 
 training data は以下 2 源から構成する mixed コーパスで補強する (詳細は Phase 5 spec §4.7 を参照)。
 
@@ -149,7 +149,10 @@ training data は以下 2 源から構成する mixed コーパスで補強す�
 - **Size の大幅削減**: Gemma-2-2B-jpn-it の 2.6B / 1.92GB から 90〜180M / ≤ 200MB へ縮小する。IME 常駐用途に適合する
 - **プログラマ / 技術ライター use case の IME 体験が根本改善する**: C4 で示した `tuginocommitwoshuuseisitepull requestwodasite` のような mixed JP/EN 入力が Tier 1 (モデル自動判定) で成立するため、ユーザは明示的モード切替を意識せずに混在文章を打鍵できる。
 - **Phase 5 完成後、Tier 2 / Tier 3 の明示 mode 切替 UX は不要になる**: Phase 5 モデルが context 判定を担うため、Alternatives E が想定する `InputMode::Latin` sticky mode を実装する必要が無くなる。結果として Phase 0 ADR 0002 が決定した 2 値 InputMode (Hiragana / Direct) を Phase 5 完了後も維持できる。
-- **row 3 類と mixed JP/EN の両方を単一モデルで解決する (投資集約)**: C1 の synonym bias と C4 の言語判定は別症状だが、いずれも「task-specific fine-tune で学習分布を制御する」ことで同時に解決可能である。Phase 5 の 1 本の training run で 2 要件を同時に満たせる。
+- **row 3 類と mixed JP/EN の両方を単一モデルで解決する (投資集約)**:
+  - C1 (synonym bias) と C4 (言語判定) は別症状だが、根本原因は同一 (汎用 LLM の ICL 限界) である
+  - 両症状は task-specific fine-tune で training 分布内に含める同一解法で解決できる
+  - Phase 5 の 1 本の training run で 2 要件 (row 3 類 + mixed JP/EN) を同時に満たせる投資集約が成立する
 
 ### 負の帰結
 
@@ -159,7 +162,7 @@ training data は以下 2 源から構成する mixed コーパスで補強す�
 - **Phase 6 完遂までの schedule が延びる**: Phase 5 の data pipeline + training + evaluation で 3〜6 ヶ月程度を見込む。Phase 6 (旧 Phase 5) の着手時期は Phase 5 完了に連動する
 - Phase 5 は手動 training を前提とし、CI-driven training pipeline の自動化は Phase 6 以降へ延期する (spec §7 参照)。
 - **training data の scope が Wikipedia JP 単独から多 source へ拡大する**: D8 で定義した programming context + 一般 loanword context の 2 追加源 (GitHub issues / OSS README / 技術 blog / Wikipedia JP IT カテゴリ / 青空文庫) を P5-A corpus に取り込む必要があり、ライセンス確認と抽出スクリプトの整備工数が増える。
-- **model complexity が増す (multi-language vocabulary + context span 管理)**: 単一言語 (JP) を想定した vocabulary から JP + EN 両対応の vocabulary へ拡張する必要があり、tokenizer 設計と special tokens 設計 (D4 + D8 で言及した `{en-span}` / `{jp-span}` marker) の empirical 検証工数が増える。
+- **model complexity が増す (multi-language vocabulary + context span 管理)**: 単一言語 (JP) を想定した vocabulary から JP + EN 両対応の vocabulary へ拡張する必要があり、tokenizer 設計と special tokens 設計 (D4 + D8 で言及した `<en-span>` / `<jp-span>` marker) の empirical 検証工数が増える。
 - **評価 fixture に mixed ケースを追加する必要がある**: Phase 5 spec §6 の smoke / regression / golden / typo robustness の 4 fixture に加え、「row 3 系 synonym bias + commit / pull request 等 programming context + 一般 loanword context」の 3 カテゴリを mixed fixture として新設する。測定項目 (EN 単語の英字出力 F1 / JP span の変換精度 / space handling 正答率) も追加する。
 
 ## Alternatives considered
@@ -184,9 +187,9 @@ training data は以下 2 源から構成する mixed コーパスで補強す�
 
 ### E. Tier 2 採用 (Shift → EN sticky mode) + Phase 0 ADR 0002 の InputMode 拡張
 
-Phase 5 custom model で Tier 1 (D8 の language-context detection) が empirical に達成困難と判明した場合の fallback として、新 variant `InputMode::Latin` を Phase 0 input state machine に追加する案である。ADR 0002 が決定した「Transient vs Sticky」の判断を拡張し、Shift 起動で Latin に入り明示的に Hiragana へ戻るまで EN 入力を継続する Sticky 挙動を採用する。行内 EN span (C4) と行末 Transient (ADR 0002) の両要件を共存させる必要から、Direct (Phase 0 で実装済、行末 Transient 専用) と Latin (新規、行内 Sticky 専用) は別モードとして分離する。
+Phase 5 custom model で Tier 1 (D8 の language-context detection) が empirical に達成困難と判明した場合の fallback として、新 variant `InputMode::Latin` を Phase 0 input state machine に追加する案である。ADR 0002 が決定した「Transient vs Sticky」の判断を拡張し、Shift trigger 起動で Latin に入り明示的に Hiragana へ戻るまで EN 入力を継続する Sticky 挙動を採用する。行内 EN span (C4) と Shift trigger 起動の Transient Direct policy (ADR 0002) の両要件を共存させる必要から、Direct (Phase 0 で実装済、Shift trigger 起動時の Transient 専用) と Latin (新規、行内 Sticky 専用) は別モードとして分離する。
 
-**Status**: Tier 1 (Phase 5 model auto-detect) の empirical 検証後に判断する。Tier 1 成功なら本 Alternative E は不要、Tier 1 失敗なら本 Alternative E を ADR 0015 で正式採用する。**現時点では Rejected**、Phase 5 model の学習可能性を優先検証する。
+**Status**: Tier 1 (Phase 5 custom model の auto-detect) の empirical 検証を優先する。Phase 5 spec §8 Q7 の最低基準 **F1 ≥ 0.90** を P5-A kick-off 前の PoC で達成できる見込みならば本 Alternative E は永続的 Rejected とする。F1 < 0.90 で baseline が届かない場合は ADR 0015 で本 Alternative E を正式採用として昇格する。**現時点 (PR #89 時点) では Rejected**、Phase 5 model の学習可能性を優先検証する。
 
 ### F. Dictionary (Phase 2) のみで英語 loanword を辞書 lookup 解決
 

--- a/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
+++ b/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
@@ -70,6 +70,16 @@ Phase 5 は以下 4 点を同時解決する。
 - **G3**: partial-input 対応 (`s` / `sh` / `si` 等の prefix から top-k 候補を即時算出)
 - **G4**: context-aware 変換 (周辺テキストを special token で注入し同音異義の曖昧性を解決)
 
+### 1.5 Mixed JP/EN 入力要件 (Phase 5 primary goal 追加)
+
+プログラマおよび技術ライター use case では、日本語と英語が 1 行内で混在する入力 (例: `tuginocommitwoshuuseisitepull requestwodasite` → 「次のcommitを修正してpull requestを出して」) を自然に処理する要件が本 Phase の primary goal に追加された (ADR 0010 C4 / D8)。本要件は Phase 1 row 3 (§1.1) と同系統の LLM ICL 限界事例であり、汎用 instruction-tuned LLM の prompt 指示では context 依存の言語判定を安定させるのが困難であるため、Phase 5 custom model の context-aware fine-tune で根本解決する方針を取る。
+
+Phase 5 は §1.4 の G1-G4 に加え、以下 3 点を G5-G7 として追加する。詳細は §3.5 と §4.7 を参照する。
+
+- **G5**: language-context detection (input romaji stream 中で JP / EN boundary を decoder hidden state で暗黙判定)
+- **G6**: context-aware space handling (space を word separator と変換 trigger の両義として context で解釈)
+- **G7**: mixed output generation (単一推論 pass で JP 部 = kanji / kana surface、EN 部 = ASCII 文字列を混在 decode)
+
 詳細は Phase 5 kick-off で確定する。
 
 ## 2. スコープ
@@ -155,6 +165,34 @@ Phase 5 の実装範囲は以下 5 項目とする。
 
 詳細は Phase 5 kick-off で確定する。
 
+### 3.5 Mixed JP/EN handling
+
+§1.5 の G5-G7 要件を実現するためのアーキテクチャ設計を本節にまとめる。ADR 0010 D8 に対応する spec 層の記述である。
+
+#### 3.5.1 Language-context detection
+
+Phase 5 モデルは input romaji stream を prefix から逐次 consume し、各位置で「現在 EN span 中か JP 変換対象か」を decoder の hidden state に保持する。boundary の推定は空白 / punctuation / 語彙 plausibility (当該 prefix が EN 単語の初頭に一致するか、JP kana 列に展開可能か) の複合信号で行う。
+
+実装方式として、(a) 明示的 classifier head を decoder に追加する案と、(b) decoder の hidden state に暗黙学習で担わせる案の 2 候補があるが、Phase 5 の default 方針は (b) 暗黙学習とする。(a) は debug しやすい一方で model parameter を分裂させ training 難度を上げるため、(b) が成立しない場合の fallback とする。
+
+詳細 (hidden state dim / training loss 構成 / 暗黙学習 vs 明示 classifier の empirical 比較) は Phase 5 kick-off で確定する。
+
+#### 3.5.2 Context-aware space handling
+
+Phase 5 モデルは space 文字を単一意味の変換 trigger として扱わず、「EN 文脈では word separator、JP 文脈では区切り記号 (変換 boundary hint)」の 2 義として context で解釈する。training data 側は space を含む mixed sentence を十分 sampling することで学習分布内に含める (§4.7 参照)。
+
+既存 Phase 1 IME input layer (`kotoha-core::input`) との調整として、「space event を IME layer で前処理してモデルに渡す / space event を生のまま decoder に渡す」の 2 方式が成立する。前者は既存 IME 層の挙動を変えないで済む利点、後者は model 側の context 判定に space 前後の情報を全部委ねる利点がある。Phase 5 kick-off で empirical に確定する。
+
+詳細は Phase 5 kick-off で確定する。
+
+#### 3.5.3 Mixed output generation
+
+Phase 5 モデルは単一推論 pass で JP 部 (kanji / kana surface) と EN 部 (ASCII 文字列) を混在させた 1 本の出力列を decode する。2 パス方式 (JP decode → EN overlay) は採用しない (context の整合性を単一 pass で保証するため)。
+
+明示的 span marker として `{en-span}` / `{jp-span}` を special tokens に追加する案と、暗黙で通す (marker なし、hidden state と出力 surface の連動で判別) 案の 2 候補がある。明示 marker は debug しやすく再現性が高い一方で、training data の構築工数と output decode の後処理工数が増える。Phase 5 kick-off で empirical 比較する。
+
+詳細は Phase 5 kick-off で確定する。
+
 ## 4. データ設計
 
 ### 4.1 コーパス source とライセンス
@@ -228,6 +266,63 @@ Phase 5 の拡張 special tokens 候補は以下 3 種を検討する。
 ### 4.6 データ scale
 
 目標は 1M〜10M kana→kanji ペアである。B1 scratch training では 10M+ ペアが必要と推定し、B3 distillation では 1M〜3M ペアで teacher の soft label を引き継げる想定である。最終 scale は Phase 5 kick-off 時の empirical pilot で確定する。
+
+### 4.7 Mixed JP/EN コーパス設計
+
+§3.5 の G5-G7 要件を学習分布内に持ち込むため、Phase 5 の training data は JP-only コーパス (§4.1) に加えて以下 2 種類の mixed 源を追加する。ADR 0010 D8 に対応する data 層の記述である。
+
+#### 4.7.1 Programming context source
+
+プログラマ use case (`tuginocommitwoshuuseisitepull requestwodasite` 系) の学習源として以下を候補とする。各源は再配布可能ライセンス (Apache-2.0 / MIT / CC BY 相当) であることを前提とし、採用可否は Phase 5 kick-off のライセンス審査で個別判定する。
+
+- GitHub issues / pull request 本文 (GitHub API 経由で抽出、repository 単位でライセンス確認)
+- commit messages (同上)
+- OSS README (Apache-2.0 / MIT / BSD license の repository のみ)
+- 技術 blog (Zenn / Qiita 等、各 platform の利用規約に基づく範囲)
+- 技術書 (O'Reilly 等、明示パーミッション必須)
+
+詳細 (具体的 repository 候補 / 抽出 pipeline / ライセンス審査フロー) は Phase 5 kick-off で確定する。
+
+#### 4.7.2 一般 loanword context source
+
+プログラマ以外の一般ユーザが使う日常的な英語借用語 (technology / IT / business / culture / 科学 カテゴリ) の学習源として以下を候補とする。
+
+- Wikipedia JP の technology / IT / business / culture / 科学 カテゴリ (CC BY-SA 3.0)
+- 青空文庫 (Public Domain、古典日本語だが歴史的 loanword を含む)
+
+詳細 (カテゴリ単位の抽出 / filter 条件 / サンプリング比率) は Phase 5 kick-off で確定する。
+
+#### 4.7.3 データ比率 (初期案)
+
+mixed コーパスと JP-only コーパスの混合比率は Phase 5 kick-off で empirical 確定するが、初期案として以下を置く。
+
+| 区分 | 比率 | 用途 |
+|---|---|---|
+| JP-only | 60% | §1.4 G1-G4 (kana→kanji 基本変換) を安定学習する主源 |
+| Mixed (JP + EN) | 30% | §1.5 G5-G7 (mixed JP/EN 判定) を学習分布内に含める主源 |
+| EN-only | 10% | EN 単独入力時の退化動作 (kana 変換せず ASCII 透過) を担保する補助源 |
+
+初期案の根拠は「JP-only を過半に保ちつつ mixed を無視できない比率で混ぜる」という経験則であり、P5-A kick-off の pilot training で比率を empirical 再確定する。詳細は Phase 5 kick-off で確定する。
+
+#### 4.7.4 Romaji 拡張規則 (mixed コーパス向け)
+
+Mixed コーパスは JP 部と EN 部が混在するため、§4.2 の kana→romaji 拡張規則を以下のように拡張する。
+
+- **JP 部**: 既存の Hepburn / Kunrei / waapuro 3 方式をそのまま適用する
+- **EN 部**: 原文の EN 単語をそのまま keep する (kana 変換 / 再拡張は行わない)
+- **境界処理**: JP 部と EN 部の境界に挿入する space は training data 上では明示的に 1 文字分保持する (context-aware space handling §3.5.2 が学習分布内で space を sample するため)
+
+詳細は Phase 5 kick-off で確定する。
+
+#### 4.7.5 Typo 注入規則 (mixed コーパス向け)
+
+§4.3 の typo 注入規則 (edit distance 1-3、隣接キー置換 / 文字転倒 / 文字欠落 / 文字余剰) を mixed コーパスに適用する際のルールを以下に定める。
+
+- EN 部にも QWERTY 隣接 typo を適用可能 (programmer が EN 部でも typo する現実を反映)
+- ただし typo の置換範囲は EN 語彙内に限定する (EN 部の 1 文字が JP 部境界を越えて置換されることは無い)
+- JP 部の typo ルールは §4.3 と同一
+
+詳細 (typo 注入率が JP 部 / EN 部で異なるか、境界領域の扱い) は Phase 5 kick-off で確定する。
 
 ## 5. 学習戦略
 
@@ -317,10 +412,11 @@ Phase 5 のスコープから以下を明示的に除外する。
 - **multilingual extension**: 英語 / 中国語 / 韓国語 入力対応は Phase 8 以降の別議論とする
 - **streaming inference**: 現行 Phase 5 は single-shot 推論のみを扱う。streaming が必要となった場合は Phase 6 着手時点で別 ADR を起こして判断する
 - **training infrastructure の CI 化**: Phase 5 は手動 training を前提とする。CI-driven 差分再学習は Phase 6 以降
+- **多言語完全対応 (中国語 / 韓国語 / ドイツ語 / フランス語 等)**: Phase 5 は JP + EN の 2 言語のみをサポートする。ADR 0010 D8 で Phase 5 primary goal に追加したのは mixed JP/EN に限定しており、他言語 (CJK 系 / 欧州言語) への拡張は Phase 5 scope 外である。将来 Phase で他言語を追加する場合は新 ADR を起票し、training data と vocabulary を拡張する必要がある。
 
 ## 8. Open questions
 
-Phase 5 kick-off 時点で解消する 6 点を以下に列挙する。
+Phase 5 kick-off 時点で解消する 7 点を以下に列挙する。
 
 | # | Question | 解消 milestone |
 |---|---|---|
@@ -330,6 +426,17 @@ Phase 5 kick-off 時点で解消する 6 点を以下に列挙する。
 | Q4 | 量子化精度を Q5_K_M default として Q4_K_M / Q8_0 をどう扱うか | Phase 5 P5-C で empirical 比較 |
 | Q5 | Sudachi 辞書 fallback の integration layer を §3.4 の候補 a / b / c のいずれにするか | Phase 5 P5-C で empirical 比較 |
 | Q6 | user learning cache (Karukan の `learning.tsv` 相当) を Phase 5 に含めるか Phase 6 に延期するか | Phase 5 kick-off 初週で scope 判断 |
+| Q7 | mixed JP/EN auto-detect の empirical 達成率目標 (F1 0.90 / 0.95 / 0.99) | P5-A kick-off 前の empirical PoC で baseline 測定後に確定 |
+
+### Q7: mixed JP/EN auto-detect の empirical 達成率目標
+
+Phase 5 custom model で §1.5 / §3.5 の mixed JP/EN 自動判定の精度目標をどの水準に置くかを確定する必要がある。候補は以下 3 水準である。
+
+- **A**: EN 単語の英字出力 F1 ≥ 0.90 (Tier 1 成功の最低ライン。ユーザは多少の誤変換を reviewer で修正する前提で IME として実用可能)
+- **B**: EN 単語の英字出力 F1 ≥ 0.95 (reviewer 不要レベル。プログラマ use case で日常的に stress 無く使える)
+- **C**: EN 単語の英字出力 F1 ≥ 0.99 (ほぼ誤変換なし。Tier 1 の完全成功に相当)
+
+P5-A kick-off 前の empirical PoC で baseline を測定し、本 Open question を確定する。baseline が A 水準 (0.90) にも届かない場合は ADR 0010 Alternative E (Tier 2 採用、`InputMode::Latin` 新設) にフォールバックする判断を下す。
 
 詳細は Phase 5 kick-off で確定する。
 

--- a/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
+++ b/docs/superpowers/specs/2026-04-25-kotoha-phase-5-custom-model.md
@@ -80,7 +80,7 @@ Phase 5 は §1.4 の G1-G4 に加え、以下 3 点を G5-G7 として追加す
 - **G6**: context-aware space handling (space を word separator と変換 trigger の両義として context で解釈)
 - **G7**: mixed output generation (単一推論 pass で JP 部 = kanji / kana surface、EN 部 = ASCII 文字列を混在 decode)
 
-詳細は Phase 5 kick-off で確定する。
+§3.5 と §4.7 の下位節は本 PR 時点では stub であり、詳細パラメータ (boundary detection 精度、corpus 実比率、token 符号化) は Phase 5 kick-off で確定する。
 
 ## 2. スコープ
 
@@ -189,7 +189,7 @@ Phase 5 モデルは space 文字を単一意味の変換 trigger として扱�
 
 Phase 5 モデルは単一推論 pass で JP 部 (kanji / kana surface) と EN 部 (ASCII 文字列) を混在させた 1 本の出力列を decode する。2 パス方式 (JP decode → EN overlay) は採用しない (context の整合性を単一 pass で保証するため)。
 
-明示的 span marker として `{en-span}` / `{jp-span}` を special tokens に追加する案と、暗黙で通す (marker なし、hidden state と出力 surface の連動で判別) 案の 2 候補がある。明示 marker は debug しやすく再現性が高い一方で、training data の構築工数と output decode の後処理工数が増える。Phase 5 kick-off で empirical 比較する。
+明示的 span marker として `<en-span>` / `<jp-span>` を special tokens に追加する案と、暗黙で通す (marker なし、hidden state と出力 surface の連動で判別) 案の 2 候補がある。明示 marker は debug しやすく再現性が高い一方で、training data の構築工数と output decode の後処理工数が増える。Phase 5 kick-off で empirical 比較する。
 
 詳細は Phase 5 kick-off で確定する。
 

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -451,6 +451,27 @@
 - **対応する identifier**: 未実装 (Phase 5 kick-off で詳細化)
 - **備考**: P5-A PoC の scope 外。Phase 5 kick-off 時に比率と分割基準を確定する。
 
+### Mixed JP/EN input (JP/EN 混在入力)
+
+- **定義**: 日本語と英語が 1 行内で混在する romaji 入力ストリーム。例: `tuginocommitwoshuuseisitepull requestwodasite` はユーザー意図として「次のcommitを修正してpull requestを出して」を表し、`commit` / `pull request` は英字列のまま出力することが期待される。
+- **初出**: ADR 0010 C4 / D8 (Phase 5 primary goal に mixed JP/EN 要件追加) / Phase 5 spec §1.5 / §3.5
+- **対応する identifier**: Phase 5 custom model が context で判定する (explicit API は持たない予定、Phase 5 実装時に確定)
+- **備考**: Phase 0 ADR 0002 が扱う Shift-triggered Transient Direct モードとは異なり、本要件は「行内に EN span が挟まる」ケースを対象とする。Phase 5 custom model の language-context detection (§3.5.1) が primary 対応、Tier 2 fallback として `InputMode::Latin` 新設案 (ADR 0010 Alternative E、現時点 Rejected) を保持する。
+
+### Language-context detection (言語文脈検出)
+
+- **定義**: Phase 5 custom model が input romaji stream 中で JP (かな / 漢字変換対象) と EN (英字出力対象) の boundary を context で判定する内部機構。decoder の hidden state に「現在 EN span 中か JP 変換対象か」の状態を保持する。
+- **初出**: ADR 0010 D8 (Phase 5 primary goal) / Phase 5 spec §3.5.1
+- **対応する identifier**: Phase 5 custom model 内部 (Phase 5 decoder の hidden state、explicit API は持たない予定)
+- **備考**: 明示的 classifier head を decoder に追加する案ではなく、decoder hidden state の暗黙学習で担わせる方針を default とする (明示 classifier は fallback)。P5-A kick-off で empirical 妥当性を検証する。
+
+### Context-aware space (文脈依存 space)
+
+- **定義**: space 文字を単一意味の変換 trigger として扱わず、「EN 文脈では word separator、JP 文脈では区切り記号 (変換 boundary hint)」の 2 義として context で解釈する model-level semantics。
+- **初出**: ADR 0010 D8 / Phase 5 spec §3.5.2
+- **対応する identifier**: Phase 5 training data + Phase 5 decoder で学習 (explicit API なし、Phase 5 実装時に確定)
+- **備考**: Phase 0 / Phase 1 の IME input layer は space = 単純な区切りとして扱ったが、Phase 5 では model が context で space の扱いを切り替える。space event の「IME layer 前処理 vs 生のまま decoder に渡す」の選択は Phase 5 kick-off で empirical 確定する (spec §3.5.2)。
+
 ## 8. 参考実装・関連エコシステム
 
 ### Karukan (`togatoga/karukan`)


### PR DESCRIPTION
## Summary

Phase 5 (Kotoha custom romaji-base model) の primary goal に **mixed JP/EN 文脈の自動判定** を追加する純粋 docs 更新。Stream B (ISSUE #86, P5-A expansion) の前提。

### 背景

プログラマ / 技術ライターの日常入力として JP + EN 混在は普通。例: romaji \`tuginocommitwoshuuseisitepull requestwodasite\` は「次のcommitを修正してpull requestを出して」を意図。期待挙動:

1. 「commit」「pull request」は英字出力 (Shift 不要の自動判定)
2. 「pull request」内の space は word separator として保持 (変換 trigger ではない)
3. JP↔EN boundary を model が context で判定

Phase 1 row 3 と同系統の LLM ICL 限界事例であり、Phase 5 custom model 的な task-specific fine-tune で根本解決するのが正攻法 (汎用 LLM では解決困難)。

### 更新内容

**Commit 1 (\`b4ff507\`): ADR 0010 + Phase 5 spec + glossary 3 文書更新**

#### ADR 0010
- **Context C4** 追加: mixed JP/EN 要件、Phase 0 ADR 0002 との関係
- **Decision D8** 追加: Phase 5 primary goal として mixed JP/EN 自動判定 (language-context detection / context-aware space / mixed output generation の 3 機能)
- **Consequences** 追記: 正 3 項 (UX 根本改善 / Tier 2-3 mode 不要 / row 3 と同時解決) + 負 3 項 (corpus scope 拡大 / model complexity 増 / fixture 追加)
- **Alternatives E 追加**: Tier 2 採用 (InputMode::Latin) — Tier 1 失敗時の fallback、ADR 0015 で再判断、現時点 Rejected
- **Alternatives F 追加**: Phase 2 dictionary のみ — Rejected、「commit 動詞」vs「コミット」の文脈判定が辞書単体では困難
- **Related documents 追記**: Phase 0 ADR 0002、Phase 5 spec 該当節

#### Phase 5 spec
- **§1.5 新設**: mixed JP/EN 要件 (G5-G7 goal 追加)
- **§3.5 新設**: language-context detection / context-aware space / mixed output generation (3 sub-sections)
- **§4.7 新設**: mixed コーパス設計 (programming context / 一般 loanword / 60-30-10 ratio / romaji 拡張 / typo 注入) 5 sub-sections
- **§7 非スコープ** 追記: 多言語完全対応 (CJK 他 / 欧州) は Phase 5 scope 外
- **§8 Q7 追加**: mixed JP/EN auto-detect F1 目標 (0.90 / 0.95 / 0.99)

#### glossary.md
§7 に 3 entries 追加: Mixed JP/EN input / Language-context detection / Context-aware space

**Commit 2 (\`d0c769a\`): forward reference 訂正**
ADR 0010 Related documents 内の Phase 5 spec section 番号を実ファイル構造に合わせて訂正 (§9 Q7 → §8 Q7、§1 → §1.5)。

## Verification

- lefthook pre-commit (doc-naming): PASS
- lefthook pre-push (Rust build / clippy / test 175): PASS (docs-only、影響なし)
- cargo check: clean
- 3 文書の用語統一 (Mixed JP/EN input / Language-context detection / Context-aware space)

## Test plan

- [x] ADR / spec / glossary の用語統一
- [x] forward reference の section 番号整合
- [x] Phase 1 ADR 0002 との棲み分け明示 (Transient vs 行内 EN span の別要件)
- [x] Tier 1 (model) / Tier 2 (InputMode::Latin) / Tier 3 (明示 toggle) の 3 階層記述
- [ ] Reviewer: ADR 0010 C4 / D8 が既存 C1-C3 / D1-D7 と logic の飛躍なく接続されているか
- [ ] Reviewer: Alternative F の rejection rationale (commit 動詞 vs コミット) が妥当か
- [ ] Reviewer: Phase 5 spec §4.7 の corpus 比率 60/30/10 が初期案として適切か

## Stream B (ISSUE #86) への影響

本 PR merge 後、Stream B (P5-A expansion iteration 1) の scope を以下に拡張:
- 当初: partial-input + special tokens
- 拡張: partial-input + special tokens + **mixed JP/EN sampling** (fixture に EN-mixed 文を追加、sample.tsv で混在処理を PoC レベルで検証)

## References

- 親: ADR 0010 (Phase 5 方針) 既存、PR #78 \`7e74556\`
- Phase 5 spec 既存: PR #78 で起票、stub 状態
- 関連 ADR: 0002 (input mode Tier 2 の基盤)、0014 (Phase 2 dictionary、Alternative F で言及)

🤖 Generated with [Claude Code](https://claude.com/claude-code)