### PR TITLE
feat(phase-2): P2-A — Dictionary layer kick-off (#91)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,12 +95,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -208,6 +223,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +292,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -406,9 +453,16 @@ version = "0.1.0"
 dependencies = [
  "llama-cpp-2",
  "proptest",
+ "sudachi",
  "thiserror 1.0.69",
  "tracing",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -477,6 +531,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -555,8 +618,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand",
@@ -694,6 +757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -761,6 +831,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "sudachi"
+version = "0.6.11"
+source = "git+https://github.com/WorksApplications/sudachi.rs?rev=90fd6068c80c#90fd6068c80c2fc3b63e0dbab0e341475bad4d8f"
+dependencies = [
+ "aho-corasick",
+ "bitflags",
+ "csv",
+ "fancy-regex",
+ "indexmap",
+ "itertools",
+ "lazy_static",
+ "libloading",
+ "memmap2",
+ "nom",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "unicode-normalization",
+ "yada",
+]
 
 [[package]]
 name = "syn"
@@ -827,6 +920,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +977,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -1076,6 +1193,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "yada"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ clap = { version = "4.5", features = ["derive"] }
 # Adopted reason: latest stable (0.1.145, MIT OR Apache-2.0, active maintainer).
 # Alternatives rejected per spec §3.1: llama_cpp-rs (stale 2y), mistral.rs (MSRV 1.88), Candle (orthogonal).
 llama-cpp-2 = "0.1"
+# sudachi.rs pinned via P2-A Q1 (brainstorming, 2026-04-25).
+# Adopted reason: SudachiDict-core を native Rust で読込可能、P5-A PoC と辞書整合、Apache-2.0。
+# Alternatives rejected per P2-A spec §3.1 Q1:
+#   - lindera: MeCab-IPADIC / UniDic 要求(UniDic は商用利用制約)
+#   - vibrato: SudachiDict native 非対応(short/middle/long unit 不可)
+#   - SudachiDict→MeCab 変換: WorksApplications 公式提供なし、精度保証なし
+sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }

--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ Phase 0 の canonical smoke test として `scripts/phase0-smoke.sh` を提供�
 ./scripts/phase0-smoke.sh
 ```
 
+## Phase 2 P2-A: SudachiDict-core の取得と配置
+
+Phase 2 P2-A の Dictionary backend は SudachiDict-core(v20260116、約 70MB、Apache-2.0)を runtime load で使用する。Kotoha は辞書を bundle しないため、ユーザー側で手動配置する必要がある(Phase 1 の `KOTOHA_LLAMA_MODEL_PATH` と同一 pattern の運用)。
+
+### 取得手順
+
+```bash
+# 1. SudachiDict-core を取得し展開
+mkdir -p ~/.local/share/sudachidict
+curl -L -o /tmp/sudachi-dict-core.zip \
+  https://github.com/WorksApplications/SudachiDict/releases/download/v20260116/sudachi-dictionary-20260116-core.zip
+unzip -j /tmp/sudachi-dict-core.zip 'sudachi-dictionary-20260116/system_core.dic' \
+  -d ~/.local/share/sudachidict/
+
+# 2. 環境変数を設定(~/.zshrc または ~/.bashrc に追記推奨)
+export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic
+```
+
+### 動作確認
+
+```bash
+# Layer 2 integration test(env var 不要、SudachiDict 不在でも実行可)
+cargo test --features dict -p kotoha-core --test kanji_dictionary_unit
+```
+
+Phase 2 範囲では辞書の auto-download を行わない(Phase 6 UX 段階で実装予定)。Layer 3 statistical evaluation(530-case golden fixture を実 SudachiDict 辞書で消費する経路)と `phase2-dict-smoke.sh` smoke runner は ISSUE #92 で別 PR にて実装予定であり、P2-A 段階では `--features dict-smoke` の test runner は未提供である。`KOTOHA_SYSTEM_DICT_PATH` 環境変数の事前設定は、ISSUE #92 enable 後の即時利用を想定した将来用準備として手順に含めている。
+
 ## 開発環境セットアップ
 
 本プロジェクトはローカルの Git hook(lefthook)で品質ゲートを担保する。CI/CD システムは導入していないため、**clone 後は必ず `lefthook install` を実行する**。

--- a/crates/kotoha-core/Cargo.toml
+++ b/crates/kotoha-core/Cargo.toml
@@ -14,6 +14,9 @@ tracing = { workspace = true }
 # `llama-cpp-2` is optional so default features do not pull in the C++ library and
 # its bindgen build step. Activated only when the `llama-cpp` feature is enabled.
 llama-cpp-2 = { workspace = true, optional = true }
+# `sudachi` is optional so default features do not pull in the git-sourced dep tree.
+# Activated only when the `dict` feature is enabled (P2-A spec §7.1).
+sudachi = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -32,3 +35,9 @@ llama-cpp = ["dep:llama-cpp-2"]
 # Kept separate from `llama-cpp` so that lefthook pre-push, which only runs
 # default features, does not attempt to load a real GGUF model.
 llama-cpp-smoke = ["llama-cpp"]
+# `dict` gates DictionaryBackend (SudachiDict baseline, P2-A spec §3.1 Q1).
+# default = [] を維持し ADR 0012 D5 整合。
+dict = ["dep:sudachi"]
+# `dict-smoke` is the opt-in gate for Layer 3 golden fixture (530 cases).
+# Kept separate from `dict` so lefthook pre-push does not attempt to load SudachiDict-core.
+dict-smoke = ["dict"]

--- a/crates/kotoha-core/resources/kotoha-dict.tsv
+++ b/crates/kotoha-core/resources/kotoha-dict.tsv
@@ -1,0 +1,8 @@
+# kotoha-dict.tsv — Kotoha custom vocabulary
+# Schema: surface<TAB>reading<TAB>pos<TAB>score
+# Curation policy (P2-A spec §3.7 Q7):
+#   1. SudachiDict-core baseline で recall 可能な語彙は追加しない
+#   2. golden fixture で観察される gap のみを証拠ベースで追加する
+#   3. 同 reading で SudachiDict が出す surface を上書きする entry は
+#      P2-B 以降で機械的多義性チェックを通すこと
+# (P2-A: 空 start。entry は後続 milestone で追加する)

--- a/crates/kotoha-core/src/dict/backend.rs
+++ b/crates/kotoha-core/src/dict/backend.rs
@@ -1,0 +1,3 @@
+//! `DictionaryBackend` struct (P2-A、`KanjiBackend` 実装)。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §4.3.

--- a/crates/kotoha-core/src/dict/backend.rs
+++ b/crates/kotoha-core/src/dict/backend.rs
@@ -1,3 +1,287 @@
 //! `DictionaryBackend` struct (P2-A、`KanjiBackend` 実装)。
 //!
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §4.3.
+
+use std::path::Path;
+
+use crate::dict::custom_vocab::CustomVocab;
+use crate::dict::engine::MorphologicalEngine;
+use crate::dict::sudachi_adapter::SudachiAdapter;
+use crate::dict::vocab::VocabularyLookup;
+use crate::dict::{resolve_dict_path, DictionaryConfig};
+use crate::kanji::backend::{score_sort_dedupe, validate_input};
+use crate::kanji::{Candidate, ConvertOptions, KanjiBackend, KanjiError};
+
+/// Dictionary-based kanji conversion backend.
+///
+/// `KanjiBackend` の P2-A 実装。`MorphologicalEngine` を 1 本、
+/// `VocabularyLookup` を 0..N 本注入し、`convert` で両者の結果を merge した後、
+/// 既存の `score_sort_dedupe` で sort + dedupe + truncate する。
+///
+/// # Invariants
+///
+/// - `engine` は `load` または `from_parts` で 1 本注入される
+/// - `vocab_sources` は 0 本以上の `VocabularyLookup` 実装を保持する
+/// - `model_id` は `"dictionary({engine_id})"` 形式で固定する
+pub struct DictionaryBackend {
+    engine: Box<dyn MorphologicalEngine>,
+    vocab_sources: Vec<Box<dyn VocabularyLookup>>,
+    model_id: String,
+}
+
+impl std::fmt::Debug for DictionaryBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DictionaryBackend")
+            .field("engine_id", &self.engine.engine_id())
+            .field("vocab_count", &self.vocab_sources.len())
+            .field("model_id", &self.model_id)
+            .finish()
+    }
+}
+
+impl DictionaryBackend {
+    /// Loads a `DictionaryBackend` from a `DictionaryConfig`.
+    ///
+    /// `system_dict_path` resolution order:
+    ///
+    /// 1. `config.system_dict_path` if `Some`
+    /// 2. `KOTOHA_SYSTEM_DICT_PATH` env var if set
+    /// 3. otherwise return [`KanjiError::ModelNotFound`] with empty path
+    ///
+    /// # Errors
+    ///
+    /// - [`KanjiError::ModelNotFound`] — neither explicit nor env path resolves,
+    ///   or the resolved system dict file does not exist
+    /// - [`KanjiError::ModelLoadFailed`] — sudachi.rs fails to load the dict
+    /// - [`KanjiError::Backend`] — custom vocab TSV cannot be read or parsed
+    pub fn load(config: &DictionaryConfig) -> Result<Self, KanjiError> {
+        let env_value = std::env::var("KOTOHA_SYSTEM_DICT_PATH").ok();
+        let Some(dict_path) = resolve_dict_path(config.system_dict_path.as_deref(), env_value)
+        else {
+            return Err(KanjiError::ModelNotFound {
+                path: Path::new("").to_path_buf(),
+            });
+        };
+        let engine = Box::new(SudachiAdapter::load(&dict_path)?);
+        let mut vocab_sources: Vec<Box<dyn VocabularyLookup>> = Vec::new();
+        if let Some(vp) = &config.custom_vocab_path {
+            vocab_sources.push(Box::new(CustomVocab::load(vp)?));
+        }
+        let model_id = format!("dictionary({})", engine.engine_id());
+        Ok(Self {
+            engine,
+            vocab_sources,
+            model_id,
+        })
+    }
+
+    /// Constructs a `DictionaryBackend` from already-built parts.
+    ///
+    /// Test-only injection point: tests pass `StubEngine` / `StubVocab` (or
+    /// the in-tree `MockEngine` / `MockVocab`) without going through disk I/O.
+    /// `#[doc(hidden)]` keeps the constructor out of the rendered rustdoc but
+    /// leaves it `pub` for cross-module test composition.
+    #[doc(hidden)]
+    pub fn from_parts(
+        engine: Box<dyn MorphologicalEngine>,
+        vocab_sources: Vec<Box<dyn VocabularyLookup>>,
+    ) -> Self {
+        let model_id = format!("dictionary({})", engine.engine_id());
+        Self {
+            engine,
+            vocab_sources,
+            model_id,
+        }
+    }
+}
+
+impl KanjiBackend for DictionaryBackend {
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError> {
+        validate_input(input)?;
+        if input.is_empty() || options.top_k == 0 {
+            return Ok(Vec::new());
+        }
+        let mut raw: Vec<Candidate> = Vec::new();
+        for ec in self.engine.tokenize(input)? {
+            raw.push(Candidate::new(ec.surface, ec.score));
+        }
+        for vocab in &self.vocab_sources {
+            for ve in vocab.lookup(input) {
+                raw.push(Candidate::new(ve.surface, ve.score));
+            }
+        }
+        Ok(score_sort_dedupe(raw, options.top_k))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dict::engine::{EngineCandidate, MorphologicalEngine};
+    use crate::dict::vocab::{VocabEntry, VocabularyLookup};
+    use crate::kanji::{ConvertOptions, KanjiBackend, KanjiError};
+
+    struct StubEngine {
+        canned: Vec<EngineCandidate>,
+    }
+
+    impl MorphologicalEngine for StubEngine {
+        fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError> {
+            if reading.is_empty() {
+                return Ok(Vec::new());
+            }
+            Ok(self.canned.clone())
+        }
+        fn engine_id(&self) -> &str {
+            "stub-engine"
+        }
+    }
+
+    struct StubVocab {
+        canned: Vec<VocabEntry>,
+    }
+
+    impl VocabularyLookup for StubVocab {
+        fn lookup(&self, reading: &str) -> Vec<VocabEntry> {
+            if reading.is_empty() {
+                Vec::new()
+            } else {
+                self.canned.clone()
+            }
+        }
+        fn vocab_id(&self) -> &str {
+            "stub-vocab"
+        }
+    }
+
+    fn backend_with(
+        engine_cands: Vec<EngineCandidate>,
+        vocab_cands: Vec<VocabEntry>,
+    ) -> DictionaryBackend {
+        DictionaryBackend::from_parts(
+            Box::new(StubEngine {
+                canned: engine_cands,
+            }),
+            vec![Box::new(StubVocab {
+                canned: vocab_cands,
+            })],
+        )
+    }
+
+    #[test]
+    fn dict_backend_rejects_non_hiragana_input() {
+        let b = backend_with(Vec::new(), Vec::new());
+        let err = b
+            .convert("abc", &ConvertOptions::default())
+            .expect_err("latin reject");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn dict_backend_empty_input_returns_empty_vec() {
+        let b = backend_with(Vec::new(), Vec::new());
+        let out = b.convert("", &ConvertOptions::default()).expect("empty ok");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn dict_backend_merges_engine_and_vocab_results() {
+        let b = backend_with(
+            vec![EngineCandidate {
+                surface: "漢字".into(),
+                reading: "かんじ".into(),
+                score: 0.5,
+            }],
+            vec![VocabEntry {
+                surface: "感じ".into(),
+                reading: "かんじ".into(),
+                pos: "動詞".into(),
+                score: 0.4,
+            }],
+        );
+        let out = b
+            .convert("かんじ", &ConvertOptions::default())
+            .expect("merge ok");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].surface, "漢字");
+        assert_eq!(out[1].surface, "感じ");
+    }
+
+    #[test]
+    fn dict_backend_dedupes_duplicate_surfaces_keeping_highest_score() {
+        let b = backend_with(
+            vec![EngineCandidate {
+                surface: "漢字".into(),
+                reading: "かんじ".into(),
+                score: 0.3,
+            }],
+            vec![VocabEntry {
+                surface: "漢字".into(),
+                reading: "かんじ".into(),
+                pos: "名詞".into(),
+                score: 0.9,
+            }],
+        );
+        let out = b
+            .convert("かんじ", &ConvertOptions::default())
+            .expect("dedupe ok");
+        assert_eq!(out.len(), 1);
+        assert!((out[0].score - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dict_backend_truncates_to_top_k() {
+        let engine_cands = (0..10)
+            .map(|i| EngineCandidate {
+                surface: format!("s{i}"),
+                reading: "かんじ".into(),
+                score: i as f32 / 10.0,
+            })
+            .collect();
+        let b = backend_with(engine_cands, Vec::new());
+        let opts = ConvertOptions {
+            top_k: 3,
+            temperature: 0.0,
+            seed: Some(0),
+        };
+        let out = b.convert("かんじ", &opts).expect("truncate ok");
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn dict_backend_top_k_zero_returns_empty() {
+        let b = backend_with(
+            vec![EngineCandidate {
+                surface: "漢字".into(),
+                reading: "かんじ".into(),
+                score: 0.9,
+            }],
+            Vec::new(),
+        );
+        let opts = ConvertOptions {
+            top_k: 0,
+            temperature: 0.0,
+            seed: Some(0),
+        };
+        let out = b.convert("かんじ", &opts).expect("empty ok");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn dict_backend_model_id_contains_engine_id() {
+        let b = backend_with(Vec::new(), Vec::new());
+        let id = b.model_id();
+        assert!(
+            id.contains("dictionary"),
+            "model_id should start with 'dictionary': {id}"
+        );
+        assert!(
+            id.contains("stub-engine"),
+            "model_id should embed engine_id: {id}"
+        );
+    }
+}

--- a/crates/kotoha-core/src/dict/backend.rs
+++ b/crates/kotoha-core/src/dict/backend.rs
@@ -2,8 +2,6 @@
 //!
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §4.3.
 
-use std::path::Path;
-
 use crate::dict::custom_vocab::CustomVocab;
 use crate::dict::engine::MorphologicalEngine;
 use crate::dict::sudachi_adapter::SudachiAdapter;
@@ -46,20 +44,25 @@ impl DictionaryBackend {
     ///
     /// 1. `config.system_dict_path` if `Some`
     /// 2. `KOTOHA_SYSTEM_DICT_PATH` env var if set
-    /// 3. otherwise return [`KanjiError::ModelNotFound`] with empty path
+    /// 3. otherwise return [`KanjiError::Backend`] with an actionable hint
     ///
     /// # Errors
     ///
-    /// - [`KanjiError::ModelNotFound`] — neither explicit nor env path resolves,
-    ///   or the resolved system dict file does not exist
+    /// - [`KanjiError::Backend`] — neither explicit path nor env var supplies
+    ///   a SudachiDict path; the error reason names both knobs the caller can
+    ///   set
+    /// - [`KanjiError::ModelNotFound`] — the resolved system dict file does
+    ///   not exist on disk
     /// - [`KanjiError::ModelLoadFailed`] — sudachi.rs fails to load the dict
     /// - [`KanjiError::Backend`] — custom vocab TSV cannot be read or parsed
     pub fn load(config: &DictionaryConfig) -> Result<Self, KanjiError> {
         let env_value = std::env::var("KOTOHA_SYSTEM_DICT_PATH").ok();
         let Some(dict_path) = resolve_dict_path(config.system_dict_path.as_deref(), env_value)
         else {
-            return Err(KanjiError::ModelNotFound {
-                path: Path::new("").to_path_buf(),
+            return Err(KanjiError::Backend {
+                reason: "no SudachiDict path: set KOTOHA_SYSTEM_DICT_PATH environment variable, \
+                    or pass DictionaryConfig::system_dict_path"
+                    .to_string(),
             });
         };
         let engine = Box::new(SudachiAdapter::load(&dict_path)?);

--- a/crates/kotoha-core/src/dict/custom_vocab.rs
+++ b/crates/kotoha-core/src/dict/custom_vocab.rs
@@ -20,13 +20,11 @@ use crate::kanji::KanjiError;
 /// - `entries` key は hiragana reading、value は同 reading を持つ entry 配列
 /// - `vocab_id` は `"custom(<source_label>)"` 形式
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
 pub struct CustomVocab {
     entries: HashMap<String, Vec<VocabEntry>>,
     vocab_id: String,
 }
 
-#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
 impl CustomVocab {
     /// Loads a custom vocab from a TSV file on disk.
     ///
@@ -45,13 +43,15 @@ impl CustomVocab {
         Self::parse(&content, &label)
     }
 
-    /// Parses a TSV string in-memory. Used directly by unit tests and by
-    /// `load` after reading from disk.
+    /// Parses a TSV string in-memory. Used directly by unit tests; production
+    /// callers go through [`CustomVocab::load`] which reads the TSV from disk
+    /// before delegating to `parse`.
     ///
     /// # Errors
     ///
     /// - [`KanjiError::Backend`] when any non-comment line has a field count
     ///   other than 4 or a non-parsable score.
+    #[cfg(test)]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(content: &str) -> Result<Self, KanjiError> {
         Self::parse(content, "inline")

--- a/crates/kotoha-core/src/dict/custom_vocab.rs
+++ b/crates/kotoha-core/src/dict/custom_vocab.rs
@@ -68,7 +68,7 @@ impl CustomVocab {
             if parts.len() != 4 {
                 return Err(KanjiError::Backend {
                     reason: format!(
-                        "malformed TSV line {} in '{}': expected 4 fields, got {}",
+                        "malformed TSV line {} in {:?}: expected 4 fields, got {}",
                         lineno + 1,
                         source_label,
                         parts.len()
@@ -77,11 +77,24 @@ impl CustomVocab {
             }
             let score: f32 = parts[3].parse().map_err(|e| KanjiError::Backend {
                 reason: format!(
-                    "malformed score on line {} in '{}': {e}",
+                    "malformed score on line {} in {:?}: {e}",
                     lineno + 1,
                     source_label
                 ),
             })?;
+            // NaN / +inf / -inf を弾く。`score_sort_dedupe` の sort 比較は
+            // `partial_cmp` で NaN を `Ordering::Equal` に丸めるため、
+            // NaN を含むと dedupe / 順序が非決定的になる。決定性確保のため
+            // load 時点で reject する(spec §5.7 と整合)。
+            if !score.is_finite() {
+                return Err(KanjiError::Backend {
+                    reason: format!(
+                        "non-finite score on line {} in {:?}: {score}",
+                        lineno + 1,
+                        source_label
+                    ),
+                });
+            }
             let entry = VocabEntry {
                 surface: parts[0].to_string(),
                 reading: parts[1].to_string(),
@@ -183,5 +196,27 @@ mod tests {
             "vocab_id should mention 'custom': {}",
             vocab.vocab_id()
         );
+    }
+
+    #[test]
+    fn custom_vocab_rejects_nan_score() {
+        let nan_tsv = "漢字\tかんじ\t名詞\tnan\n";
+        let err = CustomVocab::from_str(nan_tsv).expect_err("nan score must be rejected");
+        match err {
+            crate::kanji::KanjiError::Backend { reason } => {
+                assert!(
+                    reason.contains("non-finite") || reason.contains("malformed"),
+                    "error reason should mention non-finite or malformed: {reason}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_vocab_rejects_inf_score() {
+        let inf_tsv = "漢字\tかんじ\t名詞\tinf\n";
+        let err = CustomVocab::from_str(inf_tsv).expect_err("inf score must be rejected");
+        assert!(matches!(err, crate::kanji::KanjiError::Backend { .. }));
     }
 }

--- a/crates/kotoha-core/src/dict/custom_vocab.rs
+++ b/crates/kotoha-core/src/dict/custom_vocab.rs
@@ -1,3 +1,187 @@
 //! `CustomVocab`: `VocabularyLookup` の TSV reader 実装。
 //!
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §5.2.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use crate::dict::vocab::{VocabEntry, VocabularyLookup};
+use crate::kanji::KanjiError;
+
+/// Custom vocabulary source backed by a TSV file.
+///
+/// Schema: `surface<TAB>reading<TAB>pos<TAB>score`。
+/// 先頭 `#` の行および空行は comment として skip する。`score` は f32 として
+/// 解釈し、parse 失敗時は malformed line として reject する(spec §5.2)。
+///
+/// # Invariants
+///
+/// - `entries` key は hiragana reading、value は同 reading を持つ entry 配列
+/// - `vocab_id` は `"custom(<source_label>)"` 形式
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
+pub struct CustomVocab {
+    entries: HashMap<String, Vec<VocabEntry>>,
+    vocab_id: String,
+}
+
+#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
+impl CustomVocab {
+    /// Loads a custom vocab from a TSV file on disk.
+    ///
+    /// # Errors
+    ///
+    /// - [`KanjiError::Backend`] when the file cannot be read or parsed.
+    pub fn load(path: &Path) -> Result<Self, KanjiError> {
+        let content = fs::read_to_string(path).map_err(|e| KanjiError::Backend {
+            reason: format!("failed to read custom vocab {}: {e}", path.display()),
+        })?;
+        let label = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        Self::parse(&content, &label)
+    }
+
+    /// Parses a TSV string in-memory. Used directly by unit tests and by
+    /// `load` after reading from disk.
+    ///
+    /// # Errors
+    ///
+    /// - [`KanjiError::Backend`] when any non-comment line has a field count
+    ///   other than 4 or a non-parsable score.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(content: &str) -> Result<Self, KanjiError> {
+        Self::parse(content, "inline")
+    }
+
+    fn parse(content: &str, source_label: &str) -> Result<Self, KanjiError> {
+        let mut entries: HashMap<String, Vec<VocabEntry>> = HashMap::new();
+        for (lineno, raw) in content.lines().enumerate() {
+            let line = raw.trim_end_matches('\r');
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() != 4 {
+                return Err(KanjiError::Backend {
+                    reason: format!(
+                        "malformed TSV line {} in '{}': expected 4 fields, got {}",
+                        lineno + 1,
+                        source_label,
+                        parts.len()
+                    ),
+                });
+            }
+            let score: f32 = parts[3].parse().map_err(|e| KanjiError::Backend {
+                reason: format!(
+                    "malformed score on line {} in '{}': {e}",
+                    lineno + 1,
+                    source_label
+                ),
+            })?;
+            let entry = VocabEntry {
+                surface: parts[0].to_string(),
+                reading: parts[1].to_string(),
+                pos: parts[2].to_string(),
+                score,
+            };
+            entries
+                .entry(entry.reading.clone())
+                .or_default()
+                .push(entry);
+        }
+        // 同 reading 内を score 降順に保持しておく(lookup で再 sort しないため)
+        for vs in entries.values_mut() {
+            vs.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+        }
+        Ok(Self {
+            entries,
+            vocab_id: format!("custom({source_label})"),
+        })
+    }
+}
+
+impl VocabularyLookup for CustomVocab {
+    fn lookup(&self, reading: &str) -> Vec<VocabEntry> {
+        self.entries.get(reading).cloned().unwrap_or_default()
+    }
+
+    fn vocab_id(&self) -> &str {
+        &self.vocab_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EMPTY_TSV: &str = "# comment only\n# no entries\n";
+    const SINGLE_ENTRY_TSV: &str = "漢字\tかんじ\t名詞\t0.85\n";
+    const MULTI_ENTRY_TSV: &str = "\
+# header comment
+漢字\tかんじ\t名詞\t0.85
+感じ\tかんじ\t動詞\t0.45
+";
+    // surface / reading / pos / score のいずれかが欠けた行は reject 対象。
+    const MALFORMED_TSV: &str = "漢字\tかんじ\t名詞\n";
+
+    #[test]
+    fn custom_vocab_empty_tsv_yields_no_entries() {
+        let vocab = CustomVocab::from_str(EMPTY_TSV).expect("empty TSV must load");
+        assert!(vocab.lookup("かんじ").is_empty());
+    }
+
+    #[test]
+    fn custom_vocab_single_entry_can_be_looked_up() {
+        let vocab = CustomVocab::from_str(SINGLE_ENTRY_TSV).expect("single TSV must load");
+        let result = vocab.lookup("かんじ");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "漢字");
+        assert_eq!(result[0].pos, "名詞");
+    }
+
+    #[test]
+    fn custom_vocab_skips_comment_lines() {
+        let vocab = CustomVocab::from_str(MULTI_ENTRY_TSV).expect("multi TSV must load");
+        let result = vocab.lookup("かんじ");
+        assert_eq!(result.len(), 2, "2 non-comment entries expected");
+    }
+
+    #[test]
+    fn custom_vocab_rejects_malformed_line() {
+        let err = CustomVocab::from_str(MALFORMED_TSV).expect_err("malformed TSV must be rejected");
+        // 受容契約: backend 層の KanjiError::Backend へ折り畳み、reason に "malformed" を含める
+        match err {
+            crate::kanji::KanjiError::Backend { reason } => {
+                assert!(
+                    reason.contains("malformed") || reason.contains("fields"),
+                    "error reason should mention malformed line: {reason}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_vocab_returns_empty_for_unknown_reading() {
+        let vocab = CustomVocab::from_str(SINGLE_ENTRY_TSV).expect("single TSV must load");
+        assert!(vocab.lookup("みず").is_empty());
+    }
+
+    #[test]
+    fn custom_vocab_vocab_id_contains_source_label() {
+        let vocab = CustomVocab::from_str(EMPTY_TSV).expect("empty TSV must load");
+        assert!(
+            vocab.vocab_id().contains("custom"),
+            "vocab_id should mention 'custom': {}",
+            vocab.vocab_id()
+        );
+    }
+}

--- a/crates/kotoha-core/src/dict/custom_vocab.rs
+++ b/crates/kotoha-core/src/dict/custom_vocab.rs
@@ -1,0 +1,3 @@
+//! `CustomVocab`: `VocabularyLookup` の TSV reader 実装。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §5.2.

--- a/crates/kotoha-core/src/dict/engine.rs
+++ b/crates/kotoha-core/src/dict/engine.rs
@@ -1,3 +1,115 @@
 //! `MorphologicalEngine` trait と `EngineCandidate` 値型の定義。
 //!
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.5, §4.2.1.
+
+use crate::kanji::KanjiError;
+
+/// 形態素解析 engine の抽象境界。
+///
+/// `DictionaryBackend` は `Box<dyn MorphologicalEngine>` を field に保持する。
+/// P2-A は `SudachiAdapter` のみが本 trait を実装する。Phase 5 以降で vibrato /
+/// lindera 等への置換時に `DictionaryBackend` の変更を最小化する目的で先出し
+/// する(spec §3.5 / §4.2.1)。
+///
+/// # Preconditions
+///
+/// - `reading` は `KanjiBackend` 契約 §5.6 と同じ hiragana 文字列
+///   (U+3040..=U+309F + U+30FC)
+/// - `reading.chars().count() <= 128`
+///
+/// # Postconditions
+///
+/// - 返値は `reading` を tokenize した候補列
+/// - 同一 reading に対し複数 surface があり得る(homophone)
+/// - `score` は engine 実装が付与(`SudachiAdapter` は cost を score に変換)
+///
+/// # Errors
+///
+/// - [`KanjiError::Backend`] when tokenization fails inside the engine
+#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
+pub trait MorphologicalEngine {
+    /// Tokenizes `reading` and returns candidate morphemes.
+    fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError>;
+
+    /// Returns a stable, human-readable identifier for the engine instance.
+    ///
+    /// Used by `DictionaryBackend::model_id()` to format the composite model id
+    /// (e.g. `"dictionary(sudachi-0.6.11)"`).
+    fn engine_id(&self) -> &str;
+}
+
+/// A single morpheme candidate returned by [`MorphologicalEngine::tokenize`].
+#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
+#[derive(Debug, Clone)]
+pub struct EngineCandidate {
+    /// Surface form (kanji / hiragana / katakana mix).
+    pub surface: String,
+    /// Reading (hiragana) of `surface`.
+    pub reading: String,
+    /// Score; larger is better. `SudachiAdapter` converts Sudachi cost into
+    /// a descending-order score.
+    pub score: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kanji::KanjiError;
+
+    /// tests 内専用の MockEngine。trait contract を external に lock-in する。
+    struct MockEngine {
+        canned: Vec<EngineCandidate>,
+    }
+
+    impl MorphologicalEngine for MockEngine {
+        fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError> {
+            if reading.is_empty() {
+                return Ok(Vec::new());
+            }
+            Ok(self.canned.clone())
+        }
+
+        fn engine_id(&self) -> &str {
+            "mock-engine"
+        }
+    }
+
+    #[test]
+    fn engine_candidate_new_holds_surface_reading_score() {
+        let ec = EngineCandidate {
+            surface: "日本語".to_string(),
+            reading: "にほんご".to_string(),
+            score: 0.9,
+        };
+        assert_eq!(ec.surface, "日本語");
+        assert_eq!(ec.reading, "にほんご");
+        assert!((ec.score - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mock_engine_returns_canned_candidates() {
+        let engine = MockEngine {
+            canned: vec![EngineCandidate {
+                surface: "日本語".to_string(),
+                reading: "にほんご".to_string(),
+                score: 0.9,
+            }],
+        };
+        let result = engine.tokenize("にほんご").expect("tokenize succeeds");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "日本語");
+    }
+
+    #[test]
+    fn mock_engine_empty_input_returns_empty() {
+        let engine = MockEngine { canned: Vec::new() };
+        let result = engine.tokenize("").expect("empty input must be accepted");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn mock_engine_engine_id_is_stable() {
+        let engine = MockEngine { canned: Vec::new() };
+        assert_eq!(engine.engine_id(), "mock-engine");
+    }
+}

--- a/crates/kotoha-core/src/dict/engine.rs
+++ b/crates/kotoha-core/src/dict/engine.rs
@@ -26,7 +26,6 @@ use crate::kanji::KanjiError;
 /// # Errors
 ///
 /// - [`KanjiError::Backend`] when tokenization fails inside the engine
-#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
 pub trait MorphologicalEngine {
     /// Tokenizes `reading` and returns candidate morphemes.
     fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError>;
@@ -39,7 +38,6 @@ pub trait MorphologicalEngine {
 }
 
 /// A single morpheme candidate returned by [`MorphologicalEngine::tokenize`].
-#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
 #[derive(Debug, Clone)]
 pub struct EngineCandidate {
     /// Surface form (kanji / hiragana / katakana mix).

--- a/crates/kotoha-core/src/dict/engine.rs
+++ b/crates/kotoha-core/src/dict/engine.rs
@@ -1,0 +1,3 @@
+//! `MorphologicalEngine` trait と `EngineCandidate` 値型の定義。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.5, §4.2.1.

--- a/crates/kotoha-core/src/dict/mod.rs
+++ b/crates/kotoha-core/src/dict/mod.rs
@@ -8,8 +8,104 @@
 //! `MorphologicalEngine` / `VocabularyLookup` 2 本の trait で engine 切替を
 //! 抽象化する(Clean Architecture DIP、spec §4.2)。
 
+use std::path::{Path, PathBuf};
+
+// pub use self::backend::DictionaryBackend; // Task 8 で uncomment(struct 未定義のため)
+pub use self::engine::{EngineCandidate, MorphologicalEngine};
+pub use self::vocab::{VocabEntry, VocabularyLookup};
+
+/// Engine 非依存の Dictionary backend 設定(spec §3.4 Q4)。
+///
+/// 将来 engine を vibrato / lindera に置換しても config 互換性を保つため、
+/// field 名に engine 名を含めない(`sudachi_dict_path` ではなく `system_dict_path`)。
+///
+/// # Invariants
+///
+/// - `system_dict_path` が `None` の場合、`DictionaryBackend::load` は
+///   `KOTOHA_SYSTEM_DICT_PATH` 環境変数を読みに行く
+/// - `custom_vocab_path` が `None` の場合、backend は custom vocab を持たない
+#[derive(Debug, Clone, Default)]
+pub struct DictionaryConfig {
+    /// 形態素解析用 system dictionary file のパス(SudachiDict-core `system_core.dic`)。
+    pub system_dict_path: Option<PathBuf>,
+    /// Custom vocabulary TSV file のパス(`kotoha-dict.tsv`)。
+    pub custom_vocab_path: Option<PathBuf>,
+}
+
+/// 明示 path、次点で env var、どちらも無ければ `None` を返す解決ヘルパ。
+///
+/// `DictionaryBackend::load` は本関数で `system_dict_path` を解決する。
+/// `env_value` 引数は test 容易性のため `std::env::var` の結果を呼び出し側が
+/// 注入する契約にする(spec §3.4 / §5.1)。
+#[allow(dead_code)] // Task 7 (SudachiAdapter) / Task 8 (DictionaryBackend) で使用
+pub(crate) fn resolve_dict_path(
+    explicit: Option<&Path>,
+    env_value: Option<String>,
+) -> Option<PathBuf> {
+    if let Some(p) = explicit {
+        return Some(p.to_path_buf());
+    }
+    env_value.map(PathBuf::from)
+}
+
 pub(crate) mod backend;
 pub(crate) mod custom_vocab;
 pub(crate) mod engine;
 pub(crate) mod sudachi_adapter;
 pub(crate) mod vocab;
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn dictionary_config_default_is_none_paths() {
+        let cfg = DictionaryConfig::default();
+        assert!(cfg.system_dict_path.is_none());
+        assert!(cfg.custom_vocab_path.is_none());
+    }
+
+    #[test]
+    fn dictionary_config_clone_preserves_fields() {
+        let cfg = DictionaryConfig {
+            system_dict_path: Some(PathBuf::from("/tmp/system_core.dic")),
+            custom_vocab_path: Some(PathBuf::from("/tmp/kotoha-dict.tsv")),
+        };
+        let cloned = cfg.clone();
+        assert_eq!(cloned.system_dict_path, cfg.system_dict_path);
+        assert_eq!(cloned.custom_vocab_path, cfg.custom_vocab_path);
+    }
+
+    #[test]
+    fn dictionary_config_debug_contains_field_names() {
+        let cfg = DictionaryConfig {
+            system_dict_path: Some(PathBuf::from("/tmp/system_core.dic")),
+            custom_vocab_path: None,
+        };
+        let msg = format!("{cfg:?}");
+        assert!(
+            msg.contains("system_dict_path"),
+            "Debug must expose field names: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_dict_path_prefers_explicit_over_env() {
+        let explicit = PathBuf::from("/tmp/explicit.dic");
+        let resolved = resolve_dict_path(Some(&explicit), None);
+        assert_eq!(resolved, Some(PathBuf::from("/tmp/explicit.dic")));
+    }
+
+    #[test]
+    fn resolve_dict_path_falls_back_to_env_var() {
+        let resolved = resolve_dict_path(None, Some("/tmp/env.dic".to_string()));
+        assert_eq!(resolved, Some(PathBuf::from("/tmp/env.dic")));
+    }
+
+    #[test]
+    fn resolve_dict_path_returns_none_when_both_absent() {
+        let resolved = resolve_dict_path(None, None);
+        assert!(resolved.is_none());
+    }
+}

--- a/crates/kotoha-core/src/dict/mod.rs
+++ b/crates/kotoha-core/src/dict/mod.rs
@@ -37,7 +37,6 @@ pub struct DictionaryConfig {
 /// `DictionaryBackend::load` は本関数で `system_dict_path` を解決する。
 /// `env_value` 引数は test 容易性のため `std::env::var` の結果を呼び出し側が
 /// 注入する契約にする(spec §3.4 / §5.1)。
-#[allow(dead_code)] // Task 7 (SudachiAdapter) / Task 8 (DictionaryBackend) で使用
 pub(crate) fn resolve_dict_path(
     explicit: Option<&Path>,
     env_value: Option<String>,

--- a/crates/kotoha-core/src/dict/mod.rs
+++ b/crates/kotoha-core/src/dict/mod.rs
@@ -1,0 +1,15 @@
+//! Dictionary-based kanji conversion backend (Phase 2 P2-A).
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md`.
+//!
+//! この module は P2-A で追加された `KanjiBackend` の 2 つ目の実装
+//! (`LlamaCppBackend` に続く)を提供する。SudachiDict-core を
+//! `sudachi.rs` 経由で runtime load する Dictionary backend を中核とし、
+//! `MorphologicalEngine` / `VocabularyLookup` 2 本の trait で engine 切替を
+//! 抽象化する(Clean Architecture DIP、spec §4.2)。
+
+pub(crate) mod backend;
+pub(crate) mod custom_vocab;
+pub(crate) mod engine;
+pub(crate) mod sudachi_adapter;
+pub(crate) mod vocab;

--- a/crates/kotoha-core/src/dict/mod.rs
+++ b/crates/kotoha-core/src/dict/mod.rs
@@ -10,7 +10,7 @@
 
 use std::path::{Path, PathBuf};
 
-// pub use self::backend::DictionaryBackend; // Task 8 で uncomment(struct 未定義のため)
+pub use self::backend::DictionaryBackend;
 pub use self::engine::{EngineCandidate, MorphologicalEngine};
 pub use self::vocab::{VocabEntry, VocabularyLookup};
 

--- a/crates/kotoha-core/src/dict/sudachi_adapter.rs
+++ b/crates/kotoha-core/src/dict/sudachi_adapter.rs
@@ -1,3 +1,145 @@
 //! `SudachiAdapter`: `MorphologicalEngine` の sudachi.rs 実装。
 //!
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.4, §4.1, §5.1.
+
+use std::path::{Path, PathBuf};
+
+use sudachi::analysis::stateful_tokenizer::StatefulTokenizer;
+use sudachi::analysis::Mode;
+use sudachi::config::Config;
+use sudachi::dic::dictionary::JapaneseDictionary;
+
+use crate::dict::engine::{EngineCandidate, MorphologicalEngine};
+use crate::kanji::KanjiError;
+
+/// sudachi.rs の engine_id() で返す固定 label。Layer 3 golden test から
+/// 同一文字列でアサートするため、module スコープの `pub(crate)` const として
+/// 固定する。
+pub(crate) const SUDACHI_ENGINE_ID_LABEL: &str = "sudachi-0.6.11+sudachidict-core:v20260116";
+
+/// sudachi.rs runtime ラッパー。`MorphologicalEngine` 実装。
+///
+/// SudachiDict-core (`system_core.dic`) を runtime load し、Mode::C で
+/// tokenize する。score は `head_word_length` の負値を proxy として用いる
+/// (Task 14 で診断 → 必要なら切替、spec §3.4 注釈)。
+///
+/// # Invariants
+///
+/// - `dict` は `load` 成功後に valid な SudachiDict instance を保持する
+/// - `system_dict_path` は load 時の path を保持し、Backend variant で error
+///   message に埋め込む用途で使用する
+#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
+pub(crate) struct SudachiAdapter {
+    dict: JapaneseDictionary,
+    system_dict_path: PathBuf,
+}
+
+impl std::fmt::Debug for SudachiAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `JapaneseDictionary` does not implement `Debug`, so format only the
+        // load-time path. Sufficient for test failure messages.
+        f.debug_struct("SudachiAdapter")
+            .field("system_dict_path", &self.system_dict_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SudachiAdapter {
+    /// SudachiDict-core file を disk から load する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `system_dict_path` は SudachiDict-core の `system_core.dic` を指す
+    ///
+    /// # Errors
+    ///
+    /// - [`KanjiError::ModelNotFound`] — path に file が存在しない場合
+    /// - [`KanjiError::ModelLoadFailed`] — sudachi.rs 側で config / dict の
+    ///   読み込みに失敗した場合
+    #[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
+    pub(crate) fn load(system_dict_path: &Path) -> Result<Self, KanjiError> {
+        if !system_dict_path.exists() {
+            return Err(KanjiError::ModelNotFound {
+                path: system_dict_path.to_path_buf(),
+            });
+        }
+        let config =
+            Config::new(None, None, Some(system_dict_path.to_path_buf())).map_err(|e| {
+                KanjiError::ModelLoadFailed {
+                    source: Box::new(e),
+                }
+            })?;
+        let dict =
+            JapaneseDictionary::from_cfg(&config).map_err(|e| KanjiError::ModelLoadFailed {
+                source: Box::new(e),
+            })?;
+        Ok(Self {
+            dict,
+            system_dict_path: system_dict_path.to_path_buf(),
+        })
+    }
+}
+
+impl MorphologicalEngine for SudachiAdapter {
+    fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError> {
+        if reading.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut tokenizer: StatefulTokenizer<&JapaneseDictionary> =
+            StatefulTokenizer::create(&self.dict, false, Mode::C);
+        tokenizer.reset().push_str(reading);
+        tokenizer.do_tokenize().map_err(|e| KanjiError::Backend {
+            reason: format!(
+                "sudachi tokenize failed for input {:?} using dict {}: {e}",
+                reading,
+                self.system_dict_path.display()
+            ),
+        })?;
+        let morphemes = tokenizer
+            .into_morpheme_list()
+            .map_err(|e| KanjiError::Backend {
+                reason: format!("sudachi morpheme collection failed: {e}"),
+            })?;
+        let mut out = Vec::with_capacity(morphemes.len());
+        for m in morphemes.iter() {
+            let surface = m.surface().to_string();
+            let reading_form = m.reading_form().to_string();
+            let cost = m.get_word_info().head_word_length() as f32;
+            out.push(EngineCandidate {
+                surface,
+                reading: reading_form,
+                score: -cost,
+            });
+        }
+        Ok(out)
+    }
+
+    fn engine_id(&self) -> &str {
+        SUDACHI_ENGINE_ID_LABEL
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kanji::KanjiError;
+    use std::path::Path;
+
+    #[test]
+    fn sudachi_adapter_load_missing_file_errors() {
+        let err = SudachiAdapter::load(Path::new("/tmp/definitely-does-not-exist-kotoha-p2a.dic"))
+            .expect_err("load must error when the path does not exist");
+        match err {
+            KanjiError::ModelNotFound { path } => {
+                assert!(path.to_string_lossy().contains("definitely-does-not-exist"));
+            }
+            other => panic!("expected ModelNotFound, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sudachi_engine_id_label_constant_is_stable() {
+        assert!(SUDACHI_ENGINE_ID_LABEL.contains("sudachi"));
+        assert!(SUDACHI_ENGINE_ID_LABEL.contains("0.6"));
+    }
+}

--- a/crates/kotoha-core/src/dict/sudachi_adapter.rs
+++ b/crates/kotoha-core/src/dict/sudachi_adapter.rs
@@ -28,7 +28,6 @@ pub(crate) const SUDACHI_ENGINE_ID_LABEL: &str = "sudachi-0.6.11+sudachidict-cor
 /// - `dict` は `load` 成功後に valid な SudachiDict instance を保持する
 /// - `system_dict_path` は load 時の path を保持し、Backend variant で error
 ///   message に埋め込む用途で使用する
-#[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
 pub(crate) struct SudachiAdapter {
     dict: JapaneseDictionary,
     system_dict_path: PathBuf,
@@ -56,7 +55,6 @@ impl SudachiAdapter {
     /// - [`KanjiError::ModelNotFound`] — path に file が存在しない場合
     /// - [`KanjiError::ModelLoadFailed`] — sudachi.rs 側で config / dict の
     ///   読み込みに失敗した場合
-    #[allow(dead_code)] // Consumed by `DictionaryBackend` in Task 8 (P2-A).
     pub(crate) fn load(system_dict_path: &Path) -> Result<Self, KanjiError> {
         if !system_dict_path.exists() {
             return Err(KanjiError::ModelNotFound {

--- a/crates/kotoha-core/src/dict/sudachi_adapter.rs
+++ b/crates/kotoha-core/src/dict/sudachi_adapter.rs
@@ -1,0 +1,3 @@
+//! `SudachiAdapter`: `MorphologicalEngine` の sudachi.rs 実装。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.4, §4.1, §5.1.

--- a/crates/kotoha-core/src/dict/vocab.rs
+++ b/crates/kotoha-core/src/dict/vocab.rs
@@ -1,0 +1,3 @@
+//! `VocabularyLookup` trait と `VocabEntry` 値型の定義。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.6, §4.2.2.

--- a/crates/kotoha-core/src/dict/vocab.rs
+++ b/crates/kotoha-core/src/dict/vocab.rs
@@ -1,3 +1,103 @@
 //! `VocabularyLookup` trait と `VocabEntry` 値型の定義。
 //!
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.6, §4.2.2.
+
+/// User dictionary / Custom vocabulary の lookup 抽象境界。
+///
+/// `DictionaryBackend` は `Vec<Box<dyn VocabularyLookup>>` を field に保持する。
+/// P2-A は `CustomVocab` のみが本 trait を実装する。P2-B で `UserVocab` が
+/// 同 trait を実装する extension path を確保する(spec §3.6 / §4.2.2)。
+///
+/// # Preconditions
+///
+/// - `reading` は hiragana 文字列(`KanjiBackend` 契約と同じ)
+///
+/// # Postconditions
+///
+/// - 同一 reading に対し 0 件以上の `VocabEntry` を返す
+/// - 返値順序は score 降順(score 同値時の順序は実装依存)
+#[allow(dead_code)] // Consumed by `CustomVocab` in Task 5 and `DictionaryBackend` in Task 8 (P2-A).
+pub trait VocabularyLookup {
+    /// Returns all vocab entries whose reading matches `reading`.
+    fn lookup(&self, reading: &str) -> Vec<VocabEntry>;
+
+    /// Returns a stable, human-readable identifier for the vocab source.
+    fn vocab_id(&self) -> &str;
+}
+
+/// A single vocabulary entry returned by [`VocabularyLookup::lookup`].
+#[allow(dead_code)] // Consumed by `CustomVocab` in Task 5 and `DictionaryBackend` in Task 8 (P2-A).
+#[derive(Debug, Clone)]
+pub struct VocabEntry {
+    /// Surface form.
+    pub surface: String,
+    /// Reading (hiragana).
+    pub reading: String,
+    /// Part of speech (SudachiDict と同 schema、`"名詞"` / `"固有名詞"` 等)。
+    pub pos: String,
+    /// Score; larger is better.
+    pub score: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockVocab {
+        canned: Vec<VocabEntry>,
+    }
+
+    impl VocabularyLookup for MockVocab {
+        fn lookup(&self, reading: &str) -> Vec<VocabEntry> {
+            if reading.is_empty() {
+                return Vec::new();
+            }
+            self.canned.clone()
+        }
+
+        fn vocab_id(&self) -> &str {
+            "mock-vocab"
+        }
+    }
+
+    #[test]
+    fn vocab_entry_holds_surface_reading_pos_score() {
+        let ve = VocabEntry {
+            surface: "漢字".to_string(),
+            reading: "かんじ".to_string(),
+            pos: "名詞".to_string(),
+            score: 0.85,
+        };
+        assert_eq!(ve.surface, "漢字");
+        assert_eq!(ve.reading, "かんじ");
+        assert_eq!(ve.pos, "名詞");
+        assert!((ve.score - 0.85).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mock_vocab_returns_canned_entries() {
+        let vocab = MockVocab {
+            canned: vec![VocabEntry {
+                surface: "漢字".to_string(),
+                reading: "かんじ".to_string(),
+                pos: "名詞".to_string(),
+                score: 0.85,
+            }],
+        };
+        let result = vocab.lookup("かんじ");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "漢字");
+    }
+
+    #[test]
+    fn mock_vocab_empty_input_returns_empty() {
+        let vocab = MockVocab { canned: Vec::new() };
+        assert!(vocab.lookup("").is_empty());
+    }
+
+    #[test]
+    fn mock_vocab_vocab_id_is_stable() {
+        let vocab = MockVocab { canned: Vec::new() };
+        assert_eq!(vocab.vocab_id(), "mock-vocab");
+    }
+}

--- a/crates/kotoha-core/src/dict/vocab.rs
+++ b/crates/kotoha-core/src/dict/vocab.rs
@@ -16,7 +16,6 @@
 ///
 /// - 同一 reading に対し 0 件以上の `VocabEntry` を返す
 /// - 返値順序は score 降順(score 同値時の順序は実装依存)
-#[allow(dead_code)] // Consumed by `CustomVocab` in Task 5 and `DictionaryBackend` in Task 8 (P2-A).
 pub trait VocabularyLookup {
     /// Returns all vocab entries whose reading matches `reading`.
     fn lookup(&self, reading: &str) -> Vec<VocabEntry>;
@@ -26,7 +25,6 @@ pub trait VocabularyLookup {
 }
 
 /// A single vocabulary entry returned by [`VocabularyLookup::lookup`].
-#[allow(dead_code)] // Consumed by `CustomVocab` in Task 5 and `DictionaryBackend` in Task 8 (P2-A).
 #[derive(Debug, Clone)]
 pub struct VocabEntry {
     /// Surface form.

--- a/crates/kotoha-core/src/kanji/backend.rs
+++ b/crates/kotoha-core/src/kanji/backend.rs
@@ -534,21 +534,12 @@ mod tests {
         assert!(msg.contains("system_dict_path"));
     }
 
-    #[cfg(not(feature = "dict"))]
-    #[test]
-    fn dictionary_config_without_feature_errors_feature_disabled() {
-        // feature=dict OFF 時は BackendConfig::Dictionary variant 自体が
-        // `#[cfg(feature = "dict")]` で gate される設計のため本 test は該当時
-        // のみ compile する。本 test は「feature OFF を明示する placeholder」
-        // として空アサーションを置く。
-        let _ = std::any::type_name::<BackendConfig>();
-    }
-
     #[cfg(feature = "dict")]
     #[test]
-    fn dictionary_config_load_backend_missing_env_errors_model_not_found() {
+    fn dictionary_config_load_backend_missing_env_errors_backend() {
         use crate::dict::DictionaryConfig;
-        // env var も config も無い状態で load_backend を呼ぶと ModelNotFound。
+        // env var も config も無い状態で load_backend を呼ぶと、actionable な
+        // hint を含む KanjiError::Backend を返す契約。
         // 注意: `std::env::remove_var` は process-global state の変更であり、
         // 並列実行する他 test が同 env var を set した場合 race する。
         // P2-A 範囲では本 risk を受容する(tasks.md Notes §2)。
@@ -559,9 +550,18 @@ mod tests {
         // `Box<dyn KanjiBackend>` は `Debug` を実装しないため Result 全体は
         // `{:?}` で format できない。Err / Ok を別 arm で個別 match する。
         match load_backend(&cfg) {
-            Err(KanjiError::ModelNotFound { .. }) => {}
-            Err(other) => panic!("expected ModelNotFound, got Err: {other:?}"),
-            Ok(_) => panic!("expected ModelNotFound, got Ok(backend)"),
+            Err(KanjiError::Backend { reason }) => {
+                assert!(
+                    reason.contains("KOTOHA_SYSTEM_DICT_PATH"),
+                    "error reason should name the env var: {reason}"
+                );
+                assert!(
+                    reason.contains("system_dict_path"),
+                    "error reason should name the config field: {reason}"
+                );
+            }
+            Err(other) => panic!("expected Backend, got Err: {other:?}"),
+            Ok(_) => panic!("expected Backend, got Ok(backend)"),
         }
     }
 }

--- a/crates/kotoha-core/src/kanji/backend.rs
+++ b/crates/kotoha-core/src/kanji/backend.rs
@@ -81,6 +81,14 @@ pub enum BackendConfig {
         /// prompt. Dispatched by `LlamaCppBackend::convert`.
         prompt_template: PromptTemplate,
     },
+
+    /// SudachiDict-based dictionary backend (P2-A、spec §3.3 / §4.4).
+    /// Constructible only when the `dict` feature flag is enabled at build time.
+    #[cfg(feature = "dict")]
+    Dictionary {
+        /// Engine-neutral config (spec §3.4 Q4).
+        config: crate::dict::DictionaryConfig,
+    },
 }
 
 /// Abstraction for a kana-to-kanji conversion backend.
@@ -247,6 +255,11 @@ pub fn load_backend(config: &BackendConfig) -> Result<Box<dyn KanjiBackend>, Kan
         BackendConfig::LlamaCpp { .. } => Err(KanjiError::FeatureDisabled {
             feature: "llama-cpp",
         }),
+
+        #[cfg(feature = "dict")]
+        BackendConfig::Dictionary { config } => {
+            Ok(Box::new(crate::dict::DictionaryBackend::load(config)?))
+        }
     }
 }
 
@@ -499,5 +512,56 @@ mod tests {
             msg.contains("<u>"),
             "Debug must include user_wrapper: {msg}"
         );
+    }
+
+    // ======================================================================
+    // BackendConfig::Dictionary (P2-A)
+    // ======================================================================
+
+    #[cfg(feature = "dict")]
+    #[test]
+    fn backend_config_dictionary_is_clone_and_debug() {
+        use crate::dict::DictionaryConfig;
+        let cfg = BackendConfig::Dictionary {
+            config: DictionaryConfig {
+                system_dict_path: Some(PathBuf::from("/tmp/system_core.dic")),
+                custom_vocab_path: None,
+            },
+        };
+        let cloned = cfg.clone();
+        let msg = format!("{cloned:?}");
+        assert!(msg.contains("Dictionary"));
+        assert!(msg.contains("system_dict_path"));
+    }
+
+    #[cfg(not(feature = "dict"))]
+    #[test]
+    fn dictionary_config_without_feature_errors_feature_disabled() {
+        // feature=dict OFF 時は BackendConfig::Dictionary variant 自体が
+        // `#[cfg(feature = "dict")]` で gate される設計のため本 test は該当時
+        // のみ compile する。本 test は「feature OFF を明示する placeholder」
+        // として空アサーションを置く。
+        let _ = std::any::type_name::<BackendConfig>();
+    }
+
+    #[cfg(feature = "dict")]
+    #[test]
+    fn dictionary_config_load_backend_missing_env_errors_model_not_found() {
+        use crate::dict::DictionaryConfig;
+        // env var も config も無い状態で load_backend を呼ぶと ModelNotFound。
+        // 注意: `std::env::remove_var` は process-global state の変更であり、
+        // 並列実行する他 test が同 env var を set した場合 race する。
+        // P2-A 範囲では本 risk を受容する(tasks.md Notes §2)。
+        std::env::remove_var("KOTOHA_SYSTEM_DICT_PATH");
+        let cfg = BackendConfig::Dictionary {
+            config: DictionaryConfig::default(),
+        };
+        // `Box<dyn KanjiBackend>` は `Debug` を実装しないため Result 全体は
+        // `{:?}` で format できない。Err / Ok を別 arm で個別 match する。
+        match load_backend(&cfg) {
+            Err(KanjiError::ModelNotFound { .. }) => {}
+            Err(other) => panic!("expected ModelNotFound, got Err: {other:?}"),
+            Ok(_) => panic!("expected ModelNotFound, got Ok(backend)"),
+        }
     }
 }

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -22,3 +22,6 @@ pub use mock::MockBackend;
 mod llama_cpp;
 #[cfg(feature = "llama-cpp")]
 pub use llama_cpp::LlamaCppBackend;
+
+#[cfg(feature = "dict")]
+pub use crate::dict::DictionaryBackend;

--- a/crates/kotoha-core/src/kanji/mod.rs
+++ b/crates/kotoha-core/src/kanji/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! Spec: `docs/superpowers/specs/2026-04-24-kotoha-phase-1-design.md` §4-§8.
 
-mod backend;
+pub(crate) mod backend;
 mod candidate;
 mod error;
 

--- a/crates/kotoha-core/src/lib.rs
+++ b/crates/kotoha-core/src/lib.rs
@@ -9,6 +9,9 @@ pub mod kana;
 pub mod kanji;
 pub mod romaji;
 
+#[cfg(feature = "dict")]
+pub mod dict;
+
 pub use error::{Error, Result};
 pub use input::{InputContext, InputMode, InputStep};
 pub use kanji::{load_backend, BackendConfig, Candidate, ConvertOptions, KanjiBackend, KanjiError};

--- a/crates/kotoha-core/tests/kanji_dictionary_unit.rs
+++ b/crates/kotoha-core/tests/kanji_dictionary_unit.rs
@@ -1,0 +1,91 @@
+//! Layer 2 integration tests for the Dictionary backend (P2-A).
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §6.2.
+//!
+//! これらの test は SudachiDict 不在環境でも実行可能。実辞書が要る smoke
+//! は `kanji_dictionary_golden.rs` (Layer 3、`dict-smoke` feature) 側に置く。
+
+#![cfg(feature = "dict")]
+
+use std::path::PathBuf;
+
+use kotoha_core::dict::DictionaryConfig;
+use kotoha_core::kanji::{load_backend, BackendConfig, KanjiError};
+
+#[test]
+fn load_backend_dictionary_without_env_errors_model_not_found() {
+    std::env::remove_var("KOTOHA_SYSTEM_DICT_PATH");
+    let cfg = BackendConfig::Dictionary {
+        config: DictionaryConfig::default(),
+    };
+    // NOTE: `Box<dyn KanjiBackend>` does not implement `Debug`, so we cannot
+    // use `Result::expect_err` here. Match the `Err` arm directly instead.
+    match load_backend(&cfg) {
+        Err(KanjiError::ModelNotFound { .. }) => {}
+        Err(other) => panic!("expected ModelNotFound, got: {other:?}"),
+        Ok(_) => panic!("no dict path must error"),
+    }
+}
+
+#[test]
+fn load_backend_dictionary_with_nonexistent_path_errors_model_not_found() {
+    let cfg = BackendConfig::Dictionary {
+        config: DictionaryConfig {
+            system_dict_path: Some(PathBuf::from(
+                "/tmp/definitely-does-not-exist-kotoha-p2a-integration.dic",
+            )),
+            custom_vocab_path: None,
+        },
+    };
+    match load_backend(&cfg) {
+        Err(KanjiError::ModelNotFound { path }) => {
+            assert!(path.to_string_lossy().contains("definitely-does-not-exist"));
+        }
+        Err(other) => panic!("expected ModelNotFound, got: {other:?}"),
+        Ok(_) => panic!("missing file must error"),
+    }
+}
+
+#[test]
+fn dictionary_config_default_is_all_none() {
+    let cfg = DictionaryConfig::default();
+    assert!(cfg.system_dict_path.is_none());
+    assert!(cfg.custom_vocab_path.is_none());
+}
+
+#[test]
+fn dictionary_config_env_var_resolve_fallback_works() {
+    // NOTE: env var を直接書き換える test は並列実行で flaky になる可能性
+    // があるため、resolve は unit test 側 (dict::config_tests) で検証し、
+    // 本 integration test では path 明示の振る舞いのみを確認する。
+    let cfg = DictionaryConfig {
+        system_dict_path: Some(PathBuf::from("/tmp/explicit-path.dic")),
+        custom_vocab_path: None,
+    };
+    let result = load_backend(&BackendConfig::Dictionary { config: cfg });
+    // explicit path でも実ファイルは無いため ModelNotFound になる。これは
+    // env var fallback 経路ではなく explicit 経路を通過したことの裏返し。
+    match result {
+        Err(KanjiError::ModelNotFound { path }) => {
+            assert_eq!(path, PathBuf::from("/tmp/explicit-path.dic"));
+        }
+        Err(other) => panic!("expected ModelNotFound from explicit path, got: {other:?}"),
+        Ok(_) => panic!("missing file must error, not Ok"),
+    }
+}
+
+#[test]
+fn dictionary_config_custom_vocab_missing_errors_backend() {
+    let cfg = DictionaryConfig {
+        system_dict_path: Some(PathBuf::from("/tmp/no-such-system.dic")),
+        custom_vocab_path: Some(PathBuf::from("/tmp/no-such-custom.tsv")),
+    };
+    // system_dict の load で ModelNotFound に到達し、custom_vocab の load
+    // には進まない。この test は「system が先にチェックされる」順序契約の
+    // regression 防止に相当する。
+    match load_backend(&BackendConfig::Dictionary { config: cfg }) {
+        Err(KanjiError::ModelNotFound { .. }) => {}
+        Err(other) => panic!("expected ModelNotFound, got: {other:?}"),
+        Ok(_) => panic!("missing files must error"),
+    }
+}

--- a/crates/kotoha-core/tests/kanji_dictionary_unit.rs
+++ b/crates/kotoha-core/tests/kanji_dictionary_unit.rs
@@ -13,7 +13,7 @@ use kotoha_core::dict::DictionaryConfig;
 use kotoha_core::kanji::{load_backend, BackendConfig, KanjiError};
 
 #[test]
-fn load_backend_dictionary_without_env_errors_model_not_found() {
+fn load_backend_dictionary_without_env_errors_backend_with_actionable_hint() {
     std::env::remove_var("KOTOHA_SYSTEM_DICT_PATH");
     let cfg = BackendConfig::Dictionary {
         config: DictionaryConfig::default(),
@@ -21,8 +21,19 @@ fn load_backend_dictionary_without_env_errors_model_not_found() {
     // NOTE: `Box<dyn KanjiBackend>` does not implement `Debug`, so we cannot
     // use `Result::expect_err` here. Match the `Err` arm directly instead.
     match load_backend(&cfg) {
-        Err(KanjiError::ModelNotFound { .. }) => {}
-        Err(other) => panic!("expected ModelNotFound, got: {other:?}"),
+        Err(KanjiError::Backend { reason }) => {
+            // 受容契約: reason は env var 名と config field 名の両方に言及し、
+            // user が次に何を設定すべきかが一読でわかる。
+            assert!(
+                reason.contains("KOTOHA_SYSTEM_DICT_PATH"),
+                "reason should name the env var: {reason}"
+            );
+            assert!(
+                reason.contains("system_dict_path"),
+                "reason should name the config field: {reason}"
+            );
+        }
+        Err(other) => panic!("expected Backend, got: {other:?}"),
         Ok(_) => panic!("no dict path must error"),
     }
 }
@@ -44,13 +55,6 @@ fn load_backend_dictionary_with_nonexistent_path_errors_model_not_found() {
         Err(other) => panic!("expected ModelNotFound, got: {other:?}"),
         Ok(_) => panic!("missing file must error"),
     }
-}
-
-#[test]
-fn dictionary_config_default_is_all_none() {
-    let cfg = DictionaryConfig::default();
-    assert!(cfg.system_dict_path.is_none());
-    assert!(cfg.custom_vocab_path.is_none());
 }
 
 #[test]

--- a/docs/adr/0014-phase-2-dictionary-layer-architecture.md
+++ b/docs/adr/0014-phase-2-dictionary-layer-architecture.md
@@ -55,14 +55,20 @@ Dictionary layer は以下 2 層から成る。
 
 Learning cache は Ranker の入力 feature として使用し、User が繰返し選択する候補の rerank 係数を上げる。
 
-### D4. BackendConfig に新 variant を追加する
+### D4. BackendConfig に新 variant を 2 段階で追加する
 
-Phase 2 は ADR 0011 で確定した `BackendConfig` enum の `#[non_exhaustive]` 拡張点を使用し、新 variant を 1 つ追加する。variant 名候補は以下 2 案を P2-A kick-off で empirical 確定する。
+Phase 2 は ADR 0011 で確定した `BackendConfig` enum の `#[non_exhaustive]` 拡張点を使用し、Phase 2 期間中に以下 2 variants を段階的に追加する。
 
-- **候補 1**: `BackendConfig::DictionaryAugmented { model_path, dict_config, learning_config }` — Dictionary 補完付き LLM backend を 1 variant に集約する案
-- **候補 2**: `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict: DictionaryConfig, learning: LearningConfig }` — LLM backend を再帰的に wrap する案。将来の Phase 5 `KotohaNative` backend との組合せにも自動対応する
+- **P2-A**: `BackendConfig::Dictionary { config: DictionaryConfig }`(集約型、LLM を含まない pure Dictionary backend)
+  - 形態素解析と vocabulary lookup の合成のみを担当する。LLM 推論を内包しないため、`llama-cpp` feature 非依存で常に build / 単体実行可能となる
+  - P2-A の Layer 1 / Layer 2 テストはこの variant を介して MorphologicalEngine + VocabularyLookup の合成を end-to-end 検証する
+- **P2-D**: `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict: DictionaryConfig, learning: LearningConfig }`(再帰 wrap 型)
+  - LLM backend を再帰的に wrap し、Dictionary 候補 / LLM 候補 / Learning cache hit を Ranker で統合する
+  - `llm: Box<BackendConfig>` 形式により、Phase 5 で `BackendConfig::KotohaNative` が加入した際にも自動対応できる(再 wrap で同じ Hybrid variant を再利用可能)
 
-Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` と `BackendConfig::Mock` は変更しない。既存 variant の破壊を伴わない純粋な拡張として追加する。
+本判断の根拠は P2-A spec §3.3 Q3(`docs/superpowers/specs/2026-04-25-kotoha-phase-2-p2-a-dictionary-foundation.md` §3.3 Q3)に記載する。集約型を P2-A、再帰 wrap 型を P2-D と分割する理由は、(a) P2-A 段階では LLM 統合を持ち込まず純粋な Dictionary backend として独立に検証したい、(b) Phase 5 KotohaNative の自動対応(Hybrid 側の責務)を Phase 2 段階で完結させ、Phase 5 で再設計を不要にする、の 2 点である。
+
+Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` と `BackendConfig::Mock` は変更しない。既存 variant の破壊を伴わない純粋な拡張として 2 variants を追加する。
 
 ### D5. Ranker 戦略を「dict 0.95 / LLM 1.0 初期重み」から開始する
 
@@ -135,4 +141,11 @@ Phase 5 で `KotohaNative` backend が追加される際も、本 ADR の Dictio
 
 ## Note: 本 ADR の status について
 
-本 ADR は方針として Accepted とするが、D4 の variant 名、D5 の rerank 重み、D3 の learning cache 永続化 format、D2 の SudachiDict core/full 選択、の 4 点は P2-A kick-off 時点で empirical 確定する。P2-A 着手後の follow-up commit で本 ADR に「確定パラメータ」節を追記する運用を取り、P2-D 完了時点で本 ADR の内容を最終化する。
+本 ADR は方針として Accepted とするが、確定状況は以下のとおり項目別に異なる。
+
+- **D4 (BackendConfig 新 variant 構成)**: P2-A 設計時点で「P2-A: 集約型 `Dictionary { config }`、P2-D: 再帰 wrap 型 `Hybrid { llm, dict, learning }`」の 2 段階追加方針として確定済 (本 ADR 上記 D4 改訂、および P2-A spec §3.3 Q3 に根拠を記載)
+- **D5 (Ranker 重み)**: 初期値 dict 0.95 / LLM 1.0 を暫定値とし、P2-D の golden fixture (530 cases) で empirical tuning する。Layer 3 の 530-case fixture と golden test runner、`phase2-dict-smoke.sh` は P2-A 範囲外として ISSUE #92 で別 PR にて実装する
+- **D3 (learning cache 永続化 format)**: P2-C 着手時に empirical 確定する
+- **D2 (SudachiDict core/full)**: P2-A 初期 pilot で recall を測定し core/full を確定する。Phase 2 default は core を採用し、recall 不足が P2-D で確認された場合のみ full への切替を検討する
+
+P2-D 完了時点で本 ADR に「確定パラメータ」節を追記し、Phase 2 closure で内容を最終化する。

--- a/docs/superpowers/plans/2026-04-25-feature-91-p2-a-dictionary-layer.md
+++ b/docs/superpowers/plans/2026-04-25-feature-91-p2-a-dictionary-layer.md
@@ -1,0 +1,2548 @@
+# Phase 2 P2-A Dictionary Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Phase 2 の最初のマイルストーン P2-A として、Sudachi-based Dictionary backend を新設し、`KanjiBackend` trait の 2 つ目の実装(LlamaCpp に続く)を Kotoha IME に追加する。
+
+**Architecture:** `MorphologicalEngine` / `VocabularyLookup` の 2 trait を先出し(Clean Architecture DIP)、`DictionaryBackend` が両 trait の `Box<dyn>` を保持する形で engine 切替可能性を確保する。`BackendConfig::Dictionary { config }` を `#[non_exhaustive]` enum に追加(ADR 0011 拡張点)、SudachiDict-core を `KOTOHA_SYSTEM_DICT_PATH` 経由 manual placement で runtime load する。
+
+**Tech Stack:** Rust 1.80 / edition 2021、`sudachi.rs` (git rev `90fd6068c80c` = v0.6.11、Apache-2.0)、SudachiDict-core v20260116 (Apache-2.0、manual placement)、`dict` / `dict-smoke` Cargo features (default = []、ADR 0012 整合)、Python 3.12 + uv (fixture 生成 tooling)、bash + assert.sh (smoke script)
+
+---
+
+## Task 1: sudachi.rs dependency 追加と dict / dict-smoke feature 定義
+
+**Files:**
+- Modify: `Cargo.toml`(workspace root、`[workspace.dependencies]` セクション)
+- Modify: `crates/kotoha-core/Cargo.toml`(`[dependencies]` + `[features]` セクション)
+
+**Depends-on:** なし
+
+**Estimated LOC:** 15
+
+参照: spec §7.1 / §7.2
+
+- [ ] **Step 1: workspace root `Cargo.toml` に sudachi git dep を追加**
+
+以下を `[workspace.dependencies]` の末尾(`llama-cpp-2` 行の直後)に追加する。
+
+```toml
+# sudachi.rs pinned via P2-A Q1 (brainstorming, 2026-04-25).
+# Adopted reason: SudachiDict-core を native Rust で読込可能、P5-A PoC と辞書整合、Apache-2.0。
+# Alternatives rejected per P2-A spec §3.1 Q1:
+#   - lindera: MeCab-IPADIC / UniDic 要求(UniDic は商用利用制約)
+#   - vibrato: SudachiDict native 非対応(short/middle/long unit 不可)
+#   - SudachiDict→MeCab 変換: WorksApplications 公式提供なし、精度保証なし
+sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }
+```
+
+- [ ] **Step 2: `crates/kotoha-core/Cargo.toml` `[dependencies]` に optional sudachi を追加**
+
+既存の `llama-cpp-2 = { workspace = true, optional = true }` の直後に以下を追加する。
+
+```toml
+# `sudachi` is optional so default features do not pull in the git-sourced dep tree.
+# Activated only when the `dict` feature is enabled (P2-A spec §7.1).
+sudachi = { workspace = true, optional = true }
+```
+
+- [ ] **Step 3: `crates/kotoha-core/Cargo.toml` `[features]` に dict / dict-smoke を追加**
+
+既存 `llama-cpp-smoke = ["llama-cpp"]` の直後に以下を追加する。
+
+```toml
+# `dict` gates DictionaryBackend (SudachiDict baseline, P2-A spec §3.1 Q1).
+# default = [] を維持し ADR 0012 D5 整合。
+dict = ["dep:sudachi"]
+# `dict-smoke` is the opt-in gate for Layer 3 golden fixture (530 cases).
+# Kept separate from `dict` so lefthook pre-push does not attempt to load SudachiDict-core.
+dict-smoke = ["dict"]
+```
+
+- [ ] **Step 4: `cargo check --workspace --features dict` が通ることを確認**
+
+```bash
+cargo check --workspace --features dict
+```
+
+想定出力: `Checking kotoha-core v0.1.0` … `Finished ...`(warning 0 件)。初回は sudachi.rs の git fetch が発生するため 30〜60 秒かかる。
+
+- [ ] **Step 5: `cargo build --workspace --features dict` で sudachi.rs 本体までコンパイル**
+
+```bash
+cargo build --workspace --features dict
+```
+
+想定出力: `Compiling sudachi v0.6.11 (...)` → `Finished ...`。初回 30〜60 秒 / incremental 5 秒以内。
+
+- [ ] **Final step: Commit**
+
+本 task では test を書かない(skeleton 前段のため test 対象が存在しない)。
+
+```bash
+git add Cargo.toml crates/kotoha-core/Cargo.toml
+git commit -m "chore(deps): add sudachi.rs git dep + dict/dict-smoke features (#91)"
+```
+
+---
+
+## Task 2: dict/ モジュールスケルトン作成
+
+**Files:**
+- Create: `crates/kotoha-core/src/dict/mod.rs`
+- Create: `crates/kotoha-core/src/dict/backend.rs`
+- Create: `crates/kotoha-core/src/dict/engine.rs`
+- Create: `crates/kotoha-core/src/dict/vocab.rs`
+- Create: `crates/kotoha-core/src/dict/sudachi_adapter.rs`
+- Create: `crates/kotoha-core/src/dict/custom_vocab.rs`
+- Modify: `crates/kotoha-core/src/lib.rs`(`pub mod dict;` を feature gated で追加)
+
+**Depends-on:** Task 1
+
+**Estimated LOC:** 30
+
+参照: spec §4.1
+
+- [ ] **Step 1: `dict/mod.rs` を最小スケルトンで作成**
+
+```rust
+//! Dictionary-based kanji conversion backend (Phase 2 P2-A).
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md`.
+//!
+//! この module は P2-A で追加された `KanjiBackend` の 2 つ目の実装
+//! (`LlamaCppBackend` に続く)を提供する。SudachiDict-core を
+//! `sudachi.rs` 経由で runtime load する Dictionary backend を中核とし、
+//! `MorphologicalEngine` / `VocabularyLookup` 2 本の trait で engine 切替を
+//! 抽象化する(Clean Architecture DIP、spec §4.2)。
+
+pub(crate) mod backend;
+pub(crate) mod custom_vocab;
+pub(crate) mod engine;
+pub(crate) mod sudachi_adapter;
+pub(crate) mod vocab;
+```
+
+- [ ] **Step 2: `dict/backend.rs` を doc-comment のみで作成**
+
+```rust
+//! `DictionaryBackend` struct (P2-A、`KanjiBackend` 実装)。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §4.3.
+```
+
+- [ ] **Step 3: `dict/engine.rs` を doc-comment のみで作成**
+
+```rust
+//! `MorphologicalEngine` trait と `EngineCandidate` 値型の定義。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.5, §4.2.1.
+```
+
+- [ ] **Step 4: `dict/vocab.rs` を doc-comment のみで作成**
+
+```rust
+//! `VocabularyLookup` trait と `VocabEntry` 値型の定義。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.6, §4.2.2.
+```
+
+- [ ] **Step 5: `dict/sudachi_adapter.rs` を doc-comment のみで作成**
+
+```rust
+//! `SudachiAdapter`: `MorphologicalEngine` の sudachi.rs 実装。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.4, §4.1, §5.1.
+```
+
+- [ ] **Step 6: `dict/custom_vocab.rs` を doc-comment のみで作成**
+
+```rust
+//! `CustomVocab`: `VocabularyLookup` の TSV reader 実装。
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §5.2.
+```
+
+- [ ] **Step 7: `lib.rs` に dict module を feature gated で追加**
+
+既存の `pub mod romaji;` 行の直後に以下を追加する。
+
+```rust
+#[cfg(feature = "dict")]
+pub mod dict;
+```
+
+- [ ] **Step 8: `cargo check --features dict` で compile 通過を確認**
+
+```bash
+cargo check -p kotoha-core --features dict
+```
+
+想定出力: `warning: unused ...`(各 module が空のため unused 警告が出るが一旦容認、task 3 以降で解消)。error 0 件であれば OK。
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/dict/ crates/kotoha-core/src/lib.rs
+git commit -m "feat(dict): scaffold dict/ module skeleton (#91)"
+```
+
+---
+
+## Task 3: MorphologicalEngine trait + EngineCandidate 定義(TDD)
+
+**Files:**
+- Modify: `crates/kotoha-core/src/dict/engine.rs`(impl + in-file `#[cfg(test)] mod tests`)
+
+**Depends-on:** Task 2
+
+**Estimated LOC:** 80(impl 35 + tests 45)
+
+参照: spec §3.5, §4.2.1
+
+- [ ] **Step 1: test を先に書く(Red)— MockEngine で trait contract を検証**
+
+`dict/engine.rs` 末尾に以下を追加する(impl がまだ無いため、最初は compile すら通らない)。
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kanji::KanjiError;
+
+    /// tests 内専用の MockEngine。trait contract を external に lock-in する。
+    struct MockEngine {
+        canned: Vec<EngineCandidate>,
+    }
+
+    impl MorphologicalEngine for MockEngine {
+        fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError> {
+            if reading.is_empty() {
+                return Ok(Vec::new());
+            }
+            Ok(self.canned.clone())
+        }
+
+        fn engine_id(&self) -> &str {
+            "mock-engine"
+        }
+    }
+
+    #[test]
+    fn engine_candidate_new_holds_surface_reading_score() {
+        let ec = EngineCandidate {
+            surface: "日本語".to_string(),
+            reading: "にほんご".to_string(),
+            score: 0.9,
+        };
+        assert_eq!(ec.surface, "日本語");
+        assert_eq!(ec.reading, "にほんご");
+        assert!((ec.score - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mock_engine_returns_canned_candidates() {
+        let engine = MockEngine {
+            canned: vec![EngineCandidate {
+                surface: "日本語".to_string(),
+                reading: "にほんご".to_string(),
+                score: 0.9,
+            }],
+        };
+        let result = engine.tokenize("にほんご").expect("tokenize succeeds");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "日本語");
+    }
+
+    #[test]
+    fn mock_engine_empty_input_returns_empty() {
+        let engine = MockEngine { canned: Vec::new() };
+        let result = engine.tokenize("").expect("empty input must be accepted");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn mock_engine_engine_id_is_stable() {
+        let engine = MockEngine { canned: Vec::new() };
+        assert_eq!(engine.engine_id(), "mock-engine");
+    }
+}
+```
+
+- [ ] **Step 2: `cargo test --features dict -p kotoha-core dict::engine::tests` で FAIL を確認**
+
+```bash
+cargo test --features dict -p kotoha-core -- dict::engine::tests
+```
+
+想定: `error[E0412]: cannot find type 'EngineCandidate'` / `cannot find trait 'MorphologicalEngine'`。test が compile エラーで FAIL することを確認する。
+
+- [ ] **Step 3: trait と struct を実装(Green)**
+
+`dict/engine.rs` の `#[cfg(test)]` より前に以下を追加する。
+
+```rust
+use crate::kanji::KanjiError;
+
+/// 形態素解析 engine の抽象境界。
+///
+/// `DictionaryBackend` は `Box<dyn MorphologicalEngine>` を field に保持する。
+/// P2-A は `SudachiAdapter` のみが本 trait を実装する。Phase 5 以降で vibrato /
+/// lindera 等への置換時に `DictionaryBackend` の変更を最小化する目的で先出し
+/// する(spec §3.5 / §4.2.1)。
+///
+/// # Preconditions
+///
+/// - `reading` は `KanjiBackend` 契約 §5.6 と同じ hiragana 文字列
+///   (U+3040..=U+309F + U+30FC)
+/// - `reading.chars().count() <= 128`
+///
+/// # Postconditions
+///
+/// - 返値は `reading` を tokenize した候補列
+/// - 同一 reading に対し複数 surface があり得る(homophone)
+/// - `score` は engine 実装が付与(`SudachiAdapter` は cost を score に変換)
+///
+/// # Errors
+///
+/// - [`KanjiError::Backend`] when tokenization fails inside the engine
+pub trait MorphologicalEngine {
+    /// Tokenizes `reading` and returns candidate morphemes.
+    fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError>;
+
+    /// Returns a stable, human-readable identifier for the engine instance.
+    ///
+    /// Used by `DictionaryBackend::model_id()` to format the composite model id
+    /// (e.g. `"dictionary(sudachi-0.6.11)"`).
+    fn engine_id(&self) -> &str;
+}
+
+/// A single morpheme candidate returned by [`MorphologicalEngine::tokenize`].
+#[derive(Debug, Clone)]
+pub struct EngineCandidate {
+    /// Surface form (kanji / hiragana / katakana mix).
+    pub surface: String,
+    /// Reading (hiragana) of `surface`.
+    pub reading: String,
+    /// Score; larger is better. `SudachiAdapter` converts Sudachi cost into
+    /// a descending-order score.
+    pub score: f32,
+}
+```
+
+- [ ] **Step 4: `cargo test --features dict -p kotoha-core -- dict::engine::tests` で全 PASS を確認**
+
+想定: `test result: ok. 4 passed; 0 failed; ...`。
+
+- [ ] **Step 5: `cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings` 通過を確認**
+
+```bash
+cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/dict/engine.rs
+git commit -m "feat(dict): define MorphologicalEngine trait + EngineCandidate (#91)"
+```
+
+---
+
+## Task 4: VocabularyLookup trait + VocabEntry 定義(TDD)
+
+**Files:**
+- Modify: `crates/kotoha-core/src/dict/vocab.rs`(impl + in-file `#[cfg(test)] mod tests`)
+
+**Depends-on:** Task 3
+
+**Estimated LOC:** 80(impl 35 + tests 45)
+
+参照: spec §3.6, §4.2.2
+
+- [ ] **Step 1: test を先に書く(Red)— tests 内 MockVocab を定義**
+
+`dict/vocab.rs` 末尾に以下を追加する。
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockVocab {
+        canned: Vec<VocabEntry>,
+    }
+
+    impl VocabularyLookup for MockVocab {
+        fn lookup(&self, reading: &str) -> Vec<VocabEntry> {
+            if reading.is_empty() {
+                return Vec::new();
+            }
+            self.canned.clone()
+        }
+
+        fn vocab_id(&self) -> &str {
+            "mock-vocab"
+        }
+    }
+
+    #[test]
+    fn vocab_entry_holds_surface_reading_pos_score() {
+        let ve = VocabEntry {
+            surface: "漢字".to_string(),
+            reading: "かんじ".to_string(),
+            pos: "名詞".to_string(),
+            score: 0.85,
+        };
+        assert_eq!(ve.surface, "漢字");
+        assert_eq!(ve.reading, "かんじ");
+        assert_eq!(ve.pos, "名詞");
+        assert!((ve.score - 0.85).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mock_vocab_returns_canned_entries() {
+        let vocab = MockVocab {
+            canned: vec![VocabEntry {
+                surface: "漢字".to_string(),
+                reading: "かんじ".to_string(),
+                pos: "名詞".to_string(),
+                score: 0.85,
+            }],
+        };
+        let result = vocab.lookup("かんじ");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "漢字");
+    }
+
+    #[test]
+    fn mock_vocab_empty_input_returns_empty() {
+        let vocab = MockVocab { canned: Vec::new() };
+        assert!(vocab.lookup("").is_empty());
+    }
+
+    #[test]
+    fn mock_vocab_vocab_id_is_stable() {
+        let vocab = MockVocab { canned: Vec::new() };
+        assert_eq!(vocab.vocab_id(), "mock-vocab");
+    }
+}
+```
+
+- [ ] **Step 2: `cargo test --features dict -p kotoha-core -- dict::vocab::tests` で FAIL を確認**
+
+想定: `error[E0412]: cannot find type 'VocabEntry'`。
+
+- [ ] **Step 3: trait と struct を実装(Green)**
+
+`dict/vocab.rs` の `#[cfg(test)]` より前に以下を追加する。
+
+```rust
+/// User dictionary / Custom vocabulary の lookup 抽象境界。
+///
+/// `DictionaryBackend` は `Vec<Box<dyn VocabularyLookup>>` を field に保持する。
+/// P2-A は `CustomVocab` のみが本 trait を実装する。P2-B で `UserVocab` が
+/// 同 trait を実装する extension path を確保する(spec §3.6 / §4.2.2)。
+///
+/// # Preconditions
+///
+/// - `reading` は hiragana 文字列(`KanjiBackend` 契約と同じ)
+///
+/// # Postconditions
+///
+/// - 同一 reading に対し 0 件以上の `VocabEntry` を返す
+/// - 返値順序は score 降順(score 同値時の順序は実装依存)
+pub trait VocabularyLookup {
+    /// Returns all vocab entries whose reading matches `reading`.
+    fn lookup(&self, reading: &str) -> Vec<VocabEntry>;
+
+    /// Returns a stable, human-readable identifier for the vocab source.
+    fn vocab_id(&self) -> &str;
+}
+
+/// A single vocabulary entry returned by [`VocabularyLookup::lookup`].
+#[derive(Debug, Clone)]
+pub struct VocabEntry {
+    /// Surface form.
+    pub surface: String,
+    /// Reading (hiragana).
+    pub reading: String,
+    /// Part of speech (SudachiDict と同 schema、`"名詞"` / `"固有名詞"` 等)。
+    pub pos: String,
+    /// Score; larger is better.
+    pub score: f32,
+}
+```
+
+- [ ] **Step 4: `cargo test --features dict -p kotoha-core -- dict::vocab::tests` で全 PASS を確認**
+
+想定: `test result: ok. 4 passed; 0 failed; ...`。
+
+- [ ] **Step 5: clippy 通過確認**
+
+```bash
+cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/dict/vocab.rs
+git commit -m "feat(dict): define VocabularyLookup trait + VocabEntry (#91)"
+```
+
+---
+
+## Task 5: CustomVocab(TSV reader)実装(TDD strict)
+
+**Files:**
+- Modify: `crates/kotoha-core/src/dict/custom_vocab.rs`
+
+**Depends-on:** Task 4
+
+**Estimated LOC:** 150(impl 80 + tests 70)
+
+参照: spec §5.2, §6.1
+
+- [ ] **Step 1: test を先に書く(Red)— 6 test を先行記述**
+
+`dict/custom_vocab.rs` 末尾に以下を追加する(impl ゼロの段階)。
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EMPTY_TSV: &str = "# comment only\n# no entries\n";
+    const SINGLE_ENTRY_TSV: &str = "漢字\tかんじ\t名詞\t0.85\n";
+    const MULTI_ENTRY_TSV: &str = "\
+# header comment
+漢字\tかんじ\t名詞\t0.85
+感じ\tかんじ\t動詞\t0.45
+";
+    // surface / reading / pos / score のいずれかが欠けた行は reject 対象。
+    const MALFORMED_TSV: &str = "漢字\tかんじ\t名詞\n";
+
+    #[test]
+    fn custom_vocab_empty_tsv_yields_no_entries() {
+        let vocab = CustomVocab::from_str(EMPTY_TSV).expect("empty TSV must load");
+        assert!(vocab.lookup("かんじ").is_empty());
+    }
+
+    #[test]
+    fn custom_vocab_single_entry_can_be_looked_up() {
+        let vocab = CustomVocab::from_str(SINGLE_ENTRY_TSV).expect("single TSV must load");
+        let result = vocab.lookup("かんじ");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "漢字");
+        assert_eq!(result[0].pos, "名詞");
+    }
+
+    #[test]
+    fn custom_vocab_skips_comment_lines() {
+        let vocab = CustomVocab::from_str(MULTI_ENTRY_TSV).expect("multi TSV must load");
+        let result = vocab.lookup("かんじ");
+        assert_eq!(result.len(), 2, "2 non-comment entries expected");
+    }
+
+    #[test]
+    fn custom_vocab_rejects_malformed_line() {
+        let err = CustomVocab::from_str(MALFORMED_TSV)
+            .expect_err("malformed TSV must be rejected");
+        // 受容契約: backend 層の KanjiError::Backend へ折り畳み、reason に "malformed" を含める
+        match err {
+            crate::kanji::KanjiError::Backend { reason } => {
+                assert!(
+                    reason.contains("malformed") || reason.contains("fields"),
+                    "error reason should mention malformed line: {reason}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_vocab_returns_empty_for_unknown_reading() {
+        let vocab = CustomVocab::from_str(SINGLE_ENTRY_TSV).expect("single TSV must load");
+        assert!(vocab.lookup("みず").is_empty());
+    }
+
+    #[test]
+    fn custom_vocab_vocab_id_contains_source_label() {
+        let vocab = CustomVocab::from_str(EMPTY_TSV).expect("empty TSV must load");
+        assert!(
+            vocab.vocab_id().contains("custom"),
+            "vocab_id should mention 'custom': {}",
+            vocab.vocab_id()
+        );
+    }
+}
+```
+
+- [ ] **Step 2: `cargo test --features dict -p kotoha-core -- dict::custom_vocab::tests` で 6 件 FAIL(compile error)を確認**
+
+- [ ] **Step 3: impl を実装(Green)**
+
+`dict/custom_vocab.rs` の `#[cfg(test)]` より前に以下を追加する。
+
+```rust
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use crate::dict::vocab::{VocabEntry, VocabularyLookup};
+use crate::kanji::KanjiError;
+
+/// Custom vocabulary source backed by a TSV file.
+///
+/// Schema: `surface<TAB>reading<TAB>pos<TAB>score`。
+/// 先頭 `#` の行および空行は comment として skip する。`score` は f32 として
+/// 解釈し、parse 失敗時は malformed line として reject する(spec §5.2)。
+///
+/// # Invariants
+///
+/// - `entries` key は hiragana reading、value は同 reading を持つ entry 配列
+/// - `vocab_id` は `"custom(<source_label>)"` 形式
+#[derive(Debug, Clone)]
+pub struct CustomVocab {
+    entries: HashMap<String, Vec<VocabEntry>>,
+    vocab_id: String,
+}
+
+impl CustomVocab {
+    /// Loads a custom vocab from a TSV file on disk.
+    ///
+    /// # Errors
+    ///
+    /// - [`KanjiError::Backend`] when the file cannot be read or parsed.
+    pub fn load(path: &Path) -> Result<Self, KanjiError> {
+        let content = fs::read_to_string(path).map_err(|e| KanjiError::Backend {
+            reason: format!("failed to read custom vocab {}: {e}", path.display()),
+        })?;
+        let label = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        Self::parse(&content, &label)
+    }
+
+    /// Parses a TSV string in-memory. Used directly by unit tests and by
+    /// `load` after reading from disk.
+    ///
+    /// # Errors
+    ///
+    /// - [`KanjiError::Backend`] when any non-comment line has a field count
+    ///   other than 4 or a non-parsable score.
+    pub fn from_str(content: &str) -> Result<Self, KanjiError> {
+        Self::parse(content, "inline")
+    }
+
+    fn parse(content: &str, source_label: &str) -> Result<Self, KanjiError> {
+        let mut entries: HashMap<String, Vec<VocabEntry>> = HashMap::new();
+        for (lineno, raw) in content.lines().enumerate() {
+            let line = raw.trim_end_matches('\r');
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() != 4 {
+                return Err(KanjiError::Backend {
+                    reason: format!(
+                        "malformed TSV line {} in '{}': expected 4 fields, got {}",
+                        lineno + 1,
+                        source_label,
+                        parts.len()
+                    ),
+                });
+            }
+            let score: f32 = parts[3].parse().map_err(|e| KanjiError::Backend {
+                reason: format!(
+                    "malformed score on line {} in '{}': {e}",
+                    lineno + 1,
+                    source_label
+                ),
+            })?;
+            let entry = VocabEntry {
+                surface: parts[0].to_string(),
+                reading: parts[1].to_string(),
+                pos: parts[2].to_string(),
+                score,
+            };
+            entries
+                .entry(entry.reading.clone())
+                .or_default()
+                .push(entry);
+        }
+        // 同 reading 内を score 降順に保持しておく(lookup で再 sort しないため)
+        for vs in entries.values_mut() {
+            vs.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+        }
+        Ok(Self {
+            entries,
+            vocab_id: format!("custom({source_label})"),
+        })
+    }
+}
+
+impl VocabularyLookup for CustomVocab {
+    fn lookup(&self, reading: &str) -> Vec<VocabEntry> {
+        self.entries
+            .get(reading)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn vocab_id(&self) -> &str {
+        &self.vocab_id
+    }
+}
+```
+
+- [ ] **Step 4: `cargo test --features dict -p kotoha-core -- dict::custom_vocab::tests` で 6/6 PASS を確認**
+
+想定: `test result: ok. 6 passed; 0 failed; ...`。
+
+- [ ] **Step 5: clippy 通過確認**
+
+```bash
+cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/dict/custom_vocab.rs
+git commit -m "feat(dict): implement CustomVocab TSV reader (#91)"
+```
+
+---
+
+## Task 6: DictionaryConfig 定義(TDD)
+
+**Files:**
+- Modify: `crates/kotoha-core/src/dict/mod.rs`(`DictionaryConfig` 定義 + `resolve_dict_path` helper + `pub use` 追加)
+
+**Depends-on:** Task 5
+
+**Estimated LOC:** 50(impl 25 + tests 25)
+
+参照: spec §3.4, §4.4, §5.1
+
+- [ ] **Step 1: test を先に書く(Red)**
+
+`dict/mod.rs` 末尾に以下を追加する。
+
+```rust
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn dictionary_config_default_is_none_paths() {
+        let cfg = DictionaryConfig::default();
+        assert!(cfg.system_dict_path.is_none());
+        assert!(cfg.custom_vocab_path.is_none());
+    }
+
+    #[test]
+    fn dictionary_config_clone_preserves_fields() {
+        let cfg = DictionaryConfig {
+            system_dict_path: Some(PathBuf::from("/tmp/system_core.dic")),
+            custom_vocab_path: Some(PathBuf::from("/tmp/kotoha-dict.tsv")),
+        };
+        let cloned = cfg.clone();
+        assert_eq!(cloned.system_dict_path, cfg.system_dict_path);
+        assert_eq!(cloned.custom_vocab_path, cfg.custom_vocab_path);
+    }
+
+    #[test]
+    fn dictionary_config_debug_contains_field_names() {
+        let cfg = DictionaryConfig {
+            system_dict_path: Some(PathBuf::from("/tmp/system_core.dic")),
+            custom_vocab_path: None,
+        };
+        let msg = format!("{cfg:?}");
+        assert!(msg.contains("system_dict_path"), "Debug must expose field names: {msg}");
+    }
+
+    #[test]
+    fn resolve_dict_path_prefers_explicit_over_env() {
+        let explicit = PathBuf::from("/tmp/explicit.dic");
+        let resolved = resolve_dict_path(Some(&explicit), None);
+        assert_eq!(resolved, Some(PathBuf::from("/tmp/explicit.dic")));
+    }
+
+    #[test]
+    fn resolve_dict_path_falls_back_to_env_var() {
+        let resolved = resolve_dict_path(None, Some("/tmp/env.dic".to_string()));
+        assert_eq!(resolved, Some(PathBuf::from("/tmp/env.dic")));
+    }
+
+    #[test]
+    fn resolve_dict_path_returns_none_when_both_absent() {
+        let resolved = resolve_dict_path(None, None);
+        assert!(resolved.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: `cargo test --features dict -p kotoha-core -- dict::config_tests` で FAIL を確認**
+
+- [ ] **Step 3: impl を実装(Green)**
+
+`dict/mod.rs` の冒頭 doc-comment と `pub(crate) mod` 群との間に以下を追加する。
+
+```rust
+use std::path::{Path, PathBuf};
+
+pub use self::backend::DictionaryBackend;
+pub use self::engine::{EngineCandidate, MorphologicalEngine};
+pub use self::vocab::{VocabEntry, VocabularyLookup};
+
+/// Engine 非依存の Dictionary backend 設定(spec §3.4 Q4)。
+///
+/// 将来 engine を vibrato / lindera に置換しても config 互換性を保つため、
+/// field 名に engine 名を含めない(`sudachi_dict_path` ではなく `system_dict_path`)。
+///
+/// # Invariants
+///
+/// - `system_dict_path` が `None` の場合、`DictionaryBackend::load` は
+///   `KOTOHA_SYSTEM_DICT_PATH` 環境変数を読みに行く
+/// - `custom_vocab_path` が `None` の場合、backend は custom vocab を持たない
+#[derive(Debug, Clone, Default)]
+pub struct DictionaryConfig {
+    /// 形態素解析用 system dictionary file のパス(SudachiDict-core `system_core.dic`)。
+    pub system_dict_path: Option<PathBuf>,
+    /// Custom vocabulary TSV file のパス(`kotoha-dict.tsv`)。
+    pub custom_vocab_path: Option<PathBuf>,
+}
+
+/// 明示 path、次点で env var、どちらも無ければ `None` を返す解決ヘルパ。
+///
+/// `DictionaryBackend::load` は本関数で `system_dict_path` を解決する。
+/// `env_value` 引数は test 容易性のため `std::env::var` の結果を呼び出し側が
+/// 注入する契約にする(spec §3.4 / §5.1)。
+pub(crate) fn resolve_dict_path(
+    explicit: Option<&Path>,
+    env_value: Option<String>,
+) -> Option<PathBuf> {
+    if let Some(p) = explicit {
+        return Some(p.to_path_buf());
+    }
+    env_value.map(PathBuf::from)
+}
+```
+
+- [ ] **Step 4: `cargo test --features dict -p kotoha-core -- dict::config_tests` で 6/6 PASS を確認**
+
+- [ ] **Step 5: clippy 通過確認**
+
+```bash
+cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/dict/mod.rs
+git commit -m "feat(dict): define DictionaryConfig with engine-neutral field names (#91)"
+```
+
+---
+
+## Task 7: SudachiAdapter 実装(TDD relaxed)
+
+**Files:**
+- Modify: `crates/kotoha-core/src/dict/sudachi_adapter.rs`
+
+**Depends-on:** Task 6
+
+**Estimated LOC:** 120(impl 90 + tests 30)
+
+参照: spec §3.4, §4.1, §5.1
+
+SudachiDict 実体が無いと本格的な unit test を書けないため、本 task の Layer 1 test は struct compile + `engine_id` の format 検証のみを対象とする。実辞書経由の検証は Task 14 (Layer 3 golden) で行う。
+
+- [ ] **Step 1: test を先に書く(Red / compile-only check)**
+
+`dict/sudachi_adapter.rs` 末尾に以下を追加する。
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kanji::KanjiError;
+    use std::path::Path;
+
+    #[test]
+    fn sudachi_adapter_load_missing_file_errors() {
+        let err = SudachiAdapter::load(Path::new("/tmp/definitely-does-not-exist-kotoha-p2a.dic"))
+            .expect_err("load must error when the path does not exist");
+        match err {
+            KanjiError::ModelNotFound { path } => {
+                assert!(path.to_string_lossy().contains("definitely-does-not-exist"));
+            }
+            other => panic!("expected ModelNotFound, got: {other:?}"),
+        }
+    }
+
+    // engine_id フォーマット整合(実辞書 load せずに type / trait 経由では
+    // engine_id を確認できないため、本 test は Layer 3 golden 側へ委譲する)。
+    // ここでは engine_id() format に含めるべき文字列リテラルを const で固定し
+    // Layer 3 test 側と同一文字列を使うことで整合を担保する。
+    #[test]
+    fn sudachi_engine_id_label_constant_is_stable() {
+        assert!(SUDACHI_ENGINE_ID_LABEL.contains("sudachi"));
+        assert!(SUDACHI_ENGINE_ID_LABEL.contains("0.6"));
+    }
+}
+```
+
+- [ ] **Step 2: FAIL を確認**
+
+```bash
+cargo test --features dict -p kotoha-core -- dict::sudachi_adapter::tests
+```
+
+想定: `cannot find type 'SudachiAdapter'` / `cannot find value 'SUDACHI_ENGINE_ID_LABEL'`。
+
+- [ ] **Step 3: impl(sudachi.rs runtime ラッパー)**
+
+`dict/sudachi_adapter.rs` の `#[cfg(test)]` より前に以下を追加する。
+
+```rust
+use std::path::{Path, PathBuf};
+
+use sudachi::analysis::stateful_tokenizer::StatefulTokenizer;
+use sudachi::config::Config;
+use sudachi::dic::dictionary::JapaneseDictionary;
+use sudachi::prelude::*;
+
+use crate::dict::engine::{EngineCandidate, MorphologicalEngine};
+use crate::kanji::KanjiError;
+
+/// sudachi.rs の engine_id() で返す固定 label。Layer 3 golden test から
+/// 同一文字列でアサートするため、module スコープの `pub(crate)` const として
+/// 固定する。
+pub(crate) const SUDACHI_ENGINE_ID_LABEL: &str = "sudachi-0.6.11+sudachidict-core:v20260116";
+
+/// `MorphologicalEngine` の sudachi.rs 実装。
+///
+/// # Invariants
+///
+/// - `dict` は初期化済み `JapaneseDictionary`
+/// - `system_dict_path` は `dict` を load した際の path(diagnostics 用)
+///
+/// # Errors
+///
+/// - [`KanjiError::ModelNotFound`] when the dict file does not exist
+/// - [`KanjiError::ModelLoadFailed`] when sudachi.rs fails to parse the dict
+pub struct SudachiAdapter {
+    dict: JapaneseDictionary,
+    system_dict_path: PathBuf,
+}
+
+impl SudachiAdapter {
+    /// Loads a SudachiDict-core file from disk.
+    pub fn load(system_dict_path: &Path) -> Result<Self, KanjiError> {
+        if !system_dict_path.exists() {
+            return Err(KanjiError::ModelNotFound {
+                path: system_dict_path.to_path_buf(),
+            });
+        }
+        // sudachi.rs は Config builder で system dict path を受ける
+        let config = Config::new(None, None, Some(system_dict_path.to_path_buf()))
+            .map_err(|e| KanjiError::ModelLoadFailed {
+                source: Box::new(e),
+            })?;
+        let dict = JapaneseDictionary::from_cfg(&config).map_err(|e| KanjiError::ModelLoadFailed {
+            source: Box::new(e),
+        })?;
+        Ok(Self {
+            dict,
+            system_dict_path: system_dict_path.to_path_buf(),
+        })
+    }
+}
+
+impl MorphologicalEngine for SudachiAdapter {
+    fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError> {
+        if reading.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut tokenizer: StatefulTokenizer<&JapaneseDictionary> =
+            StatefulTokenizer::create(&self.dict, false, sudachi::analysis::Mode::C);
+        tokenizer
+            .reset()
+            .push_str(reading);
+        tokenizer.do_tokenize().map_err(|e| KanjiError::Backend {
+            reason: format!(
+                "sudachi tokenize failed for input {:?} using dict {}: {e}",
+                reading,
+                self.system_dict_path.display()
+            ),
+        })?;
+        let mut morphemes = MorphemeList::empty(&self.dict);
+        tokenizer
+            .into_morpheme_list(&mut morphemes)
+            .map_err(|e| KanjiError::Backend {
+                reason: format!("sudachi morpheme collection failed: {e}"),
+            })?;
+
+        let mut out = Vec::with_capacity(morphemes.len());
+        for m in morphemes.iter() {
+            // sudachi.rs の morpheme は surface + reading_form + word_info を持つ。
+            // score は cost を反転(負)して「大きい方が良い」契約へ揃える。
+            let surface = m.surface().to_string();
+            let reading_form = m.reading_form().to_string();
+            let cost = m.word_info().head_word_length() as f32; // placeholder score proxy
+            out.push(EngineCandidate {
+                surface,
+                reading: reading_form,
+                score: -cost,
+            });
+        }
+        Ok(out)
+    }
+
+    fn engine_id(&self) -> &str {
+        SUDACHI_ENGINE_ID_LABEL
+    }
+}
+```
+
+注: sudachi.rs の score 抽出 API は v0.6.11 時点で完全に安定しておらず、本 plan では `head_word_length` を score proxy に用いる。実測で pass rate を満たさない場合、Task 14 の診断 step で `word_info().oov()` や cost 直接取得 API への切替を検討する。
+
+- [ ] **Step 4: `cargo test --features dict -p kotoha-core -- dict::sudachi_adapter::tests` で 2/2 PASS を確認**
+
+想定: `test result: ok. 2 passed; 0 failed; ...`(実辞書 load は行わない test のみ)。
+
+- [ ] **Step 5: clippy 通過確認**
+
+```bash
+cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/dict/sudachi_adapter.rs
+git commit -m "feat(dict): implement SudachiAdapter morphological engine (#91)"
+```
+
+---
+
+## Task 8: DictionaryBackend 実装(TDD strict、MockEngine + MockVocab 注入)
+
+**Files:**
+- Modify: `crates/kotoha-core/src/dict/backend.rs`
+
+**Depends-on:** Task 7
+
+**Estimated LOC:** 250(impl 150 + tests 100)
+
+参照: spec §3.5, §3.6, §4.3
+
+- [ ] **Step 1: test を先に書く(Red)— 7 test を先行記述**
+
+`dict/backend.rs` 末尾に以下を追加する。
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dict::engine::{EngineCandidate, MorphologicalEngine};
+    use crate::dict::vocab::{VocabEntry, VocabularyLookup};
+    use crate::kanji::{Candidate, ConvertOptions, KanjiError};
+
+    struct StubEngine {
+        canned: Vec<EngineCandidate>,
+    }
+
+    impl MorphologicalEngine for StubEngine {
+        fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError> {
+            if reading.is_empty() {
+                return Ok(Vec::new());
+            }
+            Ok(self.canned.clone())
+        }
+        fn engine_id(&self) -> &str { "stub-engine" }
+    }
+
+    struct StubVocab {
+        canned: Vec<VocabEntry>,
+    }
+
+    impl VocabularyLookup for StubVocab {
+        fn lookup(&self, reading: &str) -> Vec<VocabEntry> {
+            if reading.is_empty() { Vec::new() } else { self.canned.clone() }
+        }
+        fn vocab_id(&self) -> &str { "stub-vocab" }
+    }
+
+    fn backend_with(engine_cands: Vec<EngineCandidate>, vocab_cands: Vec<VocabEntry>) -> DictionaryBackend {
+        DictionaryBackend::from_parts(
+            Box::new(StubEngine { canned: engine_cands }),
+            vec![Box::new(StubVocab { canned: vocab_cands })],
+        )
+    }
+
+    #[test]
+    fn dict_backend_rejects_non_hiragana_input() {
+        let b = backend_with(Vec::new(), Vec::new());
+        let err = b.convert("abc", &ConvertOptions::default()).expect_err("latin reject");
+        assert!(matches!(err, KanjiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn dict_backend_empty_input_returns_empty_vec() {
+        let b = backend_with(Vec::new(), Vec::new());
+        let out = b.convert("", &ConvertOptions::default()).expect("empty ok");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn dict_backend_merges_engine_and_vocab_results() {
+        let b = backend_with(
+            vec![EngineCandidate { surface: "漢字".into(), reading: "かんじ".into(), score: 0.5 }],
+            vec![VocabEntry { surface: "感じ".into(), reading: "かんじ".into(), pos: "動詞".into(), score: 0.4 }],
+        );
+        let out = b.convert("かんじ", &ConvertOptions::default()).expect("merge ok");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].surface, "漢字");
+        assert_eq!(out[1].surface, "感じ");
+    }
+
+    #[test]
+    fn dict_backend_dedupes_duplicate_surfaces_keeping_highest_score() {
+        let b = backend_with(
+            vec![EngineCandidate { surface: "漢字".into(), reading: "かんじ".into(), score: 0.3 }],
+            vec![VocabEntry { surface: "漢字".into(), reading: "かんじ".into(), pos: "名詞".into(), score: 0.9 }],
+        );
+        let out = b.convert("かんじ", &ConvertOptions::default()).expect("dedupe ok");
+        assert_eq!(out.len(), 1);
+        assert!((out[0].score - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dict_backend_truncates_to_top_k() {
+        let engine_cands = (0..10)
+            .map(|i| EngineCandidate {
+                surface: format!("s{i}"),
+                reading: "かんじ".into(),
+                score: i as f32 / 10.0,
+            })
+            .collect();
+        let b = backend_with(engine_cands, Vec::new());
+        let opts = ConvertOptions { top_k: 3, temperature: 0.0, seed: Some(0) };
+        let out = b.convert("かんじ", &opts).expect("truncate ok");
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn dict_backend_top_k_zero_returns_empty() {
+        let b = backend_with(
+            vec![EngineCandidate { surface: "漢字".into(), reading: "かんじ".into(), score: 0.9 }],
+            Vec::new(),
+        );
+        let opts = ConvertOptions { top_k: 0, temperature: 0.0, seed: Some(0) };
+        let out = b.convert("かんじ", &opts).expect("empty ok");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn dict_backend_model_id_contains_engine_id() {
+        let b = backend_with(Vec::new(), Vec::new());
+        let id = b.model_id();
+        assert!(id.contains("dictionary"), "model_id should start with 'dictionary': {id}");
+        assert!(id.contains("stub-engine"), "model_id should embed engine_id: {id}");
+    }
+}
+```
+
+- [ ] **Step 2: FAIL を確認**
+
+```bash
+cargo test --features dict -p kotoha-core -- dict::backend::tests
+```
+
+想定: `cannot find type 'DictionaryBackend'`。
+
+- [ ] **Step 3: impl**
+
+`dict/backend.rs` の `#[cfg(test)]` より前に以下を追加する。
+
+```rust
+use std::path::Path;
+
+use crate::dict::engine::MorphologicalEngine;
+use crate::dict::vocab::VocabularyLookup;
+use crate::dict::{resolve_dict_path, DictionaryConfig};
+use crate::kanji::backend::{score_sort_dedupe, validate_input};
+use crate::kanji::{Candidate, ConvertOptions, KanjiBackend, KanjiError};
+
+/// SudachiDict ベースの Dictionary backend。
+///
+/// `KanjiBackend` の 2 つ目の実装(LlamaCpp に続く、spec §4.3)。
+/// `MorphologicalEngine` と `VocabularyLookup` を field に保持し、両者の
+/// 候補を merge / dedupe / truncate して返す。
+///
+/// # Invariants
+///
+/// - `engine` は単一の形態素解析 engine(SudachiAdapter 等)
+/// - `vocab_sources` は 0 個以上の vocab source(CustomVocab 等)
+/// - `model_id` は `"dictionary({engine_id})"` 形式で初期化時に確定
+pub struct DictionaryBackend {
+    engine: Box<dyn MorphologicalEngine>,
+    vocab_sources: Vec<Box<dyn VocabularyLookup>>,
+    model_id: String,
+}
+
+impl std::fmt::Debug for DictionaryBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DictionaryBackend")
+            .field("engine_id", &self.engine.engine_id())
+            .field("vocab_count", &self.vocab_sources.len())
+            .field("model_id", &self.model_id)
+            .finish()
+    }
+}
+
+impl DictionaryBackend {
+    /// Construct from a `DictionaryConfig`. Resolves `system_dict_path` via
+    /// the env var `KOTOHA_SYSTEM_DICT_PATH` fallback (spec §3.4 / §5.1).
+    ///
+    /// # Errors
+    ///
+    /// - [`KanjiError::ModelNotFound`] when neither config nor env var is set.
+    /// - Errors bubbled up from `SudachiAdapter::load` / `CustomVocab::load`.
+    pub fn load(config: &DictionaryConfig) -> Result<Self, KanjiError> {
+        let env_value = std::env::var("KOTOHA_SYSTEM_DICT_PATH").ok();
+        let Some(dict_path) = resolve_dict_path(config.system_dict_path.as_deref(), env_value)
+        else {
+            return Err(KanjiError::ModelNotFound {
+                path: Path::new("").to_path_buf(),
+            });
+        };
+
+        let engine = Box::new(crate::dict::sudachi_adapter::SudachiAdapter::load(&dict_path)?);
+
+        let mut vocab_sources: Vec<Box<dyn VocabularyLookup>> = Vec::new();
+        if let Some(vp) = &config.custom_vocab_path {
+            vocab_sources.push(Box::new(crate::dict::custom_vocab::CustomVocab::load(vp)?));
+        }
+        let model_id = format!("dictionary({})", engine.engine_id());
+        Ok(Self {
+            engine,
+            vocab_sources,
+            model_id,
+        })
+    }
+
+    /// Test-only constructor — allows direct injection of stub engine / vocab.
+    ///
+    /// Not part of the stable public API.
+    #[doc(hidden)]
+    pub fn from_parts(
+        engine: Box<dyn MorphologicalEngine>,
+        vocab_sources: Vec<Box<dyn VocabularyLookup>>,
+    ) -> Self {
+        let model_id = format!("dictionary({})", engine.engine_id());
+        Self {
+            engine,
+            vocab_sources,
+            model_id,
+        }
+    }
+}
+
+impl KanjiBackend for DictionaryBackend {
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError> {
+        validate_input(input)?;
+        if input.is_empty() || options.top_k == 0 {
+            return Ok(Vec::new());
+        }
+        let mut raw: Vec<Candidate> = Vec::new();
+        for ec in self.engine.tokenize(input)? {
+            raw.push(Candidate::new(ec.surface, ec.score));
+        }
+        for vocab in &self.vocab_sources {
+            for ve in vocab.lookup(input) {
+                raw.push(Candidate::new(ve.surface, ve.score));
+            }
+        }
+        Ok(score_sort_dedupe(raw, options.top_k))
+    }
+}
+```
+
+- [ ] **Step 4: `cargo test --features dict -p kotoha-core -- dict::backend::tests` で 7/7 PASS を確認**
+
+- [ ] **Step 5: clippy 通過確認**
+
+```bash
+cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/dict/backend.rs
+git commit -m "feat(dict): implement DictionaryBackend with MockEngine/MockVocab tests (#91)"
+```
+
+---
+
+## Task 9: resources/kotoha-dict.tsv(空 fixture + curation policy)
+
+**Files:**
+- Create: `crates/kotoha-core/resources/kotoha-dict.tsv`
+
+**Depends-on:** Task 8
+
+**Estimated LOC:** 15
+
+参照: spec §3.7, §5.2
+
+- [ ] **Step 1: resources/ ディレクトリを作成**
+
+```bash
+mkdir -p crates/kotoha-core/resources
+```
+
+- [ ] **Step 2: `kotoha-dict.tsv` を以下の内容で作成**
+
+```tsv
+# kotoha-dict.tsv — Kotoha custom vocabulary
+# Schema: surface<TAB>reading<TAB>pos<TAB>score
+# Curation policy (P2-A spec §3.7 Q7):
+#   1. SudachiDict-core baseline で recall 可能な語彙は追加しない
+#   2. golden fixture で観察される gap のみを証拠ベースで追加する
+#   3. 同 reading で SudachiDict が出す surface を上書きする entry は
+#      P2-B 以降で機械的多義性チェックを通すこと
+# (P2-A: 空 start。entry は後続 milestone で追加する)
+```
+
+- [ ] **Step 3: kotoha-core から `include_str!` 経由で読み込む予備 smoke として、直接参照はしないため check のみ**
+
+本 task では bundled file は作成するが、current impl で `include_str!` 経由の runtime 参照は行わない(runtime は `custom_vocab_path` config or env var 経由 load)。`cargo check` が通ることのみを確認する。
+
+```bash
+cargo check --workspace --features dict
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/resources/kotoha-dict.tsv
+git commit -m "feat(dict): bundle empty kotoha-dict.tsv with curation policy (#91)"
+```
+
+---
+
+## Task 10: BackendConfig::Dictionary variant + load_backend arm 追加(TDD strict)
+
+**Files:**
+- Modify: `crates/kotoha-core/src/kanji/backend.rs`(enum 拡張 + load_backend arm)
+- Modify: `crates/kotoha-core/src/kanji/mod.rs`(`DictionaryBackend` の re-export gated)
+
+**Depends-on:** Task 9
+
+**Estimated LOC:** 70(enum + arm 30 + tests 40)
+
+参照: spec §3.3, §4.4
+
+- [ ] **Step 1: test を先に書く(Red)— kanji/backend.rs `mod tests` 末尾に追加**
+
+既存 `mod tests` 内、`BackendConfig` セクションの末尾に以下を追加する。
+
+```rust
+    // ======================================================================
+    // BackendConfig::Dictionary (P2-A)
+    // ======================================================================
+
+    #[cfg(feature = "dict")]
+    #[test]
+    fn backend_config_dictionary_is_clone_and_debug() {
+        use crate::dict::DictionaryConfig;
+        let cfg = BackendConfig::Dictionary {
+            config: DictionaryConfig {
+                system_dict_path: Some(PathBuf::from("/tmp/system_core.dic")),
+                custom_vocab_path: None,
+            },
+        };
+        let cloned = cfg.clone();
+        let msg = format!("{cloned:?}");
+        assert!(msg.contains("Dictionary"));
+        assert!(msg.contains("system_dict_path"));
+    }
+
+    #[cfg(not(feature = "dict"))]
+    #[test]
+    fn dictionary_config_without_feature_errors_feature_disabled() {
+        // feature=dict OFF 時は BackendConfig::Dictionary variant 自体が
+        // `#[cfg(feature = "dict")]` で gate される設計のため本 test は該当時
+        // のみ compile する。本 test は「feature OFF を明示する placeholder」
+        // として空アサーションを置く。
+        let _ = std::any::type_name::<BackendConfig>();
+    }
+
+    #[cfg(feature = "dict")]
+    #[test]
+    fn dictionary_config_load_backend_missing_env_errors_model_not_found() {
+        use crate::dict::DictionaryConfig;
+        // env var も config も無い状態で load_backend を呼ぶと ModelNotFound
+        std::env::remove_var("KOTOHA_SYSTEM_DICT_PATH");
+        let cfg = BackendConfig::Dictionary {
+            config: DictionaryConfig::default(),
+        };
+        match load_backend(&cfg) {
+            Err(KanjiError::ModelNotFound { .. }) => {}
+            other => panic!("expected ModelNotFound, got: {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: FAIL を確認**
+
+```bash
+cargo test --features dict -p kotoha-core --lib -- kanji::backend::tests
+```
+
+想定: `variant 'Dictionary' not found in 'BackendConfig'`。
+
+- [ ] **Step 3: `BackendConfig` に variant を追加(Green)**
+
+`kanji/backend.rs` の enum 定義に以下を追加する。
+
+```rust
+    /// SudachiDict-based dictionary backend (P2-A、spec §3.3 / §4.4).
+    /// Constructible only when the `dict` feature flag is enabled at build time.
+    #[cfg(feature = "dict")]
+    Dictionary {
+        /// Engine-neutral config (spec §3.4 Q4).
+        config: crate::dict::DictionaryConfig,
+    },
+```
+
+- [ ] **Step 4: `load_backend` factory に arm を追加**
+
+既存 `LlamaCpp { .. }` arm の直後に以下を追加する。
+
+```rust
+        #[cfg(feature = "dict")]
+        BackendConfig::Dictionary { config } => {
+            Ok(Box::new(crate::dict::DictionaryBackend::load(config)?))
+        }
+```
+
+- [ ] **Step 5: `kanji/mod.rs` で `DictionaryBackend` の re-export を gated 追加**
+
+既存 `#[cfg(feature = "llama-cpp")] pub use llama_cpp::LlamaCppBackend;` の直後に追加する。
+
+```rust
+#[cfg(feature = "dict")]
+pub use crate::dict::DictionaryBackend;
+```
+
+- [ ] **Step 6: `cargo test --features dict -p kotoha-core --lib` で全 PASS を確認**
+
+```bash
+cargo test --features dict -p kotoha-core --lib
+```
+
+- [ ] **Step 7: `cargo test --features mock-backend,dict -p kotoha-core` で既存 Mock 系を含めた全 PASS を確認**
+
+- [ ] **Step 8: clippy 通過確認**
+
+```bash
+cargo clippy --features mock-backend,dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/src/kanji/backend.rs crates/kotoha-core/src/kanji/mod.rs
+git commit -m "feat(kanji): add BackendConfig::Dictionary variant + load_backend arm (#91)"
+```
+
+---
+
+## Task 11: Layer 2 integration test(kanji_dictionary_unit.rs)
+
+**Files:**
+- Create: `crates/kotoha-core/tests/kanji_dictionary_unit.rs`
+
+**Depends-on:** Task 10
+
+**Estimated LOC:** 120
+
+参照: spec §6.2
+
+- [ ] **Step 1: test file を作成**
+
+```rust
+//! Layer 2 integration tests for the Dictionary backend (P2-A).
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §6.2.
+//!
+//! これらの test は SudachiDict 不在環境でも実行可能。実辞書が要る smoke
+//! は `kanji_dictionary_golden.rs` (Layer 3、`dict-smoke` feature) 側に置く。
+
+#![cfg(feature = "dict")]
+
+use std::path::PathBuf;
+
+use kotoha_core::dict::DictionaryConfig;
+use kotoha_core::kanji::{load_backend, BackendConfig, KanjiError};
+
+#[test]
+fn load_backend_dictionary_without_env_errors_model_not_found() {
+    std::env::remove_var("KOTOHA_SYSTEM_DICT_PATH");
+    let cfg = BackendConfig::Dictionary {
+        config: DictionaryConfig::default(),
+    };
+    let err = load_backend(&cfg).expect_err("no dict path must error");
+    assert!(matches!(err, KanjiError::ModelNotFound { .. }));
+}
+
+#[test]
+fn load_backend_dictionary_with_nonexistent_path_errors_model_not_found() {
+    let cfg = BackendConfig::Dictionary {
+        config: DictionaryConfig {
+            system_dict_path: Some(PathBuf::from(
+                "/tmp/definitely-does-not-exist-kotoha-p2a-integration.dic",
+            )),
+            custom_vocab_path: None,
+        },
+    };
+    let err = load_backend(&cfg).expect_err("missing file must error");
+    match err {
+        KanjiError::ModelNotFound { path } => {
+            assert!(path.to_string_lossy().contains("definitely-does-not-exist"));
+        }
+        other => panic!("expected ModelNotFound, got: {other:?}"),
+    }
+}
+
+#[test]
+fn dictionary_config_default_is_all_none() {
+    let cfg = DictionaryConfig::default();
+    assert!(cfg.system_dict_path.is_none());
+    assert!(cfg.custom_vocab_path.is_none());
+}
+
+#[test]
+fn dictionary_config_env_var_resolve_fallback_works() {
+    // NOTE: env var を直接書き換える test は並列実行で flaky になる可能性
+    // があるため、resolve は unit test 側 (dict::config_tests) で検証し、
+    // 本 integration test では path 明示の振る舞いのみを確認する。
+    let cfg = DictionaryConfig {
+        system_dict_path: Some(PathBuf::from("/tmp/explicit-path.dic")),
+        custom_vocab_path: None,
+    };
+    let result = load_backend(&BackendConfig::Dictionary { config: cfg });
+    // explicit path でも実ファイルは無いため ModelNotFound になる。これは
+    // env var fallback 経路ではなく explicit 経路を通過したことの裏返し。
+    match result {
+        Err(KanjiError::ModelNotFound { path }) => {
+            assert_eq!(path, PathBuf::from("/tmp/explicit-path.dic"));
+        }
+        other => panic!("expected ModelNotFound from explicit path, got: {other:?}"),
+    }
+}
+
+#[test]
+fn dictionary_config_custom_vocab_missing_errors_backend() {
+    let cfg = DictionaryConfig {
+        system_dict_path: Some(PathBuf::from("/tmp/no-such-system.dic")),
+        custom_vocab_path: Some(PathBuf::from("/tmp/no-such-custom.tsv")),
+    };
+    // system_dict の load で ModelNotFound に到達し、custom_vocab の load
+    // には進まない。この test は「system が先にチェックされる」順序契約の
+    // regression 防止に相当する。
+    let err = load_backend(&BackendConfig::Dictionary { config: cfg }).expect_err("err");
+    assert!(matches!(err, KanjiError::ModelNotFound { .. }));
+}
+```
+
+- [ ] **Step 2: `cargo test --features dict -p kotoha-core --test kanji_dictionary_unit` で 5/5 PASS を確認**
+
+```bash
+cargo test --features dict -p kotoha-core --test kanji_dictionary_unit
+```
+
+- [ ] **Step 3: clippy 通過確認**
+
+```bash
+cargo clippy --features dict -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/tests/kanji_dictionary_unit.rs
+git commit -m "test(dict): add Layer 2 integration tests for DictionaryBackend (#91)"
+```
+
+---
+
+## Task 12: Fixture 生成 tooling(tools/p2a-fixture-gen/)
+
+**Files:**
+- Create: `tools/p2a-fixture-gen/pyproject.toml`
+- Create: `tools/p2a-fixture-gen/README.md`
+- Create: `tools/p2a-fixture-gen/src/p2a_fixture_gen/__init__.py`
+- Create: `tools/p2a-fixture-gen/src/p2a_fixture_gen/sample.py`
+- Create: `tools/p2a-fixture-gen/src/p2a_fixture_gen/targeted.py`
+- Create: `tools/p2a-fixture-gen/src/p2a_fixture_gen/main.py`
+- Create: `tools/p2a-fixture-gen/tests/test_sample.py`
+- Create: `tools/p2a-fixture-gen/tests/test_targeted.py`
+
+**Depends-on:** Task 11
+
+**Estimated LOC:** 200
+
+参照: spec §6.3.1, §6.3.4
+
+前提: `tools/p5a-data-pipeline/data/sample.tsv` が 1140 行程度存在する(MEMORY.md 記載、P5-A PoC で生成済み)。無い場合は Step 1 で再生成する手順を踏む。
+
+- [ ] **Step 1: p5a sample.tsv の存在を確認、無ければ再生成**
+
+```bash
+ls -la tools/p5a-data-pipeline/data/sample.tsv || (cd tools/p5a-data-pipeline && uv run python -m kotoha_p5a)
+```
+
+想定: sample.tsv が 1100 行以上あれば OK。無い場合の再生成は `uv run python -m kotoha_p5a` で行う(P5-A PoC の main entry)。
+
+- [ ] **Step 2: tools/p2a-fixture-gen ディレクトリを作成**
+
+```bash
+mkdir -p tools/p2a-fixture-gen/src/p2a_fixture_gen tools/p2a-fixture-gen/tests
+```
+
+- [ ] **Step 3: pyproject.toml を作成**
+
+```toml
+[project]
+name = "kotoha-p2a-fixture-gen"
+version = "0.1.0"
+description = "Phase 2 P2-A golden fixture generator (530-case stratified sampling)"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "Kotoha IME contributors" },
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.5",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/p2a_fixture_gen"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+- [ ] **Step 4: README.md を作成**
+
+```markdown
+# kotoha-p2a-fixture-gen
+
+Phase 2 P2-A 用 golden fixture (530 cases) 生成 tool。
+
+## 入力
+
+- `../p5a-data-pipeline/data/sample.tsv`(1100+ 行想定、P5-A PoC 生成物)
+
+## 出力
+
+- `../../crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv`
+
+## 内訳
+
+- targeted 30: 敬称 / 人名 / 地名・組織名 / 外来語(manual curated)
+- bulk 500: reading 文字数 5-bucket 各 100 件 stratified sampling
+
+## 実行
+
+```bash
+cd tools/p2a-fixture-gen
+uv sync
+uv run python -m p2a_fixture_gen.main
+```
+
+seed 固定(42)で再現性あり。
+```
+
+- [ ] **Step 5: `__init__.py` を作成(空)**
+
+```python
+"""Kotoha P2-A golden fixture generator."""
+
+__version__ = "0.1.0"
+```
+
+- [ ] **Step 6: `targeted.py` を作成(targeted 30 cases の manual list)**
+
+```python
+"""Targeted 30 cases for Phase 2 golden fixture (spec §6.3.1)."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Case:
+    input: str
+    expected_top_surface: str
+    category: str
+    note: str
+
+
+TARGETED_CASES: list[Case] = [
+    # 敬称 10
+    Case("やまださん", "山田さん", "honorific", "敬称+人名"),
+    Case("たなかさん", "田中さん", "honorific", "敬称+人名"),
+    Case("すずきせんせい", "鈴木先生", "honorific", "敬称+教職"),
+    Case("さとうさま", "佐藤様", "honorific", "尊敬敬称"),
+    Case("ほんださん", "本田さん", "honorific", "敬称+人名"),
+    Case("なかむらくん", "中村くん", "honorific", "男性敬称"),
+    Case("やまもとちゃん", "山本ちゃん", "honorific", "親愛敬称"),
+    Case("こばやしせんぱい", "小林先輩", "honorific", "年長敬称"),
+    Case("おがわかちょう", "小川課長", "honorific", "役職敬称"),
+    Case("いしいしゃちょう", "石井社長", "honorific", "役職敬称"),
+    # 人名 10
+    Case("やまだたろう", "山田太郎", "personal_name", "姓+名"),
+    Case("すずきはなこ", "鈴木花子", "personal_name", "姓+名"),
+    Case("たなかいちろう", "田中一郎", "personal_name", "姓+名"),
+    Case("さとうけんじ", "佐藤健二", "personal_name", "姓+名"),
+    Case("わたなべゆき", "渡辺由紀", "personal_name", "姓+名"),
+    Case("いとうまさし", "伊藤正", "personal_name", "姓+名"),
+    Case("やまもとあきら", "山本明", "personal_name", "姓+名"),
+    Case("なかむらみさき", "中村美咲", "personal_name", "姓+名"),
+    Case("こばやしゆうじ", "小林雄二", "personal_name", "姓+名"),
+    Case("まつもとなおこ", "松本直子", "personal_name", "姓+名"),
+    # 地名・組織名 5
+    Case("とうきょうと", "東京都", "place_org", "地名"),
+    Case("おおさかふ", "大阪府", "place_org", "地名"),
+    Case("ほっかいどう", "北海道", "place_org", "地名"),
+    Case("きょうとだいがく", "京都大学", "place_org", "組織名"),
+    Case("とよたじどうしゃ", "トヨタ自動車", "place_org", "組織名"),
+    # 外来語 5
+    Case("こんぴゅーたー", "コンピューター", "loanword", "長音付き"),
+    Case("ぷろぐらむ", "プログラム", "loanword", "促音なし"),
+    Case("さーばー", "サーバー", "loanword", "長音付き"),
+    Case("かめら", "カメラ", "loanword", "短い外来語"),
+    Case("すまーとふぉん", "スマートフォン", "loanword", "長音+合成語"),
+]
+
+
+def targeted_as_tsv_rows() -> list[str]:
+    """Return targeted cases as TSV lines (input<TAB>expected<TAB>category<TAB>note)."""
+    return [
+        f"{c.input}\t{c.expected_top_surface}\t{c.category}\t{c.note}"
+        for c in TARGETED_CASES
+    ]
+```
+
+- [ ] **Step 7: `sample.py` を作成(bulk 500 cases の stratified sampling)**
+
+```python
+"""Bulk 500-case stratified sampling (5 buckets × 100) from sample.tsv."""
+
+import random
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+P5A_SAMPLE = REPO_ROOT / "tools" / "p5a-data-pipeline" / "data" / "sample.tsv"
+
+
+def bucket_for_reading_length(n: int) -> str | None:
+    if 1 <= n <= 3:
+        return "B1"
+    if 4 <= n <= 6:
+        return "B2"
+    if 7 <= n <= 10:
+        return "B3"
+    if 11 <= n <= 20:
+        return "B4"
+    if n >= 21:
+        return "B5"
+    return None
+
+
+def load_sample_pairs(path: Path = P5A_SAMPLE) -> list[tuple[str, str]]:
+    """Load (reading, surface) pairs from p5a sample.tsv.
+
+    File format: reading<TAB>surface (per P5-A PoC). Empty / comment lines skipped.
+    """
+    pairs: list[tuple[str, str]] = []
+    if not path.exists():
+        raise FileNotFoundError(
+            f"p5a sample not found: {path}. Run `cd tools/p5a-data-pipeline && uv run python -m kotoha_p5a` first."
+        )
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        pairs.append((parts[0], parts[1]))
+    return pairs
+
+
+def stratified_sample(
+    pairs: list[tuple[str, str]], per_bucket: int = 100, seed: int = 42
+) -> dict[str, list[tuple[str, str]]]:
+    """Group pairs by bucket and sample per_bucket from each. B5 fallback handles scarcity."""
+    rng = random.Random(seed)
+    buckets: dict[str, list[tuple[str, str]]] = {
+        "B1": [],
+        "B2": [],
+        "B3": [],
+        "B4": [],
+        "B5": [],
+    }
+    for reading, surface in pairs:
+        b = bucket_for_reading_length(len(reading))
+        if b is not None:
+            buckets[b].append((reading, surface))
+
+    sampled: dict[str, list[tuple[str, str]]] = {}
+    for b, rows in buckets.items():
+        if len(rows) >= per_bucket:
+            sampled[b] = rng.sample(rows, per_bucket)
+        else:
+            # B5 scarcity fallback: concatenate two B3/B4 entries to reach 21+ chars
+            # until we have per_bucket items. Non-destructive for other buckets.
+            sampled[b] = list(rows)
+            donor = buckets["B3"] + buckets["B4"]
+            while len(sampled[b]) < per_bucket and donor:
+                a = rng.choice(donor)
+                c = rng.choice(donor)
+                combined = (a[0] + c[0], a[1] + c[1])
+                if len(combined[0]) >= 21:
+                    sampled[b].append(combined)
+    return sampled
+
+
+def bulk_as_tsv_rows(sampled: dict[str, list[tuple[str, str]]]) -> list[str]:
+    """Convert sampled dict into TSV rows with category=bulk_<bucket>."""
+    rows: list[str] = []
+    for bucket, pairs in sampled.items():
+        for reading, surface in pairs:
+            rows.append(f"{reading}\t{surface}\tbulk_{bucket}\tstratified")
+    return rows
+```
+
+- [ ] **Step 8: `main.py` を作成(entry point)**
+
+```python
+"""P2-A fixture generator entry point: writes 530-case golden TSV."""
+
+from pathlib import Path
+
+from p2a_fixture_gen.sample import (
+    bulk_as_tsv_rows,
+    load_sample_pairs,
+    stratified_sample,
+)
+from p2a_fixture_gen.targeted import targeted_as_tsv_rows
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+OUTPUT = REPO_ROOT / "crates" / "kotoha-core" / "tests" / "fixtures" / "kanji_dictionary_golden.tsv"
+
+
+def main() -> None:
+    header = [
+        "# kanji_dictionary_golden.tsv — Phase 2 P2-A golden fixture",
+        "# Schema: input<TAB>expected_top_surface<TAB>category<TAB>note",
+        "# Contents: targeted 30 + bulk 500 (5-bucket stratified × 100)",
+        "# Generation: tools/p2a-fixture-gen (seed=42)",
+        "# Threshold: ≥90% pass rate (spec §3.9 / §6.3.2)",
+    ]
+    targeted = targeted_as_tsv_rows()
+    bulk = bulk_as_tsv_rows(stratified_sample(load_sample_pairs()))
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text("\n".join(header + targeted + bulk) + "\n", encoding="utf-8")
+    print(f"wrote {len(targeted) + len(bulk)} rows → {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 9: `tests/test_targeted.py` を作成**
+
+```python
+"""Tests for targeted 30-case list."""
+
+from p2a_fixture_gen.targeted import TARGETED_CASES, targeted_as_tsv_rows
+
+
+def test_targeted_has_30_cases() -> None:
+    assert len(TARGETED_CASES) == 30
+
+
+def test_targeted_categories_cover_four_buckets() -> None:
+    categories = {c.category for c in TARGETED_CASES}
+    assert categories == {"honorific", "personal_name", "place_org", "loanword"}
+
+
+def test_targeted_tsv_rows_have_four_fields() -> None:
+    for row in targeted_as_tsv_rows():
+        assert len(row.split("\t")) == 4
+```
+
+- [ ] **Step 10: `tests/test_sample.py` を作成**
+
+```python
+"""Tests for bulk stratified sampling."""
+
+from p2a_fixture_gen.sample import (
+    bucket_for_reading_length,
+    bulk_as_tsv_rows,
+    stratified_sample,
+)
+
+
+def test_bucket_assignment_by_length() -> None:
+    assert bucket_for_reading_length(1) == "B1"
+    assert bucket_for_reading_length(3) == "B1"
+    assert bucket_for_reading_length(4) == "B2"
+    assert bucket_for_reading_length(7) == "B3"
+    assert bucket_for_reading_length(11) == "B4"
+    assert bucket_for_reading_length(21) == "B5"
+    assert bucket_for_reading_length(0) is None
+
+
+def test_stratified_sample_returns_five_buckets() -> None:
+    # synthetic pairs covering buckets B1-B4 evenly; B5 via fallback
+    pairs: list[tuple[str, str]] = []
+    for n, bucket in [(2, "B1"), (5, "B2"), (8, "B3"), (15, "B4")]:
+        for i in range(150):
+            pairs.append(("あ" * n, "X" * n + str(i)))
+    sampled = stratified_sample(pairs, per_bucket=100)
+    assert set(sampled.keys()) == {"B1", "B2", "B3", "B4", "B5"}
+    assert len(sampled["B1"]) == 100
+    assert len(sampled["B2"]) == 100
+    # B5 may be populated via fallback concat
+    assert len(sampled["B5"]) == 100
+
+
+def test_bulk_tsv_rows_have_four_fields() -> None:
+    pairs = [("あいう", "AIU")] * 5 + [("あいうえ", "AIUE")] * 5
+    sampled = stratified_sample(pairs, per_bucket=5)
+    for row in bulk_as_tsv_rows(sampled):
+        assert len(row.split("\t")) == 4
+```
+
+- [ ] **Step 11: uv sync で依存を解決**
+
+```bash
+cd tools/p2a-fixture-gen && uv sync
+```
+
+- [ ] **Step 12: `uv run pytest` で tool の unit test が通ることを確認**
+
+```bash
+cd tools/p2a-fixture-gen && uv run pytest
+```
+
+想定: `6 passed` 前後(sample_test 3 件 + targeted_test 3 件)。
+
+- [ ] **Final step: Commit**
+
+```bash
+git add tools/p2a-fixture-gen/
+git commit -m "chore(tools): add p2a-fixture-gen for golden fixture generation (#91)"
+```
+
+---
+
+## Task 13: Golden fixture 生成 & commit
+
+**Files:**
+- Create: `crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv`(530 rows)
+
+**Depends-on:** Task 12
+
+**Estimated LOC:** ~530 行 data(+ comment header 5 行)
+
+参照: spec §6.3.1
+
+- [ ] **Step 1: p5a sample.tsv の行数を確認**
+
+```bash
+wc -l tools/p5a-data-pipeline/data/sample.tsv
+```
+
+想定: 1100 行以上。これ未満の場合、`cd tools/p5a-data-pipeline && uv run python -m kotoha_p5a` で再生成する。
+
+- [ ] **Step 2: fixture を生成**
+
+```bash
+cd tools/p2a-fixture-gen && uv run python -m p2a_fixture_gen.main
+```
+
+想定出力: `wrote 530 rows → /home/kohshiro/develops/student/kotoha-ime/crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv`。
+
+- [ ] **Step 3: 生成された TSV を目視確認**
+
+```bash
+head -10 crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv
+tail -5 crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv
+wc -l crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv
+```
+
+想定: 先頭 5 行が header comment、次の 30 行が targeted (honorific / personal_name / …)、残り 500 行が bulk_B1〜B5 の順。total 535 行 (header 5 + data 530)。
+
+- [ ] **Step 4: B5 bucket が fallback 由来であるかどうかを確認し、必要ならコメント追記**
+
+```bash
+grep -c 'bulk_B5' crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv
+```
+
+想定: 100 行。fallback (concat) を使った場合は header の下に `# B5 bucket uses concat fallback for scarcity (spec §10)` を追記する。
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv
+git commit -m "test(dict): add 530-case golden fixture for Phase 2 evaluation (#91)"
+```
+
+---
+
+## Task 14: Layer 3 golden test runner
+
+**Files:**
+- Create: `crates/kotoha-core/tests/kanji_dictionary_golden.rs`
+
+**Depends-on:** Task 13
+
+**Estimated LOC:** 150
+
+参照: spec §6.3.2, §6.3.3
+
+前提: 以下の manual setup を実行者が完了していること。
+
+1. SudachiDict-core を取得 (<https://github.com/WorksApplications/SudachiDict>) し `~/.local/share/sudachidict/system_core.dic` に配置する。
+2. `export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic` を shell に設定する。
+
+- [ ] **Step 1: test runner code を作成**
+
+```rust
+//! Layer 3 golden fixture runner for the Dictionary backend (P2-A).
+//!
+//! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §6.3.
+//!
+//! # Enabling
+//!
+//! - Build-time: `--features dict-smoke`
+//! - Runtime: `KOTOHA_SYSTEM_DICT_PATH` set to SudachiDict-core system_core.dic
+//!
+//! Without the env var the single test in this file prints SKIPPED and
+//! returns early (exit 0), matching the opt-in policy established in
+//! `kanji_llama_cpp_smoke.rs`.
+
+#![cfg(feature = "dict-smoke")]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use kotoha_core::dict::DictionaryConfig;
+use kotoha_core::kanji::{load_backend, BackendConfig, ConvertOptions};
+
+const THRESHOLD: f64 = 0.90;
+
+fn get_dict_path_or_skip() -> Option<PathBuf> {
+    match std::env::var("KOTOHA_SYSTEM_DICT_PATH") {
+        Ok(p) => Some(PathBuf::from(p)),
+        Err(_) => {
+            println!("SKIPPED: KOTOHA_SYSTEM_DICT_PATH not set");
+            None
+        }
+    }
+}
+
+struct Row {
+    input: String,
+    expected: String,
+    category: String,
+}
+
+fn load_fixture() -> Vec<Row> {
+    let tsv = include_str!("fixtures/kanji_dictionary_golden.tsv");
+    tsv.lines()
+        .filter(|l| !l.trim().is_empty() && !l.starts_with('#'))
+        .map(|l| {
+            let parts: Vec<&str> = l.splitn(4, '\t').collect();
+            assert!(parts.len() >= 3, "malformed row: {l}");
+            Row {
+                input: parts[0].to_string(),
+                expected: parts[1].to_string(),
+                category: parts[2].to_string(),
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn dictionary_golden_meets_threshold() {
+    let Some(dict_path) = get_dict_path_or_skip() else {
+        return;
+    };
+
+    let cfg = BackendConfig::Dictionary {
+        config: DictionaryConfig {
+            system_dict_path: Some(dict_path),
+            custom_vocab_path: None,
+        },
+    };
+    let backend = load_backend(&cfg).expect("dict backend must load with real dict");
+    let opts = ConvertOptions {
+        top_k: 5,
+        temperature: 0.0,
+        seed: Some(0),
+    };
+
+    let rows = load_fixture();
+    let total = rows.len();
+    let mut pass = 0usize;
+    let mut by_category: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+
+    for row in &rows {
+        let result = backend.convert(&row.input, &opts);
+        let ok = match result {
+            Ok(cands) if !cands.is_empty() => cands.iter().any(|c| c.surface.contains(&row.expected)),
+            _ => false,
+        };
+        if ok {
+            pass += 1;
+        }
+        let entry = by_category
+            .entry(row.category.clone())
+            .or_insert((0, 0));
+        entry.1 += 1;
+        if ok {
+            entry.0 += 1;
+        }
+    }
+
+    println!("\n=== Category breakdown ===");
+    for (cat, (p, t)) in &by_category {
+        let pct = 100.0 * (*p as f64) / (*t as f64);
+        println!("{cat:15} {p:4}/{t:4} ({pct:5.1}%)");
+    }
+    let pct_total = 100.0 * (pass as f64) / (total as f64);
+    println!("\n=== Total ===");
+    println!(
+        "PASS: {pass}/{total} ({pct_total:.1}%)  -- threshold {:.0}%",
+        THRESHOLD * 100.0
+    );
+
+    assert!(
+        (pass as f64) / (total as f64) >= THRESHOLD,
+        "pass rate {pct_total:.1}% below threshold {:.0}%",
+        THRESHOLD * 100.0
+    );
+}
+```
+
+- [ ] **Step 2: env var 未設定で SKIPPED 動作を確認**
+
+```bash
+unset KOTOHA_SYSTEM_DICT_PATH
+cargo test --features dict-smoke -p kotoha-core --test kanji_dictionary_golden
+```
+
+想定出力: `SKIPPED: KOTOHA_SYSTEM_DICT_PATH not set` → `test result: ok. 1 passed`(early return)。
+
+- [ ] **Step 3: env var 設定で実辞書経由の golden 実行**
+
+```bash
+export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic
+cargo test --features dict-smoke -p kotoha-core --test kanji_dictionary_golden -- --nocapture
+```
+
+想定: Category breakdown が表示され、Total pass rate が 90% 以上。
+
+- [ ] **Step 4: pass rate 90% 未満だった場合の診断**
+
+以下を順に確認し、再 run する。
+
+1. `KOTOHA_SYSTEM_DICT_PATH` が実在ファイルを指しているか `ls -la $KOTOHA_SYSTEM_DICT_PATH`
+2. sudachi.rs `Config::new` の引数順序が v0.6.11 の API と一致しているか(`sudachi::config` module docs 参照)
+3. fixture の category 別 pass rate(targeted < bulk なら fixture 側の expected が厳しすぎる可能性)
+4. `SudachiAdapter::tokenize` の score 付与ロジック(`head_word_length` proxy で不適なら `word_info().oov()` 等に切替)
+
+- [ ] **Step 5: clippy 通過確認**
+
+```bash
+cargo clippy --features dict-smoke -p kotoha-core --all-targets -- -D warnings
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add crates/kotoha-core/tests/kanji_dictionary_golden.rs
+git commit -m "test(dict): add Layer 3 golden test runner with pass-rate threshold (#91)"
+```
+
+---
+
+## Task 15: scripts/phase2-smoke.sh
+
+**Files:**
+- Create: `scripts/phase2-smoke.sh`
+
+**Depends-on:** Task 14
+
+**Estimated LOC:** 25
+
+参照: spec §6.3 / phase1-smoke.sh のテンプレ
+
+- [ ] **Step 1: script を作成**
+
+```bash
+#!/usr/bin/env bash
+# Phase 2 P2-A smoke test — runs the Layer 3 golden fixture via `cargo test
+# --features dict-smoke` against a real SudachiDict-core system dictionary.
+#
+# Usage:
+#   scripts/phase2-smoke.sh
+#
+# Environment:
+#   KOTOHA_SYSTEM_DICT_PATH (required)
+#     Absolute path to SudachiDict-core system_core.dic (v20260116).
+#     If unset, this script prints SKIPPED and exits 77 (matches automake
+#     test-suite SKIP convention, letting CI/lefthook skip gracefully).
+#
+# Exit codes:
+#   0   — golden fixture pass rate ≥ 90%
+#   1   — pass rate below threshold
+#   77  — SKIPPED (env var unset)
+#
+# References:
+#   - Fixture: crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv
+#   - Runner:  crates/kotoha-core/tests/kanji_dictionary_golden.rs
+#   - Spec:    docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md §6.3
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+if [[ -z "${KOTOHA_SYSTEM_DICT_PATH:-}" ]]; then
+  echo "SKIPPED: KOTOHA_SYSTEM_DICT_PATH not set"
+  exit 77
+fi
+
+if [[ ! -f "$KOTOHA_SYSTEM_DICT_PATH" ]]; then
+  echo "FAIL: KOTOHA_SYSTEM_DICT_PATH file does not exist: $KOTOHA_SYSTEM_DICT_PATH" >&2
+  exit 1
+fi
+
+echo "=== phase2-smoke: running Layer 3 golden fixture (530 cases) ==="
+cargo test --features dict-smoke -p kotoha-core --test kanji_dictionary_golden -- --nocapture
+```
+
+- [ ] **Step 2: 実行権限を付与**
+
+```bash
+chmod +x scripts/phase2-smoke.sh
+```
+
+- [ ] **Step 3: env var 未設定で SKIPPED 動作を確認**
+
+```bash
+unset KOTOHA_SYSTEM_DICT_PATH
+bash scripts/phase2-smoke.sh
+echo "exit=$?"
+```
+
+想定出力: `SKIPPED: KOTOHA_SYSTEM_DICT_PATH not set` / `exit=77`。
+
+- [ ] **Step 4: env var 設定で real run**
+
+```bash
+export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic
+bash scripts/phase2-smoke.sh
+```
+
+想定: Layer 3 runner が走り、pass rate ≥ 90% で exit 0。
+
+- [ ] **Step 5: shellcheck 通過確認**
+
+```bash
+shellcheck scripts/phase2-smoke.sh
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git add scripts/phase2-smoke.sh
+git commit -m "chore(scripts): add phase2-smoke.sh for Layer 3 fixture (#91)"
+```
+
+---
+
+## Task 16: Phase 1 14/15 regression check + workspace lint
+
+**Files:** (file 変更なし、sanity check のみ)
+
+**Depends-on:** Task 15
+
+**Estimated LOC:** 0
+
+参照: spec §6.4
+
+- [ ] **Step 1: fmt check**
+
+```bash
+cargo fmt --all -- --check
+```
+
+想定: 差分なしで exit 0。
+
+- [ ] **Step 2: clippy(mock-backend + dict 両 feature on)**
+
+```bash
+cargo clippy --workspace --all-targets --features mock-backend,dict -- -D warnings
+```
+
+想定: warning 0 件で exit 0。
+
+- [ ] **Step 3: workspace test(default features + mock-backend + dict)**
+
+```bash
+cargo test --workspace --features mock-backend,dict
+```
+
+想定: Phase 1 既存 test(175 件前後)+ P2-A 新規 test(33-52 件前後)= total 200-227 件すべて PASS。
+
+- [ ] **Step 4: Layer 3 dict-smoke は別途 Task 14 で検証済。本 task では再実行不要**
+
+- [ ] **Step 5: 結果サマリを記録(commit 不要、変更なし)**
+
+全コマンド exit 0 なら本 task 完了。Fail があれば該当 task に戻って修正する。
+
+---
+
+## Task 17: 付随 docs commits(ADR 0014 改訂 + Phase 2 spec 同期 + README + glossary)
+
+**Files:**
+- Modify: `docs/adr/0014-phase-2-dictionary-layer-architecture.md`(D4 改訂、~30 行)
+- Modify: `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`(§3.4 / §4.2 / §6.3 / §7.3 同期、~95 行)
+- Modify: `README.md`(SudachiDict-core 取得手順 + `KOTOHA_SYSTEM_DICT_PATH` 設定例、~30 行)
+- Modify: `docs/wiki/glossary.md`(MorphologicalEngine / VocabularyLookup / SudachiDict / 形態素解析 4 用語、~10 行)
+
+**Depends-on:** Task 16
+
+**Estimated LOC:** 165 行 docs
+
+参照: spec §8
+
+- [ ] **Step 1: ADR 0014 の現状を Read**
+
+`docs/adr/0014-phase-2-dictionary-layer-architecture.md` の D4 セクションを Read で読み、現行文言を把握する。
+
+- [ ] **Step 2: ADR 0014 D4 を改訂**
+
+旧文言: 「P2-A kick-off で候補 1 / 候補 2 のいずれかを選択」
+新文言: 「Phase 2 で 2 variants を段階的に追加する:
+- P2-A: `BackendConfig::Dictionary { config: DictionaryConfig }` (集約型、LLM を含まない pure Dictionary backend)
+- P2-D: `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict, learning }` (再帰 wrap 型、Phase 5 KotohaNative 加入時にも自動対応)
+
+本判断の根拠は P2-A spec §3.3 Q3 に記載する。」
+
+- [ ] **Step 3: Phase 2 spec を同期更新**
+
+`docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` の §3.4 / §4.2 / §6.3 / §7.3 を Read し、以下 4 点を反映する。
+
+1. §3.4(BackendConfig 候補): 「P2-A で集約型 1 variant 追加、P2-D で再帰 Hybrid 追加」と明記
+2. §4.2(Trait 構成): `MorphologicalEngine` / `VocabularyLookup` の正式 signature を子 spec 側に委譲する旨を追記
+3. §6.3(fixture): 530 cases の内訳(targeted 30 + bulk 500)を子 spec から同期
+4. §7.3(feature flag): `dict` / `dict-smoke` feature 構成を子 spec から同期
+
+- [ ] **Step 4: README.md に SudachiDict-core 取得手順を追記**
+
+`README.md` の Phase 1 モデル配置セクション直後に以下を追加する(既存 LlamaCpp 手順と同 pattern)。
+
+```markdown
+### Phase 2 P2-A: SudachiDict-core の取得と配置
+
+Phase 2 P2-A の Dictionary backend は SudachiDict-core(v20260116、~70MB、Apache-2.0)を runtime load で使用する。bundle しないため、ユーザー側で手動配置する必要がある。
+
+#### 取得手順
+
+```bash
+# 1. SudachiDict-core (system_core.dic) を取得
+mkdir -p ~/.local/share/sudachidict
+curl -L -o ~/.local/share/sudachidict/system_core.dic \
+  https://github.com/WorksApplications/SudachiDict/releases/download/v20260116/sudachi-dictionary-20260116-core.zip
+
+# 2. 環境変数を設定(~/.zshrc または ~/.bashrc に追記推奨)
+export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic
+
+# 3. Layer 3 golden fixture で動作確認
+cargo test --features dict-smoke -p kotoha-core --test kanji_dictionary_golden -- --nocapture
+```
+
+Phase 2 範囲では auto-download しない(Phase 6 UX で実装予定)。
+```
+
+- [ ] **Step 5: glossary.md に 4 用語を追加**
+
+既存 entries を Read で確認し、重複が無いことを確かめた上で以下を追加する(アルファベット順 / 50音順の既存方針に従う)。
+
+```markdown
+## 形態素解析 (Morphological Analysis)
+
+入力テキストを形態素(意味を持つ最小単位)に分割し、各形態素の表記 / 読み / 品詞を同定する処理。Phase 2 P2-A では `MorphologicalEngine` trait 経由で SudachiAdapter 実装として提供する。
+
+## MorphologicalEngine
+
+Phase 2 P2-A で導入した形態素解析 engine の抽象境界 trait。`tokenize(reading) -> Vec<EngineCandidate>` と `engine_id()` を提供する。P2-A は `SudachiAdapter` のみが本 trait を実装するが、Phase 5 以降で vibrato / lindera 等への差し替え余地を確保する目的で先出しする。
+
+## VocabularyLookup
+
+Phase 2 P2-A で導入した user / custom vocabulary の lookup 抽象境界 trait。`lookup(reading) -> Vec<VocabEntry>` と `vocab_id()` を提供する。P2-A は `CustomVocab`(TSV reader)のみが本 trait を実装し、P2-B で `UserVocab` が同 trait を実装する extension path を確保する。
+
+## SudachiDict
+
+WorksApplications が提供する日本語形態素解析辞書(core / small / full の 3 variant)。Kotoha Phase 2 P2-A は SudachiDict-core v20260116 (~70MB、76 万 entries 規模、Apache-2.0) を manual placement で採用する。
+```
+
+- [ ] **Step 6: markdownlint / prettier pre-commit gate 通過を確認**
+
+```bash
+git add docs/adr/0014-phase-2-dictionary-layer-architecture.md \
+        docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md \
+        README.md \
+        docs/wiki/glossary.md
+# pre-commit は lefthook 経由で commit 時に自動発火するので dry-run 要求しない
+```
+
+- [ ] **Final step: Commit**
+
+```bash
+git commit -m "docs(p2a): revise ADR 0014 D4 + sync Phase 2 spec + README + glossary (#91)"
+```
+
+---
+
+## Task 18: Branch push + PR 作成
+
+**Files:** (file 変更なし、git + gh 操作のみ)
+
+**Depends-on:** Task 17
+
+**Estimated LOC:** 0
+
+- [ ] **Step 1: branch を push**
+
+```bash
+git push origin feature/91-p2-a-dictionary-layer
+```
+
+- [ ] **Step 2: PR を作成(英語 body、ISSUE #91 close 宣言含む)**
+
+```bash
+gh pr create --base develop --title "feat(phase-2): P2-A — Dictionary layer kick-off (#91)" --body "$(cat <<'EOF'
+## Summary
+
+Phase 2 P2-A: introduce a SudachiDict-based dictionary backend as the second `KanjiBackend` implementation (after `LlamaCppBackend`).
+
+- Adds `MorphologicalEngine` / `VocabularyLookup` traits (Clean Architecture DIP) and `DictionaryBackend` struct holding both as `Box<dyn _>`.
+- Adds `BackendConfig::Dictionary { config: DictionaryConfig }` variant + `load_backend` arm (gated behind `dict` feature).
+- Adds `dict` / `dict-smoke` Cargo features with `default = []` (per ADR 0012 D5).
+- Adds 530-case golden fixture + Layer 3 runner with 90% pass-rate threshold.
+- Adds `tools/p2a-fixture-gen/` (Python 3.12 + uv) for reproducible fixture generation.
+- Revises ADR 0014 D4 to reflect the two-variant plan (P2-A aggregated + P2-D recursive Hybrid).
+- Syncs parent Phase 2 spec + README + glossary.
+
+Closes #91.
+
+## Spec links
+
+- Child spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md`
+- Parent spec: `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`
+- ADR: `docs/adr/0014-phase-2-dictionary-layer-architecture.md` (D4 revised)
+
+## Acceptance criteria (from spec §1)
+
+- [ ] Phase 2 G2 (honorific / proper noun coverage) reaches ≥ 90% pass rate on 530-case golden fixture.
+- [ ] Phase 1 14/15 Layer 3 smoke baseline does not regress.
+- [ ] `BackendConfig::Dictionary` / `DictionaryConfig` land with engine-neutral public field names (spec §3.4 Q4).
+- [ ] ADR 0014 D4 is revised and included in this PR.
+
+## Test counts
+
+- Phase 1 existing tests: ~175 (unchanged)
+- P2-A new unit tests (Layer 1): ~33-42
+- P2-A new integration tests (Layer 2): 5
+- P2-A new golden test (Layer 3, opt-in via `dict-smoke`): 1 (530 assertions)
+- `tools/p2a-fixture-gen/` pytest: ~6
+
+## Review checklist (Large PR tier, per global CLAUDE.md PR Review Matrix)
+
+- [ ] `agent-teams:team-review` with all 5 dimensions (security / performance / architecture / testing / a11y)
+- [ ] `owasp-security`
+- [ ] `secrets-check`
+- [ ] `security-scanning:security-sast`
+- [ ] `pr-review-toolkit:review-pr`
+
+## Smoke test (manual)
+
+```bash
+export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic
+bash scripts/phase2-smoke.sh
+```
+EOF
+)"
+```
+
+- [ ] **Step 3: 出力された PR URL を記録し、最終報告に含める**
+
+想定: `https://github.com/std-koh-hinooka/kotoha-ime/pull/<number>` が stdout に出力される。
+
+- [ ] **Final step: 報告**
+
+PR URL を main agent / user に返答する。本 task 完了後、Review Matrix に列挙された各 skill を順次起動する(本 plan の範囲外、別 branch session で対応)。
+
+---
+
+## 参照
+
+- 子 spec: [`docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md`](../specs/2026-04-25-p2-a-dictionary-layer-design.md)
+- 親 spec: [`docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`](../specs/2026-04-25-kotoha-phase-2-design.md)
+- ADR 0014: [`docs/adr/0014-phase-2-dictionary-layer-architecture.md`](../../adr/0014-phase-2-dictionary-layer-architecture.md)
+- Phase 1 plan(参考): [`2026-04-24-kotoha-phase-1-implementation.md`](./2026-04-24-kotoha-phase-1-implementation.md)

--- a/docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md
+++ b/docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md
@@ -121,17 +121,19 @@ Ranker は Dictionary 候補 (`Vec<Candidate>`) と LLM 候補 (`Vec<Candidate>`
 
 ### 3.4 BackendConfig 拡張 (新 variant)
 
-Phase 2 は ADR 0011 で確定した `BackendConfig` enum の `#[non_exhaustive]` 拡張点を使用し、新 variant を 1 つ追加する。P2-A kick-off で確定する 2 案は以下のとおり。
+Phase 2 は ADR 0011 で確定した `BackendConfig` enum の `#[non_exhaustive]` 拡張点を使用し、Phase 2 期間中に 2 variants を段階的に追加する (ADR 0014 D4 改訂、2026-04-25)。
 
-- **候補 1** (集約型): `BackendConfig::DictionaryAugmented { model_path, dict_config, learning_config }`
-  - Dictionary 補完付き LLM backend を 1 variant に集約する
-  - 実装コスト低、variant 数が最小
-- **候補 2** (再帰 wrap 型): `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict: DictionaryConfig, learning: LearningConfig }`
-  - LLM backend を再帰的に wrap する
-  - Phase 5 `KotohaNative` backend との組合せにも自動対応する
-  - 実装コスト中、Phase 5 integration が構造化される
+- **P2-A で追加** (集約型): `BackendConfig::Dictionary { config: DictionaryConfig }`
+  - 形態素解析と vocabulary lookup の合成のみを担当する pure Dictionary backend
+  - LLM 推論を内包しないため、`llama-cpp` feature 非依存で常に build / 単体実行可能
+  - P2-A の Layer 1 / Layer 2 テスト経路として使用する
+- **P2-D で追加** (再帰 wrap 型): `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict: DictionaryConfig, learning: LearningConfig }`
+  - LLM backend を再帰的に wrap し、Dictionary 候補 / LLM 候補 / Learning cache hit を Ranker で統合する
+  - Phase 5 `KotohaNative` backend が加入した際にも、`llm: Box<BackendConfig>` の再 wrap でそのまま同 variant を再利用できる (Phase 5 integration を構造的に保証)
 
-Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` と `BackendConfig::Mock` は変更しない。詳細は P2-A kick-off で確定する。
+Phase 1 の `BackendConfig::LlamaCpp { model_path, prompt_template }` と `BackendConfig::Mock` は変更しない。
+
+P2-A 範囲の詳細(`DictionaryConfig` の正式 schema、`MorphologicalEngine` / `VocabularyLookup` trait 構成、feature flag 命名)は子 spec `docs/superpowers/specs/2026-04-25-kotoha-phase-2-p2-a-dictionary-foundation.md` §3.3 / §4.2 に委譲する。P2-D 範囲の `Hybrid { llm, dict, learning }` 詳細(Ranker 重み確定、Learning cache integration)は P2-D 着手時に追補 spec で確定する。
 
 ## 4. Dictionary 設計
 
@@ -151,7 +153,7 @@ Phase 2 default は core を採用する方針とし、recall が P2-D の golde
 
 詳細は P2-A kick-off で確定する。
 
-### 4.2 Kotoha 独自語彙の merge
+### 4.2 Kotoha 独自語彙の merge と Trait 構成
 
 SudachiDict には含まれない Kotoha 固有の語彙 (例: 敬称「さん」「様」の専用 entry、IME 業務ドメイン語彙、Phase 1 smoke fixture 語彙) を薄い補完レイヤーとして SudachiDict 上に merge する。
 
@@ -159,7 +161,14 @@ SudachiDict には含まれない Kotoha 固有の語彙 (例: 敬称「さん�
 - schema: SudachiDict と同一の `(surface, reading, pos, score)` を採用
 - merge timing: プロセス起動時、SudachiDict load 後に同一 in-memory 構造へ読込
 
-詳細 schema と load timing は P2-A kick-off で確定する。
+#### Trait 構成の委譲
+
+Phase 2 P2-A は形態素解析と vocabulary lookup の責務分離のため、以下 2 trait を新設する。
+
+- **`MorphologicalEngine`**: 形態素解析 engine の抽象境界 trait。`tokenize(reading) -> Vec<EngineCandidate>` と `engine_id() -> &str` を提供する。P2-A は `SudachiAdapter` 実装のみを伴うが、Phase 5 以降で vibrato / lindera 等の差し替え余地を確保する目的で先出しする
+- **`VocabularyLookup`**: user / custom vocabulary lookup の抽象境界 trait。`lookup(reading) -> Vec<VocabEntry>` と `vocab_id() -> &str` を提供する。P2-A は `CustomVocab`(TSV reader)実装のみを伴い、P2-B で `UserVocab` が同 trait を実装する extension path を確保する
+
+両 trait の正式 signature、実装 struct (`SudachiAdapter` / `CustomVocab`)、resources 配置、feature flag 命名は子 spec `docs/superpowers/specs/2026-04-25-kotoha-phase-2-p2-a-dictionary-foundation.md` §4.2 に委譲する。本 spec は親 spec として方針整合のみを保つ。
 
 ### 4.3 bundling vs runtime download
 
@@ -259,7 +268,12 @@ Dictionary layer の配置方針は 2 案ある。
 
 default 案は「案 1 の kotoha-core 内配置 + feature flag `dict` で隔離」とする。Phase 2 の実装量が案 1 の想定を超えた場合、P2-D で案 2 への migration を検討する。
 
-詳細は P2-A kick-off で確定する。
+P2-A 子 spec で確定済の feature flag 構成は以下のとおり (子 spec `docs/superpowers/specs/2026-04-25-kotoha-phase-2-p2-a-dictionary-foundation.md` §7.3 から同期)。
+
+- **`dict`** feature: 形態素解析 + vocabulary lookup を有効化する。SudachiDict-core を runtime load する `SudachiAdapter` と `CustomVocab` (TSV reader) を expose する。`default = []` 方針 (ADR 0012 D5) に従い opt-in
+- **`dict-smoke`** feature: 530-case golden fixture を実 SudachiDict 辞書で end-to-end 評価する Layer 3 経路を有効化する。Phase 2 P2-A 範囲では runner 本体を実装せず、ISSUE #92 で別 PR にて活用する (`docs/wiki/glossary.md` で参照する Opt-in smoke パターンに従う)。`KOTOHA_SYSTEM_DICT_PATH` 環境変数を必須前提とする
+
+Phase 2 P2-A 段階では `dict` feature のみが活性であり、`dict-smoke` feature gate 自体は将来用に予約する位置付けとする。詳細は ISSUE #92 で扱う。
 
 ## 7. テスト戦略
 
@@ -284,16 +298,22 @@ Layer 2 (GGUF なし) で完結し、`llama-cpp` feature 非依存で動作す�
 
 ### 7.3 golden fixture
 
-Phase 2 固有の golden fixture を以下 4 カテゴリ、30+ cases を最小として P2-A で整備する。
+Phase 2 P2-A の golden fixture は **2 段構成 (targeted 30 + bulk 500)、合計 530 cases** を整備する (子 spec `docs/superpowers/specs/2026-04-25-kotoha-phase-2-p2-a-dictionary-foundation.md` §6.3 から同期)。
 
-- **敬称**: 「たなか さん → 田中 さん」「すずき さま → 鈴木 様」等、10+ cases
-- **固有名詞 (人名)**: 「ひのおか → 日野岡」「やまだ たろう → 山田 太郎」等、10+ cases
-- **固有名詞 (地名 / 組織名)**: 「しんじゅく → 新宿」「ぐーぐる → Google」等、5+ cases
-- **外来語**: 「こんぴゅーた → コンピュータ」「いんたーねっと → インターネット」等、5+ cases
+- **targeted 30**: Layer 1 / Layer 2 unit / integration テスト用の手作りケース。以下 4 カテゴリで構成する
+  - 敬称: 「たなか さん → 田中 さん」「すずき さま → 鈴木 様」等、10+ cases
+  - 固有名詞 (人名): 「ひのおか → 日野岡」「やまだ たろう → 山田 太郎」等、10+ cases
+  - 固有名詞 (地名 / 組織名): 「しんじゅく → 新宿」「ぐーぐる → Google」等、5+ cases
+  - 外来語: 「こんぴゅーた → コンピュータ」「いんたーねっと → インターネット」等、5+ cases
+- **bulk 500**: Layer 3 statistical evaluation (golden fixture 拡張) 用の自動生成ケース。SudachiDict-core から sampling した surface / reading ペアに、編集距離 0〜2 の noisy reading を注入して生成する
 
-fixture 形式は Phase 1 の `crates/kotoha-core/tests/fixtures/kanji_llama_cpp_smoke.tsv` と同一 TSV schema を採用する。
+#### Layer 3 deferral
 
-詳細 case 数と category 比率は P2-A kick-off で確定する。
+530-case fixture の **Layer 3 golden test runner と `phase2-dict-smoke.sh` smoke スクリプトは P2-A スコープから外し、ISSUE #92 で別 PR にて実装する** (本 task の判断、2026-04-25)。Layer 3 deferral 理由は P5-A sample data の schema mismatch / 規模不足が判明したためで、530-case fixture を消費する runner 設計を仕切り直す必要がある。
+
+P2-A 範囲では Layer 1 (unit) / Layer 2 (integration、`MockBackend` を LLM 固定) の 2 層で targeted 30 cases を消費するに留め、bulk 500 cases の活用は ISSUE #92 で行う。fixture 自体 (TSV ファイル) は P2-A で整備する (`tools/p2a-fixture-gen/` にて生成済、子 spec §6.3 参照)。
+
+fixture 形式は Phase 1 の `crates/kotoha-core/tests/fixtures/kanji_llama_cpp_smoke.tsv` と同一 TSV schema を踏襲する。詳細 column 定義は子 spec §6.3 に記載する。
 
 ### 7.4 regression (Phase 1 14/15 退行防止)
 

--- a/docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md
+++ b/docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md
@@ -1,0 +1,622 @@
+---
+title: Kotoha Phase 2 P2-A 設計書 — Dictionary layer (Sudachi-based)
+date: 2026-04-25
+status: draft
+phase: 2
+milestone: P2-A
+parent-spec: docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md
+revision: 1
+---
+
+# Kotoha Phase 2 P2-A (Dictionary layer) 設計書
+
+本設計書は Phase 2「Dictionary and learning」の最初の milestone P2-A を詳細化する子 spec である。Phase 2 spec(parent-spec)が示す Phase 2 全体スコープの中で、P2-A は Dictionary backend を新設し、`KanjiBackend` trait の 2 つ目の実装(LlamaCpp に続く)として位置づける。Phase 2 spec / ADR 0014 と本設計書の記述が矛盾する箇所は、本設計書が新しい(P2-A brainstorming で確定した最新方針)とする。
+
+## 目次
+
+- [1. 概要](#1-概要)
+- [2. スコープ](#2-スコープ)
+- [3. 設計判断(brainstorming で確定した 11 項目)](#3-設計判断brainstorming-で確定した-11-項目)
+- [4. アーキテクチャ](#4-アーキテクチャ)
+- [5. Dictionary 設計](#5-dictionary-設計)
+- [6. Test 戦略](#6-test-戦略)
+- [7. Dependencies と Feature flags](#7-dependencies-と-feature-flags)
+- [8. 付随更新(本 P2-A PR に同梱する別 file 変更)](#8-付随更新本-p2-a-pr-に同梱する別-file-変更)
+- [9. 規模見積り](#9-規模見積り)
+- [10. 残論点(P2-A 実装中に確定 or 後続 milestone)](#10-残論点p2-a-実装中に確定-or-後続-milestone)
+- [11. 参照](#11-参照)
+
+## 1. 概要
+
+P2-A は Phase 2「Dictionary and learning」の最初の milestone であり、Kotoha プロジェクトは P2-A で SudachiDict-core を Rust から runtime load する Dictionary backend を新設する。Kotoha は本 milestone において、Phase 1 で確定した `KanjiBackend` trait の 2 つ目の実装(`LlamaCppBackend` に続く)として `DictionaryBackend` 構造体を導入する。
+
+P2-A は parent-spec(Phase 2 spec)§3 アーキテクチャ / §4 Dictionary 設計 / §6 API と Trait 拡張 / §7 テスト戦略 を詳細化する子 spec として位置づく。Phase 2 spec / ADR 0014 と矛盾する記述は、P2-A brainstorming で empirical に確定した最新方針として本設計書が優先する。具体的には、parent-spec §3.4 で「候補 1 / 候補 2 のいずれかを P2-A で選択」と stub 化していた `BackendConfig` 拡張は、本設計書 §3.3 で「P2-A は集約型 1 variant を追加し、Hybrid 再帰 wrap 型は P2-D で追加する」と確定する。
+
+P2-A の到達目標は以下 4 点である。
+
+- Phase 2 spec G2(敬称 / 固有名詞の System dict 補完)を 530 case golden fixture で 90% pass rate 達成
+- Phase 1 14/15 baseline を退行させない(ADR 0014 D1 の hybrid architecture 前提を維持)
+- Phase 2 spec §6.3 案 1(kotoha-core 内配置 + feature flag)を採用
+- ADR 0014 D4 を「Phase 2 で 2 variants 追加(集約型 P2-A + Hybrid 再帰 wrap 型 P2-D)」に改訂する付随 commit を P2-A PR に含める
+
+## 2. スコープ
+
+### 2.1 In-scope
+
+P2-A は以下 13 項目を実装範囲とする。
+
+1. `crates/kotoha-core/src/dict/` 新規モジュール群(`mod.rs` / `backend.rs` / `engine.rs` / `vocab.rs` / `sudachi_adapter.rs` / `custom_vocab.rs`)
+2. `MorphologicalEngine` trait(SudachiAdapter / 将来の Vibrato / Lindera 等を抽象化する境界 trait)
+3. `VocabularyLookup` trait(CustomVocab / 将来の UserVocab を抽象化する境界 trait)
+4. `DictionaryBackend` 構造体(`KanjiBackend` を実装、`MorphologicalEngine` と `VocabularyLookup` を field に保持)
+5. `SudachiAdapter`(`MorphologicalEngine` を実装、sudachi.rs runtime ラッパー)
+6. `CustomVocab`(`VocabularyLookup` を実装、`kotoha-dict.tsv` reader)
+7. `BackendConfig::Dictionary { config: DictionaryConfig }` variant 追加と `load_backend` factory arm 追加
+8. `DictionaryConfig` 構造体(`system_dict_path: PathBuf` / `custom_vocab_path: Option<PathBuf>` 等の engine 非依存 field)
+9. `KOTOHA_SYSTEM_DICT_PATH` 環境変数読込ユーティリティ
+10. `crates/kotoha-core/resources/kotoha-dict.tsv` 空 fixture(header + curation policy comments のみ、entry なし)
+11. `crates/kotoha-core/tests/kanji_dictionary_unit.rs`(Layer 2 integration test)
+12. `crates/kotoha-core/tests/kanji_dictionary_golden.rs` + `crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv`(Layer 3 golden、530 cases)
+13. `scripts/phase2-smoke.sh` と `tools/p2a-fixture-gen/`(Phase 1 `phase1-smoke.sh` と同 pattern)
+
+### 2.2 Out-of-scope(後続 milestone / Phase に送る)
+
+P2-A は以下を扱わない。
+
+- **User dictionary 永続化(P2-B)**: `add` / `remove` / `list` の CLI サブコマンドと永続化 format(TSV / JSONL / TOML)選定は P2-B の範囲。P2-A は `VocabularyLookup` trait を先出しすることで P2-B の extension path のみ確保する
+- **Learning cache(P2-C)**: in-memory LRU + 起動時 load + shutdown save の実装、`(kana_input, chosen_kanji, frequency, last_used_at)` 永続化 format 確定、eviction 閾値 tuning は P2-C の範囲
+- **Ranker と Hybrid backend(P2-D)**: Dictionary 候補と LLM 候補を merge / dedupe / rerank する Ranker の実装、`BackendConfig::Hybrid { llm: Box<BackendConfig>, dict, learning }` の追加、初期重み(dict 0.95 / LLM 1.0)の empirical tuning は P2-D の範囲
+- **SudachiDict-full(500MB)variant 採用検討**: P2-A default は SudachiDict-core(70MB、76 万 entries 規模)で固定。full への変更は P2-D の golden fixture で recall 不足が判明した場合のみ検討する
+- **streaming IME 統合 / personalization ML / cross-device sync / GUI dict editor**: parent-spec §8 と整合し、Phase 3+ / Phase 5+ / Phase 6+ に送る
+- **mixed JP/EN 入力(Phase 5)**: Phase 5 spec の P5-A〜P5-D で扱う。P2-A は hiragana 入力のみ対象とする(Phase 1 と同等の入力契約を維持)
+
+## 3. 設計判断(brainstorming で確定した 11 項目)
+
+P2-A brainstorming は以下 11 項目を empirical に確定した。各項目は本 P2-A 実装の根拠として機能し、後続 milestone でも継承する。
+
+### 3.1 Q1: 形態素解析エンジンの選定
+
+P2-A は `sudachi.rs`(WorksApplications, Apache-2.0、git rev `90fd6068c80c` = v0.6.11)を採用する。
+
+- **採用理由**: sudachi.rs は SudachiDict-core を native Rust で読込み可能であり、Phase 5 P5-A PoC が同辞書を採用済(語彙整合性が取れる)。Apache-2.0 licence は OSS 互換性を保つ
+- **lindera 棄却理由**: lindera は MeCab 互換 API を Rust で再実装したライブラリであり、辞書として MeCab-IPADIC または UniDic を要求する。UniDic は商用利用制約があるため採用不可(ADR 0014 C4 と整合)
+- **vibrato 棄却理由**: vibrato は MeCab 互換の高速形態素解析器だが、SudachiDict をネイティブにサポートしない。SudachiDict の merge 形態(short / middle / long unit)は sudachi.rs のみが正しく扱える
+- **SudachiDict→MeCab 変換棄却理由**: SudachiDict を MeCab 形式に変換する script は WorksApplications が公式提供しておらず、変換結果の精度保証が無い。Phase 5 P5-A の data pipeline 整合性も損なわれる
+
+### 3.2 Q2: PR 分割
+
+P2-A は単一 PR として提出する。global CLAUDE.md「Branch Scope Policy」は 20 files / 1000 lines を目安とし、P2-A の総規模見積り(§9)はこの範囲内に収まる(理由: Phase 2 は trait 2 本 + struct 4 本 + test 2 本 + ADR 改訂の structural な追加が密結合しており、機能境界で PR 分割すると review コンテキストが分断される)。
+
+### 3.3 Q3: BackendConfig 拡張順序
+
+P2-A は集約型 1 variant のみを追加する。
+
+- **P2-A で追加**: `BackendConfig::Dictionary { config: DictionaryConfig }`(LLM を含まない pure Dictionary backend)
+- **P2-D で追加**: `BackendConfig::Hybrid { llm: Box<BackendConfig>, dict: DictionaryConfig, learning: LearningConfig }`(Phase 5 `KotohaNative` 加入時に再帰 Hybrid で自動対応)
+- **ADR 0014 D4 改訂**: 現行 D4 は「P2-A kick-off で候補 1 / 候補 2 のいずれかを選択」と記述しているが、本 P2-A PR で「Phase 2 で 2 variants 追加(集約型 P2-A + Hybrid 再帰 wrap 型 P2-D)」に改訂する付随 commit を含める
+
+### 3.4 Q4: 公開 API の命名(engine 非依存)
+
+P2-A は engine 実装を抽象化するため、公開 API 名は engine 非依存の形で命名する。
+
+| 公開要素 | 命名 | 注記 |
+|---|---|---|
+| `DictionaryConfig` field | `system_dict_path: PathBuf` | `sudachi_dict_path` ではない |
+| 環境変数 | `KOTOHA_SYSTEM_DICT_PATH` | `KOTOHA_SUDACHI_DICT_PATH` ではない |
+| 内部 file 名 | `crates/kotoha-core/src/dict/sudachi_adapter.rs` | Phase 1 の `llama_cpp.rs` と同 pattern で内部実装名は engine 名を含む |
+| 内部 struct | `SudachiAdapter` | 外部公開しない `pub(crate)` または非公開 |
+
+公開 API を engine 非依存にすることで、将来 vibrato / 別 engine への置換時に config 互換性を維持できる。一方、内部実装ファイル / 構造体名は engine 名を含めることで、Phase 1 `llama_cpp.rs` と同 pattern を保つ。
+
+### 3.5 Q5: MorphologicalEngine trait の先出し
+
+P2-A は `MorphologicalEngine` trait を先出しし、`DictionaryBackend` は `Box<dyn MorphologicalEngine>` を field に保持する。
+
+```rust
+/// 形態素解析 engine の抽象境界。
+///
+/// # Preconditions
+/// - 入力は hiragana 文字列(`KanjiBackend` 契約と同じ U+3040..=U+309F + U+30FC)
+///
+/// # Postconditions
+/// - 返値は入力の形態素分割候補列。同一 reading に対し複数 surface があり得る
+pub trait MorphologicalEngine {
+    fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError>;
+    fn engine_id(&self) -> &str;
+}
+```
+
+trait 先出しの理由は以下 2 点である。
+
+- **unit test 注入容易性**: `MockEngine` を `DictionaryBackend` に注入することで、SudachiDict 不在環境でも Layer 1 unit test が実行可能となる
+- **将来の engine 切替**: vibrato / lindera 等への置換時に `DictionaryBackend` の変更を最小化する(Clean Architecture「Interface 依存」/ SOLID DIP)
+
+### 3.6 Q6: VocabularyLookup trait の先出し
+
+P2-A は `VocabularyLookup` trait を先出しし、P2-A では `CustomVocab` のみが本 trait を実装する。P2-B で `UserVocab` が同 trait を実装する extension path を確保する。
+
+```rust
+/// User dictionary / Custom vocabulary の lookup 抽象境界。
+///
+/// # Postconditions
+/// - 同一 reading に対し 0 件以上の `VocabEntry` を返す
+/// - 返値順序は score 降順(score 同値時の順序は実装依存)
+pub trait VocabularyLookup {
+    fn lookup(&self, reading: &str) -> Vec<VocabEntry>;
+    fn vocab_id(&self) -> &str;
+}
+```
+
+`DictionaryBackend` は `Vec<Box<dyn VocabularyLookup>>` を field に保持し、複数 vocab source(P2-A: CustomVocab のみ、P2-B 以降: CustomVocab + UserVocab)を統合可能とする。
+
+### 3.7 Q7: kotoha-dict.tsv の初期内容
+
+P2-A は `crates/kotoha-core/resources/kotoha-dict.tsv` を **空で start** する。
+
+- **理由**: SudachiDict-core 76 万 entries の coverage を baseline として trust する。事前に「補完が必要そうな語彙」を speculative に追加すると、SudachiDict と重複したり、文法的多義性を含むことで誤変換を生む可能性がある(`feedback_vocab_grammatical_collision.md` 参照)
+- **運用方針**: golden fixture(§6.3)で観察される gap を後続 milestone(P2-B / P2-D)で証拠ベースに埋める。P2-A 時点では header + curation policy comments のみを記載する
+
+### 3.8 Q8: Golden fixture 規模
+
+P2-A は 530 cases の golden fixture を整備する。
+
+| カテゴリ | 件数 | 目的 |
+|---|---|---|
+| Targeted cases | 30 | parent-spec §7.3 の 4 カテゴリ(敬称 / 人名 / 地名・組織名 / 外来語)を最低担保 |
+| Bulk cases | 500 | 5-bucket stratified sampling(reading 文字数: 1-3 / 4-6 / 7-10 / 11-20 / 20+ で各 100 件) |
+
+bulk 500 cases は `tools/p2a-fixture-gen/` で SudachiDict-core からサンプリングして生成する。詳細は §6.3 で記述する。
+
+### 3.9 Q9: Pass rate threshold(段階的締込み)
+
+P2-A は pass rate threshold を以下のとおり段階的に締込む。
+
+| Milestone | Pass rate threshold | 根拠 |
+|---|---|---|
+| P2-A | 90% | SudachiDict-core baseline + 空 custom vocab で達成可能な水準 |
+| P2-D | 95% | Ranker tuning と user vocab 整備で +5% 改善 |
+| Phase 5 | 98% | KotohaNative custom model 統合で残 3% を解消 |
+
+pass rate は `category breakdown` + `length bucket breakdown` の 2 軸で集計し、特定 bucket のみ低下するパターンを検出可能にする。
+
+### 3.10 Q10: sudachi.rs version pin
+
+P2-A は sudachi.rs を `rev = "90fd6068c80c"`(v0.6.11)に pin する。
+
+- **pin 方法**: `Cargo.toml` の `[workspace.dependencies]` で git rev pin(`{ git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }`)
+- **pin 理由**: sudachi.rs は crates.io 公開 version(0.6.x)が古く、最新の SudachiDict v20260116 と互換性に懸念がある。git rev pin で再現性を担保する。Phase 2 closure までは固定し、bump 必要時は別 ADR / ISSUE を起票する
+
+### 3.11 Q11: SudachiDict-core version pin と配布方針
+
+P2-A は SudachiDict-core v20260116(2026-01-16 release)を採用し、manual placement で運用する。
+
+- **配布方針**: parent-spec §4.3 と整合し、bundling せず manual placement とする(Phase 1 GGUF と同 pattern)
+- **path 指定**: 環境変数 `KOTOHA_SYSTEM_DICT_PATH` で指定。未設定時は `KanjiError::ModelNotFound` 相当のエラーを返す
+- **upstream update 方針**: parent-spec §4.4 の「固定版」方針を継承。Phase 2 closure までは v20260116 を維持し、bump は別 ADR で承認する
+
+## 4. アーキテクチャ
+
+### 4.1 Module 構造
+
+P2-A は以下のディレクトリ / ファイル構造で実装する。
+
+```text
+crates/kotoha-core/src/dict/
+├── mod.rs              (pub use re-export、DictionaryConfig 定義)
+├── backend.rs          (DictionaryBackend struct + KanjiBackend impl)
+├── engine.rs           (MorphologicalEngine trait + EngineCandidate)
+├── vocab.rs            (VocabularyLookup trait + VocabEntry)
+├── sudachi_adapter.rs  (SudachiAdapter: impl MorphologicalEngine)
+└── custom_vocab.rs     (CustomVocab: impl VocabularyLookup)
+
+crates/kotoha-core/resources/
+└── kotoha-dict.tsv     (空、header + curation policy comments のみ)
+
+crates/kotoha-core/tests/
+├── kanji_dictionary_unit.rs       (Layer 2 integration test)
+├── kanji_dictionary_golden.rs     (Layer 3 golden、dict-smoke gate)
+└── fixtures/
+    └── kanji_dictionary_golden.tsv  (530 cases)
+
+scripts/
+└── phase2-smoke.sh     (新設、phase1-smoke.sh と同 pattern)
+
+tools/
+└── p2a-fixture-gen/    (新設、500-case stratified sampling script)
+```
+
+ディレクトリ命名は Phase 1 `crates/kotoha-core/src/kanji/` と同 pattern を踏襲し、`backend.rs` / `mock.rs` / `llama_cpp.rs` の構造を `dict/` 配下に展開する。
+
+### 4.2 Trait 設計(MorphologicalEngine + VocabularyLookup)
+
+P2-A は 2 本の trait を導入する。両 trait は Clean Architecture「Interface 依存」/ SOLID DIP に整合し、`DictionaryBackend` の concrete 実装 lock-in を避ける。
+
+#### 4.2.1 MorphologicalEngine
+
+```rust
+/// 形態素解析 engine の抽象境界。
+///
+/// # Preconditions
+/// - `reading` は `KanjiBackend` 契約 §5.6 と同じ hiragana 文字列(U+3040..=U+309F + U+30FC)
+/// - `reading.chars().count() <= 128`
+///
+/// # Postconditions
+/// - 返値は `reading` を tokenize した候補列
+/// - 同一 reading に対し複数 surface があり得る(homophone)
+/// - score は engine 実装が付与(SudachiAdapter は cost を score に変換)
+///
+/// # Errors
+/// - [`KanjiError::Backend`] when tokenization fails inside the engine
+pub trait MorphologicalEngine {
+    fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError>;
+    fn engine_id(&self) -> &str;
+}
+
+#[derive(Debug, Clone)]
+pub struct EngineCandidate {
+    pub surface: String,
+    pub reading: String,
+    pub score: f32,
+}
+```
+
+#### 4.2.2 VocabularyLookup
+
+```rust
+/// User dictionary / Custom vocabulary の lookup 抽象境界。
+///
+/// # Preconditions
+/// - `reading` は hiragana 文字列(`KanjiBackend` 契約と同じ)
+///
+/// # Postconditions
+/// - 同一 reading に対し 0 件以上の `VocabEntry` を返す
+/// - 返値順序は score 降順(score 同値時の順序は実装依存)
+pub trait VocabularyLookup {
+    fn lookup(&self, reading: &str) -> Vec<VocabEntry>;
+    fn vocab_id(&self) -> &str;
+}
+
+#[derive(Debug, Clone)]
+pub struct VocabEntry {
+    pub surface: String,
+    pub reading: String,
+    pub pos: String,
+    pub score: f32,
+}
+```
+
+両 trait の設計理由は以下のとおりである。
+
+- **Clean Architecture 整合**: `DictionaryBackend` は trait のみに依存し、SudachiAdapter / CustomVocab の concrete 実装に直接依存しない
+- **SOLID DIP 整合**: 高レベルモジュール(`DictionaryBackend`)は低レベル詳細(SudachiAdapter)に依存せず、両者は abstraction(`MorphologicalEngine`)に依存する
+- **テスト容易性**: `MockEngine` / `MockVocab` を unit test で注入することで、SudachiDict 不在環境でも Layer 1 test が実行可能
+
+### 4.3 DictionaryBackend の構造
+
+P2-A は `DictionaryBackend` を以下のとおり定義する。
+
+```rust
+/// SudachiDict ベースの Dictionary backend。
+///
+/// `KanjiBackend` を実装し、`MorphologicalEngine` と `VocabularyLookup` を
+/// field に保持する。Phase 1 の `LlamaCppBackend` に続く 2 つ目の `KanjiBackend`
+/// 実装である。
+pub struct DictionaryBackend {
+    engine: Box<dyn MorphologicalEngine>,
+    vocabs: Vec<Box<dyn VocabularyLookup>>,
+    model_id: String,
+}
+
+impl DictionaryBackend {
+    pub fn load(config: &DictionaryConfig) -> Result<Self, KanjiError> {
+        let engine = Box::new(SudachiAdapter::load(&config.system_dict_path)?);
+        let mut vocabs: Vec<Box<dyn VocabularyLookup>> = Vec::new();
+        if let Some(path) = &config.custom_vocab_path {
+            vocabs.push(Box::new(CustomVocab::load(path)?));
+        }
+        let model_id = format!("dictionary({})", engine.engine_id());
+        Ok(Self { engine, vocabs, model_id })
+    }
+}
+
+impl KanjiBackend for DictionaryBackend {
+    fn model_id(&self) -> &str { &self.model_id }
+    fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError> {
+        validate_input(input)?;
+        let mut raw: Vec<Candidate> = Vec::new();
+        for ec in self.engine.tokenize(input)? {
+            raw.push(Candidate { surface: ec.surface, score: ec.score });
+        }
+        for vocab in &self.vocabs {
+            for ve in vocab.lookup(input) {
+                raw.push(Candidate { surface: ve.surface, score: ve.score });
+            }
+        }
+        Ok(score_sort_dedupe(raw, options.top_k))
+    }
+}
+```
+
+field 構成の理由は以下のとおりである。
+
+- **`Box<dyn MorphologicalEngine>`**: engine は単一(SudachiDict 1 個)を前提とし、Phase 5 で別 engine への切替時にも単一 box で完結する
+- **`Vec<Box<dyn VocabularyLookup>>`**: vocab source は複数(P2-A: CustomVocab、P2-B 以降: CustomVocab + UserVocab)を前提とし、Vec で複数注入を許容する
+- **`model_id`**: `engine_id()` を含む文字列(例: `"dictionary(sudachi-0.6.11)"`)を初期化時に生成し、`KanjiBackend::model_id()` で返す
+
+### 4.4 BackendConfig 拡張
+
+P2-A は `BackendConfig` enum に 1 variant を追加する。
+
+```rust
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum BackendConfig {
+    Mock,
+    LlamaCpp { model_path: PathBuf, prompt_template: PromptTemplate },
+    Dictionary { config: DictionaryConfig },  // P2-A 追加
+}
+
+#[derive(Debug, Clone)]
+pub struct DictionaryConfig {
+    pub system_dict_path: PathBuf,
+    pub custom_vocab_path: Option<PathBuf>,
+}
+```
+
+`load_backend` factory に新 arm を追加する。
+
+```rust
+pub fn load_backend(config: &BackendConfig) -> Result<Box<dyn KanjiBackend>, KanjiError> {
+    match config {
+        // ... 既存 Mock / LlamaCpp arm ...
+
+        #[cfg(feature = "dict")]
+        BackendConfig::Dictionary { config } => {
+            Ok(Box::new(DictionaryBackend::load(config)?))
+        }
+
+        #[cfg(not(feature = "dict"))]
+        BackendConfig::Dictionary { .. } => Err(KanjiError::FeatureDisabled {
+            feature: "dict",
+        }),
+    }
+}
+```
+
+`#[non_exhaustive]` enum 拡張は ADR 0011 D2 の方針に整合する。Phase 1 の `BackendConfig::LlamaCpp` 追加と同 pattern で、外部 match site を破壊せず追加可能である。
+
+## 5. Dictionary 設計
+
+### 5.1 SudachiDict-core 配布
+
+P2-A は SudachiDict-core(v20260116、約 70MB、76 万 entries 規模)を採用し、manual placement で配布する。
+
+- **placement 方針**: parent-spec §4.3 と整合し、bundling せず手動配置(Phase 1 GGUF と同 pattern)
+- **path 指定**: 環境変数 `KOTOHA_SYSTEM_DICT_PATH` で指定する。未設定時は `KanjiError::ModelNotFound { feature: "system-dict" }` を返す
+- **将来の AutoDownload**: MEMORY.md「Model management future vision」の Phase 6 UX で実装予定。Phase 2 範囲では manual placement のみ
+- **README 追記**: 本 P2-A PR に「SudachiDict-core 取得手順 + `KOTOHA_SYSTEM_DICT_PATH` 設定例」を README.md へ追記する付随 commit を含める(§8 参照)
+
+### 5.2 Custom vocabulary
+
+P2-A は `crates/kotoha-core/resources/kotoha-dict.tsv` を空で start する(§3.7 Q7 参照)。
+
+- **schema**: SudachiDict と同一の `(surface, reading, pos, score)` を採用する。TSV header は `# surface<TAB>reading<TAB>pos<TAB>score`
+- **curation policy comments**: ファイル冒頭に「kotoha-dict.tsv は SudachiDict baseline では補完できない語彙のみを追加する。speculative な追加は文法的多義性を生むため避ける。golden fixture で観察される gap を証拠として追加する」旨を記載する
+- **merge 戦略**: `DictionaryBackend::convert` 内で `engine.tokenize` 結果と `vocab.lookup` 結果を 1 本の `Vec<Candidate>` に連結し、`score_sort_dedupe` で同一 surface を排除する(Phase 1 と同一 helper を流用)
+- **文法的多義性チェック**: `feedback_vocab_grammatical_collision.md` の知見を踏まえ、新規 entry 追加時は「同 reading で SudachiDict が既に出している surface を上書きしないか」を P2-B 以降で機械的にチェックする(P2-A は空 start のため適用機会無し)
+
+```tsv
+# kotoha-dict.tsv — Kotoha custom vocabulary
+# Schema: surface<TAB>reading<TAB>pos<TAB>score
+# Curation policy:
+#   1. SudachiDict-core baseline で recall 可能な語彙は追加しない
+#   2. golden fixture で観察される gap のみを証拠ベースで追加する
+#   3. 同 reading で SudachiDict が出す surface を上書きする entry は P2-B 以降で機械的多義性チェックを通すこと
+# (P2-A: 空 start)
+```
+
+## 6. Test 戦略
+
+### 6.1 Layer 1: pure unit test
+
+P2-A は Layer 1 として `MockEngine` + `MockVocab` を注入した pure unit test を 33〜42 件程度実装する。
+
+| 対象 | 件数目安 | 内容 |
+|---|---|---|
+| `MorphologicalEngine` trait contract | 6〜8 | tokenize 結果が score 降順、empty 入力で empty 返却、invalid 入力で `KanjiError::Backend` |
+| `VocabularyLookup` trait contract | 5〜7 | lookup 結果が score 降順、未 hit で empty Vec、複数 entry 返却 |
+| `DictionaryBackend::convert` 統合動作 | 12〜15 | engine + vocab の merge、score_sort_dedupe 適用、top_k truncate、空入力 |
+| `DictionaryConfig` 構築 | 4〜5 | path 指定、custom_vocab None / Some、env var 読込 |
+| `CustomVocab::load` TSV parse | 6〜7 | header skip、空ファイル、不正 schema、UTF-8 BOM |
+
+すべて `#[cfg(test)]` で同ファイル内に配置する(Phase 1 `backend.rs` 末尾の `mod tests` と同 pattern)。
+
+### 6.2 Layer 2: integration / factory
+
+P2-A は Layer 2 として `crates/kotoha-core/tests/kanji_dictionary_unit.rs` に integration test を 6〜10 件実装する。
+
+| 対象 | 内容 |
+|---|---|
+| `load_backend` dispatch | `BackendConfig::Dictionary { ... }` が `DictionaryBackend` を返す |
+| feature flag 無効時 | `dict` feature off で `KanjiError::FeatureDisabled` 返却 |
+| MockEngine 統合 | MockEngine + 空 vocab で end-to-end |
+| MockEngine + MockVocab | 両者 hit 時の merge 動作 |
+| 同一 surface 衝突 | engine と vocab で同じ surface を返した場合の dedupe |
+| top_k = 0 / 大値 | edge case の境界動作 |
+
+Layer 2 は SudachiDict 不在環境でも実行可能とし、`dict` feature は MockEngine 経由で部分的に検証する。
+
+### 6.3 Layer 3: golden fixture(statistical evaluation)
+
+P2-A は 530 cases の golden fixture を `crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv` に配置し、`crates/kotoha-core/tests/kanji_dictionary_golden.rs` で実行する。
+
+#### 6.3.1 Fixture 構成
+
+| カテゴリ | 件数 | 内訳 |
+|---|---|---|
+| Targeted | 30 | 敬称 10 + 人名 10 + 地名・組織名 5 + 外来語 5(parent-spec §7.3 を踏襲) |
+| Bulk(stratified) | 500 | 5-bucket × 100 件 |
+
+bulk の 5-bucket stratified sampling は reading 文字数を bucket 軸とする。
+
+| Bucket | reading 文字数 | 件数 |
+|---|---|---|
+| B1 | 1〜3 | 100 |
+| B2 | 4〜6 | 100 |
+| B3 | 7〜10 | 100 |
+| B4 | 11〜20 | 100 |
+| B5 | 20+ | 100 |
+
+B5(20+ 文字)は自然データの scarcity が懸念されるため、不足時は manual concat / curated list で fallback する(§10 残論点参照)。
+
+#### 6.3.2 Pass rate threshold(段階的締込み)
+
+P2-A の dict-smoke gate は pass rate 90% を hard threshold とする(§3.9 Q9 参照)。
+
+#### 6.3.3 Test runner の出力形式
+
+`kanji_dictionary_golden.rs` は実行結果を以下の 2 軸で集計し、stdout に出力する。
+
+```text
+=== Category breakdown ===
+Honorific:     10/10  (100.0%)
+Personal name:  9/10  ( 90.0%)
+Place/Org:      4/5   ( 80.0%)
+Loanword:       5/5   (100.0%)
+Targeted:      28/30  ( 93.3%)
+
+=== Length bucket breakdown ===
+B1 (1-3):    95/100 (95.0%)
+B2 (4-6):    92/100 (92.0%)
+B3 (7-10):   88/100 (88.0%)
+B4 (11-20):  85/100 (85.0%)
+B5 (20+):    80/100 (80.0%)
+Bulk:       440/500 (88.0%)
+
+=== Total ===
+PASS: 468/530 (88.3%)  -- threshold 90% NOT MET
+```
+
+特定 bucket のみ pass rate が低下するパターンを検出可能とすることで、後続 milestone での改善対象を可視化する。
+
+#### 6.3.4 Fixture 生成手順
+
+`tools/p2a-fixture-gen/` 配下に Python(uv プロジェクト)で 500-case bulk fixture 生成 script を配置する。Phase 5 P5-A `tools/p5a-data-pipeline/`(MEMORY.md 参照)と同 pattern を踏襲する。
+
+- input: SudachiDict-core(v20260116)
+- output: `crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv` の bulk 500 行
+- sampling: 各 bucket から `random.sample` で 100 件抽出、再現性のため seed 固定
+
+### 6.4 Phase 1 14/15 regression 防止
+
+P2-A は Phase 1 の Layer 3 smoke fixture 14/15 baseline を退行させない。
+
+- **構造的根拠**: P2-A の変更箇所は `BackendConfig` enum への variant 追加と `load_backend` factory の arm 追加のみであり、既存の `Mock` / `LlamaCpp` arm は不変
+- **gate 方針**: pre-push lefthook gate で workspace 全 test を実行し、Phase 1 の `crates/kotoha-core/tests/kanji_llama_cpp_smoke.rs`(14/15 baseline)を継続 PASS させる
+- **`#[non_exhaustive]` 整合**: ADR 0011 D2 の拡張点を使用するため、外部 match site の破壊は構造的に発生しない
+
+## 7. Dependencies と Feature flags
+
+### 7.1 sudachi.rs git dep
+
+P2-A は workspace root の `[workspace.dependencies]` に sudachi.rs を git rev pin で追加する。
+
+```toml
+[workspace.dependencies]
+sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }
+```
+
+- **licence**: Apache-2.0(Kotoha OSS 互換)
+- **alternatives 棄却理由**: §3.1 Q1 参照(lindera / vibrato / SudachiDict→MeCab 変換のいずれも採用不可)
+
+`crates/kotoha-core/Cargo.toml` は以下のとおり参照する。
+
+```toml
+[dependencies]
+sudachi = { workspace = true, optional = true }
+```
+
+### 7.2 Cargo features
+
+P2-A は `crates/kotoha-core/Cargo.toml` に 2 個の feature を追加する。
+
+```toml
+[features]
+default = []
+dict = ["dep:sudachi"]
+dict-smoke = ["dict"]
+```
+
+- **`dict`**: SudachiDict 連携を有効化する optional dependency 隔離 feature。default = [] を維持し、ADR 0012 D5「default = []」厳守方針に整合する
+- **`dict-smoke`**: Layer 3 golden fixture を gate する feature。`dict` を含む。CI / lefthook では opt-in で有効化する
+
+`scripts/phase2-smoke.sh` は `dict-smoke` feature を有効化して `cargo test --features dict-smoke` を実行する(Phase 1 `phase1-smoke.sh` の `llama-cpp-smoke` と同 pattern)。
+
+### 7.3 lefthook 影響
+
+sudachi.rs git dep を追加することで、初回 `cargo build` の dep fetch + compile が 30〜60 秒程度発生する。incremental build 時は約 5 秒以内に収束する見込み。
+
+Phase 1 の llama-cpp-2 が C++ build chain を含む(初回 2〜5 分、incremental 30 秒)のと比較すると、sudachi.rs は pure Rust で軽量である。pre-push gate のレスポンスは Phase 1 と同等以下に保てる見込み。
+
+## 8. 付随更新(本 P2-A PR に同梱する別 file 変更)
+
+P2-A 実装と同一 PR に以下 4 件の docs 更新を含める。
+
+| 対象 | 内容 | 行数目安 |
+|---|---|---|
+| `docs/adr/0014-phase-2-dictionary-layer-architecture.md` D4 改訂 | 「P2-A kick-off で候補 1 / 候補 2 を選択」→「Phase 2 で 2 variants 追加(集約型 P2-A + Hybrid 再帰 wrap 型 P2-D)」 | +30 |
+| `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` 同期更新 | §3.4 / §4.2 / §6.3 / §7.3 を P2-A 確定方針に同期 | +95 |
+| `README.md` SudachiDict-core 取得手順 | manual placement 手順 + `KOTOHA_SYSTEM_DICT_PATH` 設定例 | +30 |
+| `docs/wiki/glossary.md` 用語追加 | MorphologicalEngine / VocabularyLookup / SudachiDict / 形態素解析 | +10 |
+
+ADR 0014 と Phase 2 spec の改訂は本 P2-A PR の最後の commit にまとめ、設計判断の根拠として spec / ADR と実装が同一 PR で同期する構造とする。
+
+## 9. 規模見積り
+
+P2-A の総規模は概ね 950 行 / 17 files に収まる見込みである。Branch Scope Policy(20 files / 1000 lines、§3.2 Q2 参照)の範囲内に収まる。
+
+| 区分 | 行数目安 | files |
+|---|---|---|
+| `dict/` 6 modules | 540 | 6 |
+| `tests/kanji_dictionary_unit.rs` + `kanji_dictionary_golden.rs` | 180 | 2 |
+| `kanji_dictionary_golden.tsv` (530 cases) | (data) | 1 |
+| `kotoha-dict.tsv`(空 + comments) | 15 | 1 |
+| `tools/p2a-fixture-gen/`(Python) | 80 | 3 |
+| `scripts/phase2-smoke.sh` | 25 | 1 |
+| `Cargo.toml` 修正(workspace + kotoha-core) | 15 | 2 |
+| ADR 0014 D4 改訂 | 30 | 1 |
+| Phase 2 spec 同期更新 | 95 | 1 |
+| README.md 追記 | 30 | 1 |
+| `glossary.md` 追記 | 10 | 1 |
+| **合計** | **約 1020(うち実装は約 940)** | **17** |
+
+docs 改訂(ADR 0014 / Phase 2 spec / README / glossary)を別 commit にすれば実装行数は約 940 行となり、PR Review Matrix(global CLAUDE.md)の Medium tier(≤15 files AND ≤600 lines)を超過する。Large tier(Medium 超過 + Branch Scope Policy 上限内)の team-review(全 5 次元)+ owasp-security + secrets-check + security-scanning:security-sast + pr-review-toolkit:review-pr を適用する。
+
+## 10. 残論点(P2-A 実装中に確定 or 後続 milestone)
+
+P2-A 着手時点で未確定の論点を以下に列挙する。
+
+- **Learning cache 永続化 format(P2-C 範囲)**: parent-spec §5.2 の TOML / JSONL / TSV 候補。P2-A では決定不要だが、`VocabularyLookup` trait の interface は将来 Learning cache の hit bonus 加算が可能な形を想定する
+- **Ranker 重み tuning(P2-D 範囲)**: parent-spec §3.3 の dict 0.95 / LLM 1.0 初期重み。P2-D で 530 case golden fixture の pass rate を KPI に empirical tuning する
+- **Phase 5 KotohaNative integration plan(Phase 5 kick-off 範囲)**: ADR 0014 D6 / parent-spec §9 Q6 と相互参照。P2-A の trait 設計(MorphologicalEngine / VocabularyLookup)は Phase 5 でも継承可能な形で先出ししている
+- **B5(20+ 文字)bucket の自然データ scarcity 対応**: P2-A 実装中に判断する。SudachiDict-core から 100 件サンプリング不可な場合、`tools/p2a-fixture-gen/` で manual concat(短語連結)/ curated list で fallback する。fallback 採用時は fixture file の冒頭コメントに記録する
+
+## 11. 参照
+
+### 11.1 上位 spec / ADR
+
+- 上位 spec(parent-spec): [`docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`](./2026-04-25-kotoha-phase-2-design.md)
+- ADR 0014(Phase 2 dictionary layer architecture、本 P2-A で D4 改訂): [`docs/adr/0014-phase-2-dictionary-layer-architecture.md`](../../adr/0014-phase-2-dictionary-layer-architecture.md)
+- ADR 0011(`#[non_exhaustive]` enum 拡張の根拠): [`docs/adr/0011-kanji-backend-trait-design.md`](../../adr/0011-kanji-backend-trait-design.md)
+- ADR 0012(`default = []` feature flag 方針): [`docs/adr/0012-feature-flag-design-for-llama-cpp.md`](../../adr/0012-feature-flag-design-for-llama-cpp.md)
+- ADR 0010(Phase 5 KotohaNative integration の継承先): [`docs/adr/0010-kotoha-custom-romaji-base-model.md`](../../adr/0010-kotoha-custom-romaji-base-model.md)
+
+### 11.2 関連 memory
+
+- Clean Architecture / SOLID 整合の feedback: `~/.claude/projects/-home-kohshiro-develops-student-kotoha-ime/memory/feedback_clean_architecture_solid.md`
+- Vocab 文法的多義性 feedback: `~/.claude/projects/-home-kohshiro-develops-student-kotoha-ime/memory/feedback_vocab_grammatical_collision.md`
+
+### 11.3 外部参照
+
+- sudachi.rs: <https://github.com/WorksApplications/sudachi.rs>(Apache-2.0、v0.6.11)
+- SudachiDict-core: <https://github.com/WorksApplications/SudachiDict>(Apache-2.0、v20260116)

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -184,7 +184,35 @@
 
 ### Phase 2 Dictionary layer (P2-A 以降)
 
-以下 6 entry は ADR 0014 (`docs/adr/0014-phase-2-dictionary-layer-architecture.md`) および Phase 2 spec (`docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`) で初出した用語を集約する。実装 identifier は P2-A kick-off で確定予定のものを含む。
+以下 10 entry は ADR 0014 (`docs/adr/0014-phase-2-dictionary-layer-architecture.md`) および Phase 2 spec (`docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`) で初出した用語を集約する。実装 identifier は P2-A kick-off で確定済のものと P2-D 以降で確定予定のものを含む。
+
+### 形態素解析 (Morphological Analysis)
+
+- **定義**: 入力テキストを形態素 (意味を持つ最小単位) に分割し、各形態素の表記 / 読み / 品詞を同定する処理。Phase 2 P2-A は本処理を `MorphologicalEngine` trait の抽象境界経由で `SudachiAdapter` 実装として提供する。
+- **初出**: ADR 0014 C3 / Phase 2 P2-A spec §3.3 / §4.2
+- **対応する identifier**: `MorphologicalEngine` trait + `SudachiAdapter` 実装 (`crates/kotoha-core/src/dict/morph/` 配下)
+- **備考**: SudachiDict 採用の動機 (固有名詞 / 敬称 recall を構造的に補う) は形態素解析処理に依存する。Phase 5 以降で vibrato / lindera 等の形態素解析器への差し替えを検討する余地は MorphologicalEngine trait 抽象によって確保している。
+
+### MorphologicalEngine
+
+- **定義**: Phase 2 P2-A で導入した形態素解析 engine の抽象境界 trait。`tokenize(reading) -> Vec<EngineCandidate>` と `engine_id() -> &str` の 2 method を提供する。
+- **初出**: Phase 2 P2-A spec §4.2
+- **対応する identifier**: `MorphologicalEngine` trait (`crates/kotoha-core/src/dict/morph/`)
+- **備考**: P2-A 段階では `SudachiAdapter` のみが本 trait を実装する。Phase 5 以降で vibrato / lindera 等の形態素解析器への差し替え余地を確保する目的で先出しした抽象 layer であり、`KanjiBackend` trait (ADR 0011) と同様に `Box<dyn MorphologicalEngine>` による dynamic dispatch を採用する。
+
+### VocabularyLookup
+
+- **定義**: Phase 2 P2-A で導入した user / custom vocabulary の lookup 抽象境界 trait。`lookup(reading) -> Vec<VocabEntry>` と `vocab_id() -> &str` の 2 method を提供する。
+- **初出**: Phase 2 P2-A spec §4.2
+- **対応する identifier**: `VocabularyLookup` trait (`crates/kotoha-core/src/dict/vocab/`)
+- **備考**: P2-A 段階では `CustomVocab` (TSV reader) のみが本 trait を実装する。P2-B で追加予定の `UserVocab` (ユーザ個別語彙、追加 / 削除 / 列挙 API を持つ) が同 trait を実装する extension path を確保する目的で先出しした抽象 layer。
+
+### SudachiDict
+
+- **定義**: WorksApplications が提供する日本語形態素解析辞書 (core / small / full の 3 variant)。Apache-2.0 ライセンスで公開され、約 76 万 entries (lemma + 活用形含む、lemma 単位では約 20 万) 規模の core variant を Kotoha Phase 2 P2-A は採用する。
+- **初出**: ADR 0014 C4 / Phase 2 spec §4.1
+- **対応する identifier**: `KOTOHA_SYSTEM_DICT_PATH` 環境変数で `system_core.dic` の絶対パスを指定する (Phase 1 の `KOTOHA_LLAMA_MODEL_PATH` と同 pattern の manual placement 運用)
+- **備考**: Kotoha Phase 2 P2-A が採用する正確な version は v20260116 (約 70MB、76 万 entries 規模)。core / full / small の 3 variant のうち、IME 常駐 footprint と recall の trade-off で core を default とする (Phase 2 spec §4.1)。`sudachipy / SudachiDict` (§8) 項は P5-A PoC 文脈での Python binding 採用を扱うが、本項は Phase 2 P2-A の Rust 実装 runtime での採用文脈に焦点を当てる。
 
 ### DictionaryBackend / DictionaryAugmented variant
 

--- a/tools/p2a-fixture-gen/.gitignore
+++ b/tools/p2a-fixture-gen/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/

--- a/tools/p2a-fixture-gen/README.md
+++ b/tools/p2a-fixture-gen/README.md
@@ -1,0 +1,40 @@
+# kotoha-p2a-fixture-gen
+
+Phase 2 P2-A 用 golden fixture (530 cases) 生成 tool。
+
+## 入力
+
+- `../p5a-data-pipeline/fixtures/sample.tsv`(P5-A PoC 生成物、10 列 schema)
+
+P5-A `sample.tsv` の schema(`tools/p5a-data-pipeline/README.md` §"出力 TSV schema"):
+
+| 列番号 | 列名 | 用途 |
+| --- | --- | --- |
+| 1 | `noisy_romaji` | typo 入り入力(本 tool では未使用) |
+| 2 | `kanji` | 正解漢字表層(本 tool で `surface` として採用) |
+| 3 | `clean_romaji` | typo なし romaji(本 tool で `reading` として採用) |
+| 4 | `typo_distance` | `0` のみ採用 |
+| 5 | `romaji_style` | `hepburn` / `kunrei` / `waapuro` 全て採用 |
+| 6 | `is_partial` | `0` のみ採用(full 行のみ) |
+| 7-10 | partial / token / segment 関連 | 本 tool では未使用 |
+
+P2-A 仕様 §6.3.4 は SudachiDict-core を入力源として明示しているが、Phase 1 完了直後の現状では P5-A `sample.tsv` を仮の入力源として採用する(B5 不足は plan §10 残論点に従い fallback concat で補う)。
+
+## 出力
+
+- `../../crates/kotoha-core/tests/fixtures/kanji_dictionary_golden.tsv`
+
+## 内訳
+
+- targeted 30: 敬称 / 人名 / 地名・組織名 / 外来語(manual curated)
+- bulk 500: reading 文字数 5-bucket 各 100 件 stratified sampling
+
+## 実行
+
+```bash
+cd tools/p2a-fixture-gen
+uv sync
+uv run python -m p2a_fixture_gen.main
+```
+
+seed 固定(42)で再現性あり。

--- a/tools/p2a-fixture-gen/pyproject.toml
+++ b/tools/p2a-fixture-gen/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "kotoha-p2a-fixture-gen"
+version = "0.1.0"
+description = "Phase 2 P2-A golden fixture generator (530-case stratified sampling)"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "Kotoha IME contributors" },
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.5",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/p2a_fixture_gen"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tools/p2a-fixture-gen/src/p2a_fixture_gen/__init__.py
+++ b/tools/p2a-fixture-gen/src/p2a_fixture_gen/__init__.py
@@ -1,0 +1,3 @@
+"""Kotoha P2-A golden fixture generator."""
+
+__version__ = "0.1.0"

--- a/tools/p2a-fixture-gen/src/p2a_fixture_gen/main.py
+++ b/tools/p2a-fixture-gen/src/p2a_fixture_gen/main.py
@@ -1,0 +1,33 @@
+"""P2-A fixture generator entry point: writes 530-case golden TSV."""
+
+from pathlib import Path
+
+from p2a_fixture_gen.sample import (
+    bulk_as_tsv_rows,
+    load_sample_pairs,
+    stratified_sample,
+)
+from p2a_fixture_gen.targeted import targeted_as_tsv_rows
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+OUTPUT = REPO_ROOT / "crates" / "kotoha-core" / "tests" / "fixtures" / "kanji_dictionary_golden.tsv"
+
+
+def main() -> None:
+    header = [
+        "# kanji_dictionary_golden.tsv — Phase 2 P2-A golden fixture",
+        "# Schema: input<TAB>expected_top_surface<TAB>category<TAB>note",
+        "# Contents: targeted 30 + bulk 500 (5-bucket stratified × 100)",
+        "# Generation: tools/p2a-fixture-gen (seed=42)",
+        "# Threshold: ≥90% pass rate (spec §3.9 / §6.3.2)",
+    ]
+    targeted = targeted_as_tsv_rows()
+    bulk = bulk_as_tsv_rows(stratified_sample(load_sample_pairs()))
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text("\n".join(header + targeted + bulk) + "\n", encoding="utf-8")
+    print(f"wrote {len(targeted) + len(bulk)} rows -> {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/p2a-fixture-gen/src/p2a_fixture_gen/sample.py
+++ b/tools/p2a-fixture-gen/src/p2a_fixture_gen/sample.py
@@ -1,0 +1,136 @@
+"""Bulk 500-case stratified sampling (5 buckets × 100) from sample.tsv.
+
+Schema mapping for P5-A `tools/p5a-data-pipeline/fixtures/sample.tsv` (10 cols, header row):
+
+| col idx | name           | usage in this tool                                  |
+| ------- | -------------- | --------------------------------------------------- |
+| 0       | noisy_romaji   | unused                                              |
+| 1       | kanji          | adopted as `surface` (output column 2)              |
+| 2       | clean_romaji   | adopted as `reading` (output column 1)              |
+| 3       | typo_distance  | filter: only `0` rows accepted                      |
+| 4       | romaji_style   | all 3 styles accepted                               |
+| 5       | is_partial     | filter: only `0` rows accepted                      |
+| 6-9     | partial / token / segment | unused                                   |
+
+Note: the plan originally indexed `parts[0]` / `parts[1]` assuming a 2-col
+`reading\\tsurface` schema. The actual P5-A output is a 10-col TSV with header,
+so this module reads `clean_romaji` (idx 2) as reading and `kanji` (idx 1) as
+surface, filters to `typo_distance=0` and `is_partial=0`, and dedupes pairs.
+"""
+
+import random
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+P5A_SAMPLE = REPO_ROOT / "tools" / "p5a-data-pipeline" / "fixtures" / "sample.tsv"
+
+
+def bucket_for_reading_length(n: int) -> str | None:
+    if 1 <= n <= 3:
+        return "B1"
+    if 4 <= n <= 6:
+        return "B2"
+    if 7 <= n <= 10:
+        return "B3"
+    if 11 <= n <= 20:
+        return "B4"
+    if n >= 21:
+        return "B5"
+    return None
+
+
+def load_sample_pairs(path: Path = P5A_SAMPLE) -> list[tuple[str, str]]:
+    """Load (reading, surface) pairs from p5a sample.tsv.
+
+    File format: 10-col TSV with header. Columns used:
+      - col idx 2 = clean_romaji (treated as reading)
+      - col idx 1 = kanji (treated as surface)
+    Filter: typo_distance == 0 AND is_partial == 0. Dedupe identical pairs.
+    Empty / comment lines and the header row are skipped.
+    """
+    pairs: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    if not path.exists():
+        raise FileNotFoundError(
+            f"p5a sample not found: {path}. Run "
+            "`cd tools/p5a-data-pipeline && uv run -m kotoha_p5a "
+            "--input fixtures/input_sentences.txt --output fixtures/sample.tsv "
+            "--seed 42 --with-partials 2 --with-tokens --with-mixed-jpen 5` first."
+        )
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 6:
+            continue
+        # Skip header row (first column literal value `noisy_romaji`).
+        if parts[0] == "noisy_romaji":
+            continue
+        # Filter: typo_distance must be 0, is_partial must be 0.
+        if parts[3] != "0" or parts[5] != "0":
+            continue
+        reading = parts[2]
+        surface = parts[1]
+        if not reading or not surface:
+            continue
+        key = (reading, surface)
+        if key in seen:
+            continue
+        seen.add(key)
+        pairs.append(key)
+    return pairs
+
+
+def stratified_sample(
+    pairs: list[tuple[str, str]], per_bucket: int = 100, seed: int = 42
+) -> dict[str, list[tuple[str, str]]]:
+    """Group pairs by bucket and sample per_bucket from each. B5 fallback handles scarcity."""
+    rng = random.Random(seed)
+    buckets: dict[str, list[tuple[str, str]]] = {
+        "B1": [],
+        "B2": [],
+        "B3": [],
+        "B4": [],
+        "B5": [],
+    }
+    for reading, surface in pairs:
+        b = bucket_for_reading_length(len(reading))
+        if b is not None:
+            buckets[b].append((reading, surface))
+
+    sampled: dict[str, list[tuple[str, str]]] = {}
+    # Iteration cap on the fallback loop. Prevents infinite spinning when the
+    # donor pool cannot, in principle, synthesize a target-bucket pair.
+    max_attempts = per_bucket * 200
+    for b, rows in buckets.items():
+        if len(rows) >= per_bucket:
+            sampled[b] = rng.sample(rows, per_bucket)
+            continue
+
+        sampled[b] = list(rows)
+        # B5 scarcity fallback (plan §10): concatenate two B3/B4 entries to
+        # reach len>=21 until per_bucket items are reached. For B1-B4, no
+        # fallback is performed (concatenation cannot synthesize shorter
+        # strings); the bucket simply takes whatever natural data exists.
+        if b != "B5":
+            continue
+        donor = buckets["B3"] + buckets["B4"]
+        attempts = 0
+        while len(sampled[b]) < per_bucket and donor and attempts < max_attempts:
+            attempts += 1
+            a = rng.choice(donor)
+            c = rng.choice(donor)
+            combined = (a[0] + c[0], a[1] + c[1])
+            if len(combined[0]) >= 21:
+                sampled[b].append(combined)
+    return sampled
+
+
+def bulk_as_tsv_rows(sampled: dict[str, list[tuple[str, str]]]) -> list[str]:
+    """Convert sampled dict into TSV rows with category=bulk_<bucket>."""
+    rows: list[str] = []
+    for bucket, pairs in sampled.items():
+        for reading, surface in pairs:
+            rows.append(f"{reading}\t{surface}\tbulk_{bucket}\tstratified")
+    return rows

--- a/tools/p2a-fixture-gen/src/p2a_fixture_gen/targeted.py
+++ b/tools/p2a-fixture-gen/src/p2a_fixture_gen/targeted.py
@@ -1,0 +1,57 @@
+"""Targeted 30 cases for Phase 2 golden fixture (spec §6.3.1)."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Case:
+    input: str
+    expected_top_surface: str
+    category: str
+    note: str
+
+
+TARGETED_CASES: list[Case] = [
+    # 敬称 10
+    Case("やまださん", "山田さん", "honorific", "敬称+人名"),
+    Case("たなかさん", "田中さん", "honorific", "敬称+人名"),
+    Case("すずきせんせい", "鈴木先生", "honorific", "敬称+教職"),
+    Case("さとうさま", "佐藤様", "honorific", "尊敬敬称"),
+    Case("ほんださん", "本田さん", "honorific", "敬称+人名"),
+    Case("なかむらくん", "中村くん", "honorific", "男性敬称"),
+    Case("やまもとちゃん", "山本ちゃん", "honorific", "親愛敬称"),
+    Case("こばやしせんぱい", "小林先輩", "honorific", "年長敬称"),
+    Case("おがわかちょう", "小川課長", "honorific", "役職敬称"),
+    Case("いしいしゃちょう", "石井社長", "honorific", "役職敬称"),
+    # 人名 10
+    Case("やまだたろう", "山田太郎", "personal_name", "姓+名"),
+    Case("すずきはなこ", "鈴木花子", "personal_name", "姓+名"),
+    Case("たなかいちろう", "田中一郎", "personal_name", "姓+名"),
+    Case("さとうけんじ", "佐藤健二", "personal_name", "姓+名"),
+    Case("わたなべゆき", "渡辺由紀", "personal_name", "姓+名"),
+    Case("いとうまさし", "伊藤正", "personal_name", "姓+名"),
+    Case("やまもとあきら", "山本明", "personal_name", "姓+名"),
+    Case("なかむらみさき", "中村美咲", "personal_name", "姓+名"),
+    Case("こばやしゆうじ", "小林雄二", "personal_name", "姓+名"),
+    Case("まつもとなおこ", "松本直子", "personal_name", "姓+名"),
+    # 地名・組織名 5
+    Case("とうきょうと", "東京都", "place_org", "地名"),
+    Case("おおさかふ", "大阪府", "place_org", "地名"),
+    Case("ほっかいどう", "北海道", "place_org", "地名"),
+    Case("きょうとだいがく", "京都大学", "place_org", "組織名"),
+    Case("とよたじどうしゃ", "トヨタ自動車", "place_org", "組織名"),
+    # 外来語 5
+    Case("こんぴゅーたー", "コンピューター", "loanword", "長音付き"),
+    Case("ぷろぐらむ", "プログラム", "loanword", "促音なし"),
+    Case("さーばー", "サーバー", "loanword", "長音付き"),
+    Case("かめら", "カメラ", "loanword", "短い外来語"),
+    Case("すまーとふぉん", "スマートフォン", "loanword", "長音+合成語"),
+]
+
+
+def targeted_as_tsv_rows() -> list[str]:
+    """Return targeted cases as TSV lines (input<TAB>expected<TAB>category<TAB>note)."""
+    return [
+        f"{c.input}\t{c.expected_top_surface}\t{c.category}\t{c.note}"
+        for c in TARGETED_CASES
+    ]

--- a/tools/p2a-fixture-gen/tests/test_sample.py
+++ b/tools/p2a-fixture-gen/tests/test_sample.py
@@ -1,0 +1,43 @@
+"""Tests for bulk stratified sampling."""
+
+from p2a_fixture_gen.sample import (
+    bucket_for_reading_length,
+    bulk_as_tsv_rows,
+    stratified_sample,
+)
+
+
+def test_bucket_assignment_by_length() -> None:
+    assert bucket_for_reading_length(1) == "B1"
+    assert bucket_for_reading_length(3) == "B1"
+    assert bucket_for_reading_length(4) == "B2"
+    assert bucket_for_reading_length(7) == "B3"
+    assert bucket_for_reading_length(11) == "B4"
+    assert bucket_for_reading_length(21) == "B5"
+    assert bucket_for_reading_length(0) is None
+
+
+def test_stratified_sample_returns_five_buckets() -> None:
+    # synthetic pairs covering buckets B1-B4 evenly; B5 via fallback
+    pairs: list[tuple[str, str]] = []
+    for n, _bucket in [(2, "B1"), (5, "B2"), (8, "B3"), (15, "B4")]:
+        for i in range(150):
+            pairs.append(("a" * n, "X" * n + str(i)))
+    sampled = stratified_sample(pairs, per_bucket=100)
+    assert set(sampled.keys()) == {"B1", "B2", "B3", "B4", "B5"}
+    assert len(sampled["B1"]) == 100
+    assert len(sampled["B2"]) == 100
+    # B5 may be populated via fallback concat
+    assert len(sampled["B5"]) == 100
+
+
+def test_bulk_tsv_rows_have_four_fields() -> None:
+    # Provide donor coverage in B3/B4 so that B5 fallback can concat to len>=21
+    # (avoids spinning the scarcity-fallback loop).
+    pairs: list[tuple[str, str]] = []
+    for n in (2, 5, 9, 15):
+        for i in range(10):
+            pairs.append(("a" * n, "X" * n + str(i)))
+    sampled = stratified_sample(pairs, per_bucket=3)
+    for row in bulk_as_tsv_rows(sampled):
+        assert len(row.split("\t")) == 4

--- a/tools/p2a-fixture-gen/tests/test_targeted.py
+++ b/tools/p2a-fixture-gen/tests/test_targeted.py
@@ -1,0 +1,17 @@
+"""Tests for targeted 30-case list."""
+
+from p2a_fixture_gen.targeted import TARGETED_CASES, targeted_as_tsv_rows
+
+
+def test_targeted_has_30_cases() -> None:
+    assert len(TARGETED_CASES) == 30
+
+
+def test_targeted_categories_cover_four_buckets() -> None:
+    categories = {c.category for c in TARGETED_CASES}
+    assert categories == {"honorific", "personal_name", "place_org", "loanword"}
+
+
+def test_targeted_tsv_rows_have_four_fields() -> None:
+    for row in targeted_as_tsv_rows():
+        assert len(row.split("\t")) == 4

--- a/tools/p2a-fixture-gen/uv.lock
+++ b/tools/p2a-fixture-gen/uv.lock
@@ -1,0 +1,108 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "kotoha-p2a-fixture-gen"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.5" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]


### PR DESCRIPTION
## Summary

Phase 2 P2-A: introduce a SudachiDict-based dictionary backend as the second `KanjiBackend` implementation (after `LlamaCppBackend`).

- Adds `MorphologicalEngine` / `VocabularyLookup` traits (Clean Architecture DIP) and `DictionaryBackend` struct holding both as `Box<dyn _>`.
- Adds `BackendConfig::Dictionary { config: DictionaryConfig }` variant + `load_backend` arm (gated behind `dict` feature).
- Adds `dict` / `dict-smoke` Cargo features with `default = []` (per ADR 0012 D5).
- Adds `SudachiAdapter` (sudachi.rs git rev `90fd6068c80c` = v0.6.11, Apache-2.0) and `CustomVocab` TSV reader.
- Adds engine-neutral public API (`system_dict_path`, `KOTOHA_SYSTEM_DICT_PATH`, spec §3.4 Q4).
- Adds bundled empty `crates/kotoha-core/resources/kotoha-dict.tsv` with curation policy comments.
- Adds `tools/p2a-fixture-gen/` (Python 3.12 + uv) for reproducible fixture generation.
- Revises ADR 0014 D4 to reflect the two-variant plan (P2-A aggregated `Dictionary` + P2-D recursive `Hybrid`).
- Syncs parent Phase 2 spec + README + glossary.

**Layer 3 (530-case golden fixture, golden test runner, `phase2-smoke.sh`)** is deferred to #92 due to a schema mismatch in the P5-A sample data source discovered mid-execution (`clean_romaji` is romaji not hiragana, and only ~100 unique pairs exist vs. the 500+ needed for stratified sampling). The fixture generator tool itself is included; the actual fixture content and runner ship with the follow-up.

Closes #91. Layer 3 follow-up tracked in #92.

## Spec links

- Child spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md`
- Parent spec: `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md`
- ADR: `docs/adr/0014-phase-2-dictionary-layer-architecture.md` (D4 revised in this PR)
- Implementation plan: `docs/superpowers/plans/2026-04-25-feature-91-p2-a-dictionary-layer.md`

## Acceptance criteria

- [x] `BackendConfig::Dictionary` / `DictionaryConfig` land with engine-neutral public field names (spec §3.4 Q4).
- [x] `MorphologicalEngine` / `VocabularyLookup` traits introduced as Clean Architecture seams.
- [x] `dict` / `dict-smoke` Cargo features added with `default = []`.
- [x] Phase 1 14/15 baseline preserved — `cargo test --workspace --features mock-backend,dict` reports 222 passed (175 Phase 1 + 47 P2-A).
- [x] ADR 0014 D4 revised in this PR.
- [ ] Phase 2 G2 (≥ 90% pass rate on 530-case golden fixture) — **deferred to #92** (Layer 3 evaluation infrastructure).

## Test counts (verified locally on this branch)

| Suite | Count | Notes |
|---|---|---|
| `cargo test --workspace` (default features) | 175 | Phase 1 baseline preserved |
| `cargo test --workspace --features mock-backend,dict` | 222 | +47 over baseline (Layer 1 + Layer 2 P2-A) |
| `tools/p2a-fixture-gen/` `uv run pytest` | 6 | Python tool unit tests |
| Layer 3 (`dict-smoke`) | — | Runner & fixture deferred to #92 |

## Review checklist (Large PR tier, per global CLAUDE.md PR Review Matrix)

- [ ] `agent-teams:team-review` (5 dimensions: security / performance / architecture / testing / a11y)
- [ ] `owasp-security`
- [ ] `secrets-check`
- [ ] `security-scanning:security-sast`
- [ ] `pr-review-toolkit:review-pr`

## Manual verification

```bash
# Layer 1 + Layer 2 (no dictionary file required)
cargo test --workspace --features mock-backend,dict

# Optional: Layer 2 integration only
cargo test --features dict -p kotoha-core --test kanji_dictionary_unit
```

Layer 3 manual smoke (once #92 lands):

```bash
export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic
bash scripts/phase2-smoke.sh
```