### PR TITLE
fix(p2-a): apply 10 hardening findings + Medium-tier review fixes (#97)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +488,7 @@ version = "0.1.0"
 dependencies = [
  "llama-cpp-2",
  "proptest",
+ "serial_test",
  "sudachi",
  "thiserror 1.0.69",
  "tracing",
@@ -521,6 +557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +622,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -697,6 +765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +849,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,10 +919,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -835,7 +971,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "sudachi"
 version = "0.6.11"
-source = "git+https://github.com/WorksApplications/sudachi.rs?rev=90fd6068c80c#90fd6068c80c2fc3b63e0dbab0e341475bad4d8f"
+source = "git+https://github.com/WorksApplications/sudachi.rs?rev=90fd6068c80c2fc3b63e0dbab0e341475bad4d8f#90fd6068c80c2fc3b63e0dbab0e341475bad4d8f"
 dependencies = [
  "aho-corasick",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,8 @@ llama-cpp-2 = "0.1"
 #   - lindera: MeCab-IPADIC / UniDic 要求(UniDic は商用利用制約)
 #   - vibrato: SudachiDict native 非対応(short/middle/long unit 不可)
 #   - SudachiDict→MeCab 変換: WorksApplications 公式提供なし、精度保証なし
-sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }
+# rev は v0.6.11 tag の full SHA-1。短縮 SHA は将来衝突リスクがあるため 40-char に固定する。
+# rev を更新したら `SUDACHI_ENGINE_ID_LABEL`
+# (`crates/kotoha-core/src/dict/sudachi_adapter.rs`) を同期せよ。
+sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c2fc3b63e0dbab0e341475bad4d8f" }
+serial_test = "3"

--- a/README.md
+++ b/README.md
@@ -108,14 +108,19 @@ Phase 2 P2-A の Dictionary backend は SudachiDict-core(v20260116、約 70MB、
 ### 取得手順
 
 ```bash
-# 1. SudachiDict-core を取得し展開
+# 1. SudachiDict-core を取得
 mkdir -p ~/.local/share/sudachidict
 curl -L -o /tmp/sudachi-dict-core.zip \
   https://github.com/WorksApplications/SudachiDict/releases/download/v20260116/sudachi-dictionary-20260116-core.zip
+
+# 2. SHA-256 で integrity を検証(digest pinned 2026-04-25, release v20260116)
+echo "e80e68c8e7b17e2082341284cffefbc11fb7838b2c318ae280c1690fc1ee1e2f  /tmp/sudachi-dict-core.zip" | sha256sum -c -
+
+# 3. 検証成功後に展開
 unzip -j /tmp/sudachi-dict-core.zip 'sudachi-dictionary-20260116/system_core.dic' \
   -d ~/.local/share/sudachidict/
 
-# 2. 環境変数を設定(~/.zshrc または ~/.bashrc に追記推奨)
+# 4. 環境変数を設定(~/.zshrc または ~/.bashrc に追記推奨)
 export KOTOHA_SYSTEM_DICT_PATH=$HOME/.local/share/sudachidict/system_core.dic
 ```
 

--- a/crates/kotoha-core/Cargo.toml
+++ b/crates/kotoha-core/Cargo.toml
@@ -20,6 +20,7 @@ sudachi = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+serial_test = { workspace = true }
 
 [features]
 default = []

--- a/crates/kotoha-core/src/dict/custom_vocab.rs
+++ b/crates/kotoha-core/src/dict/custom_vocab.rs
@@ -3,11 +3,18 @@
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §5.2.
 
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs;
+use std::io;
 use std::path::Path;
 
 use crate::dict::vocab::{VocabEntry, VocabularyLookup};
 use crate::kanji::KanjiError;
+
+/// Custom vocab TSV の最大許容サイズ(bytes)。
+/// 64 MiB を超える file は CWE-400 / 資源枯渇防止のため reject する
+/// (P2-A hardening item 2)。
+const CUSTOM_VOCAB_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Custom vocabulary source backed by a TSV file.
 ///
@@ -28,14 +35,59 @@ pub struct CustomVocab {
 impl CustomVocab {
     /// Loads a custom vocab from a TSV file on disk.
     ///
+    /// # Preconditions
+    ///
+    /// - 拡張子は `.tsv` でなければならない(P2-A hardening item 2)
+    /// - canonicalize 後のサイズは [`CUSTOM_VOCAB_MAX_BYTES`] 以下でなければならない
+    ///
     /// # Errors
     ///
-    /// - [`KanjiError::Backend`] when the file cannot be read or parsed.
+    /// - [`KanjiError::ModelNotFound`] when the canonicalize step fails with NotFound.
+    /// - [`KanjiError::Backend`] when extension is not `.tsv`, the file exceeds
+    ///   the size cap, or any other I/O / parse error occurs.
     pub fn load(path: &Path) -> Result<Self, KanjiError> {
-        let content = fs::read_to_string(path).map_err(|e| KanjiError::Backend {
-            reason: format!("failed to read custom vocab {}: {e}", path.display()),
+        // ========================================
+        // Path traversal hardening (P2-A item 2)
+        // ========================================
+        let canonical = fs::canonicalize(path).map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound => KanjiError::ModelNotFound {
+                path: path.to_path_buf(),
+            },
+            _ => KanjiError::Backend {
+                reason: format!(
+                    "failed to canonicalize custom vocab path {}: {e:?}",
+                    path.display()
+                ),
+            },
         })?;
-        let label = path
+
+        if canonical.extension().and_then(OsStr::to_str) != Some("tsv") {
+            return Err(KanjiError::Backend {
+                reason: format!(
+                    "custom vocab must have `.tsv` extension, got {}",
+                    canonical.display()
+                ),
+            });
+        }
+
+        let size = fs::metadata(&canonical)
+            .map_err(|e| KanjiError::Backend {
+                reason: format!("failed to read metadata for {}: {e:?}", canonical.display()),
+            })?
+            .len();
+        if size > CUSTOM_VOCAB_MAX_BYTES {
+            return Err(KanjiError::Backend {
+                reason: format!(
+                    "custom vocab at {} exceeds size cap: {size} > {CUSTOM_VOCAB_MAX_BYTES} bytes",
+                    canonical.display()
+                ),
+            });
+        }
+
+        let content = fs::read_to_string(&canonical).map_err(|e| KanjiError::Backend {
+            reason: format!("custom vocab load from {}: {e:?}", canonical.display()),
+        })?;
+        let label = canonical
             .file_name()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown")
@@ -218,5 +270,88 @@ mod tests {
         let inf_tsv = "漢字\tかんじ\t名詞\tinf\n";
         let err = CustomVocab::from_str(inf_tsv).expect_err("inf score must be rejected");
         assert!(matches!(err, crate::kanji::KanjiError::Backend { .. }));
+    }
+
+    // ======================================================================
+    // Path traversal hardening (P2-A item 2)
+    //
+    // tempfile crate を導入せず std のみで unique path を組み立てる。
+    // PID + nanoseconds の組み合わせで test 並列実行時の衝突を避ける。
+    // ======================================================================
+
+    fn unique_tmp_path(suffix: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "kotoha-p2a-test-{}-{}{}",
+            std::process::id(),
+            nanos,
+            suffix,
+        ))
+    }
+
+    #[test]
+    fn custom_vocab_load_rejects_non_tsv_extension() {
+        let path = unique_tmp_path("-nottsv.txt");
+        std::fs::write(&path, SINGLE_ENTRY_TSV).expect("write tmp file");
+        let err = CustomVocab::load(&path).expect_err("non-tsv extension must reject");
+        let _ = std::fs::remove_file(&path);
+        match err {
+            KanjiError::Backend { reason } => {
+                assert!(
+                    reason.contains(".tsv"),
+                    "error must mention required extension: {reason}"
+                );
+            }
+            other => panic!("expected Backend, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_vocab_load_rejects_oversized_file() {
+        // 64 MiB cap を 1 byte 超える sparse file を ftruncate-style で作成する。
+        // Linux の seek + write で疎なファイルになるため実 disk は数 KB で済む。
+        let path = unique_tmp_path("-large.tsv");
+        let f = std::fs::File::create(&path).expect("create tmp tsv");
+        f.set_len(super::CUSTOM_VOCAB_MAX_BYTES + 1)
+            .expect("set len above cap");
+        drop(f);
+        let err = CustomVocab::load(&path).expect_err("oversized file must reject");
+        let _ = std::fs::remove_file(&path);
+        match err {
+            KanjiError::Backend { reason } => {
+                assert!(
+                    reason.contains("size cap"),
+                    "error must mention size cap: {reason}"
+                );
+            }
+            other => panic!("expected Backend, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_vocab_load_round_trips_real_file_and_rejects_missing() {
+        // 1) 実 file を `.tsv` で配置し、canonicalize -> read_to_string -> parse の
+        //    happy path が通ることを確認する(canonicalize 動作の statement
+        //    coverage を兼ねる、P2-A hardening item 2)。
+        let valid_path = unique_tmp_path("-canon.tsv");
+        std::fs::write(&valid_path, SINGLE_ENTRY_TSV).expect("write tmp tsv");
+        let vocab = CustomVocab::load(&valid_path).expect("canonicalize + load must succeed");
+        let _ = std::fs::remove_file(&valid_path);
+        assert_eq!(vocab.lookup("かんじ").len(), 1);
+
+        // 2) 存在しない path に対しては canonicalize が NotFound を返し、
+        //    KanjiError::ModelNotFound に折り畳まれる(item 6 整合)。
+        let missing = unique_tmp_path("-missing.tsv");
+        let err = CustomVocab::load(&missing).expect_err("missing file must error");
+        match err {
+            KanjiError::ModelNotFound { path: p } => {
+                assert!(p.to_string_lossy().contains("missing.tsv"));
+            }
+            other => panic!("expected ModelNotFound, got: {other:?}"),
+        }
     }
 }

--- a/crates/kotoha-core/src/dict/sudachi_adapter.rs
+++ b/crates/kotoha-core/src/dict/sudachi_adapter.rs
@@ -2,6 +2,9 @@
 //!
 //! Spec: `docs/superpowers/specs/2026-04-25-p2-a-dictionary-layer-design.md` §3.4, §4.1, §5.1.
 
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use sudachi::analysis::stateful_tokenizer::StatefulTokenizer;
@@ -12,9 +15,25 @@ use sudachi::dic::dictionary::JapaneseDictionary;
 use crate::dict::engine::{EngineCandidate, MorphologicalEngine};
 use crate::kanji::KanjiError;
 
+/// SudachiDict-core を runtime load する際の最大許容サイズ(bytes)。
+/// 200 MiB は v20260116 release の実サイズ(約 70 MB)に対し将来の dictionary 拡張を
+/// 見越した上限。これを超える file が指定された場合は CWE-400 / 資源枯渇防止のため
+/// load を reject する(P2-A hardening item 2)。
+const SYSTEM_DICT_MAX_BYTES: u64 = 200 * 1024 * 1024;
+
 /// sudachi.rs の engine_id() で返す固定 label。Layer 3 golden test から
 /// 同一文字列でアサートするため、module スコープの `pub(crate)` const として
 /// 固定する。
+///
+/// # 同期義務
+///
+/// `Cargo.toml` `[workspace.dependencies]` の `sudachi` git rev を更新したら、
+/// 以下を **必ず** 同期せよ(P2-A hardening item 7):
+/// - `sudachi-X.Y.Z` 部分を新 sudachi.rs release tag に揃える
+/// - `sudachidict-core:vYYYYMMDD` 部分を `README.md` 配置手順で参照している
+///   SudachiDict-core release tag に揃える
+///
+/// build-time 自動化は YAGNI として見送り、PR review チェックリストで担保する。
 pub(crate) const SUDACHI_ENGINE_ID_LABEL: &str = "sudachi-0.6.11+sudachidict-core:v20260116";
 
 /// sudachi.rs runtime ラッパー。`MorphologicalEngine` 実装。
@@ -49,32 +68,115 @@ impl SudachiAdapter {
     /// # Preconditions
     ///
     /// - `system_dict_path` は SudachiDict-core の `system_core.dic` を指す
+    /// - 拡張子は `.dic` でなければならない(P2-A hardening item 2、extension allowlist)
+    /// - canonicalize 後のサイズは [`SYSTEM_DICT_MAX_BYTES`] 以下でなければならない
+    ///
+    /// # Postconditions
+    ///
+    /// - sudachi.rs の config search は default location に fallback しない。
+    ///   `Config::new_embedded()` で sudachi 同梱の baseline config を読み込み、
+    ///   `with_system_dic()` で system dictionary だけを caller 提供 path で
+    ///   override する(P2-A hardening item 1、CWE-426 対策)。
     ///
     /// # Errors
     ///
-    /// - [`KanjiError::ModelNotFound`] — path に file が存在しない場合
+    /// - [`KanjiError::ModelNotFound`] — path に file が存在しない場合 / canonicalize 失敗時
+    /// - [`KanjiError::Backend`] — 拡張子が `.dic` でない / size cap 超過 / I/O error
     /// - [`KanjiError::ModelLoadFailed`] — sudachi.rs 側で config / dict の
-    ///   読み込みに失敗した場合
+    ///   読み込みに失敗した場合(NotFound 以外の I/O error も含む)
     pub(crate) fn load(system_dict_path: &Path) -> Result<Self, KanjiError> {
-        if !system_dict_path.exists() {
-            return Err(KanjiError::ModelNotFound {
+        // ========================================
+        // Path traversal hardening (P2-A item 2): symlink resolve + extension allowlist + size cap
+        // ========================================
+        // canonicalize は symlink を解決し、`..` 等を正規化する。NotFound 系の
+        // I/O error は ModelNotFound に折り畳み(item 6 と整合: TOCTOU を避けるため
+        // exists() の早期 check は廃する)、それ以外は Backend として通知する。
+        let canonical = fs::canonicalize(system_dict_path).map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound => KanjiError::ModelNotFound {
                 path: system_dict_path.to_path_buf(),
+            },
+            _ => KanjiError::Backend {
+                reason: format!(
+                    "failed to canonicalize system dict path {}: {e:?}",
+                    system_dict_path.display()
+                ),
+            },
+        })?;
+
+        // Extension allowlist: SudachiDict は `.dic` 形式のみを受理する。
+        if canonical.extension().and_then(OsStr::to_str) != Some("dic") {
+            return Err(KanjiError::Backend {
+                reason: format!(
+                    "system dict must have `.dic` extension, got {}",
+                    canonical.display()
+                ),
             });
         }
-        let config =
-            Config::new(None, None, Some(system_dict_path.to_path_buf())).map_err(|e| {
+
+        // Size cap: 異常に大きな file の load を防ぐ(CWE-400 / 資源枯渇)。
+        let size = fs::metadata(&canonical)
+            .map_err(|e| KanjiError::Backend {
+                reason: format!("failed to read metadata for {}: {e:?}", canonical.display()),
+            })?
+            .len();
+        if size > SYSTEM_DICT_MAX_BYTES {
+            return Err(KanjiError::Backend {
+                reason: format!(
+                    "system dict at {} exceeds size cap: {size} > {SYSTEM_DICT_MAX_BYTES} bytes",
+                    canonical.display()
+                ),
+            });
+        }
+
+        // ========================================
+        // Config 構築 (P2-A item 1, CWE-426): search path を回避
+        // ========================================
+        // `Config::new_embedded()` は sudachi.rs に同梱された baseline config を
+        // bytes から読む。`Config::new(None, ..)` のように on-disk default config を
+        // search する経路を通らないため、`SUDACHI_CONFIG_PATH` 等の外部入力で
+        // 任意 config を pin できない。system dictionary のみを caller の正規化済み
+        // path で override する。
+        let config = Config::new_embedded()
+            .map(|c| c.with_system_dic(canonical.clone()))
+            .map_err(|e| KanjiError::ModelLoadFailed {
+                source: Box::new(e),
+            })?;
+        let dict = JapaneseDictionary::from_cfg(&config).map_err(|e| {
+            // sudachi.rs 内部で I/O NotFound が起きるケース(canonicalize と
+            // from_cfg の間で file を消されたなど TOCTOU race)は ModelNotFound に
+            // 折り畳む。それ以外は ModelLoadFailed のまま伝播する。
+            if io_error_is_not_found(&e) {
+                KanjiError::ModelNotFound {
+                    path: canonical.clone(),
+                }
+            } else {
                 KanjiError::ModelLoadFailed {
                     source: Box::new(e),
                 }
-            })?;
-        let dict =
-            JapaneseDictionary::from_cfg(&config).map_err(|e| KanjiError::ModelLoadFailed {
-                source: Box::new(e),
-            })?;
+            }
+        })?;
         Ok(Self {
             dict,
-            system_dict_path: system_dict_path.to_path_buf(),
+            system_dict_path: canonical,
         })
+    }
+}
+
+/// `SudachiError` 連鎖に `io::Error` の NotFound が含まれるかを判定する。
+///
+/// `SudachiError::Io { cause, .. }` か、`source()` chain を辿って `io::Error::kind()`
+/// が `NotFound` の場合に `true` を返す。`from_cfg` が file 欠損を I/O error として
+/// 投げるケースを ModelNotFound に折り畳むために用いる(P2-A hardening item 6)。
+fn io_error_is_not_found(err: &sudachi::error::SudachiError) -> bool {
+    let mut current: &dyn std::error::Error = err;
+    loop {
+        if let Some(io_err) = current.downcast_ref::<io::Error>() {
+            return io_err.kind() == io::ErrorKind::NotFound;
+        }
+        match current.source() {
+            Some(next) => current = next,
+            None => return false,
+        }
     }
 }
 
@@ -102,6 +204,13 @@ impl MorphologicalEngine for SudachiAdapter {
         for m in morphemes.iter() {
             let surface = m.surface().to_string();
             let reading_form = m.reading_form().to_string();
+            // `head_word_length` は morpheme 表記の文字数で、SudachiDict 仕様上
+            // 実用範囲は 100 を大きく超えない(u16 / u32 のいずれの返り値型でも
+            // f32 の有効精度 24 bit を逸脱しない)。EngineCandidate::score は
+            // 順序付け proxy として用いる相対値であり、絶対値の精度は不要。
+            // f64 への migrate は score の broad な API 影響を伴うため見送る
+            // (P2-A hardening item 5)。
+            #[allow(clippy::cast_precision_loss)]
             let cost = m.get_word_info().head_word_length() as f32;
             out.push(EngineCandidate {
                 surface,
@@ -134,6 +243,11 @@ mod tests {
             other => panic!("expected ModelNotFound, got: {other:?}"),
         }
     }
+
+    // NOTE: Extension allowlist の動作 verification は default features で動く
+    // `custom_vocab::tests::custom_vocab_load_rejects_non_tsv_extension` 側で
+    // 検証する。両 adapter で同一 logic を使うため重複 test を避ける
+    // (P2-A hardening item 2)。
 
     #[test]
     fn sudachi_engine_id_label_constant_is_stable() {

--- a/crates/kotoha-core/src/dict/sudachi_adapter.rs
+++ b/crates/kotoha-core/src/dict/sudachi_adapter.rs
@@ -78,6 +78,13 @@ impl SudachiAdapter {
     ///   `with_system_dic()` で system dictionary だけを caller 提供 path で
     ///   override する(P2-A hardening item 1、CWE-426 対策)。
     ///
+    /// 注: `Config::new_embedded()` は top-level config file の disk search を回避するが、
+    /// 同梱 config が参照する `char.def` 等の resource file は `Config::complete_path` 経由で
+    /// resolver anchors と current_dir を試行する(sudachi.rs v0.6.11 dictionary.rs:85)。
+    /// 完全な search 排除には `from_cfg_storage_with_embedded_chardef` への移行が必要だが、
+    /// `SudachiDicData` 構築が伴うため P2-A scope 外。kotoha process の起動 CWD を信頼境界内
+    /// に置くことで現状のリスクを許容する(threat model: single-user IME)。
+    ///
     /// # Errors
     ///
     /// - [`KanjiError::ModelNotFound`] — path に file が存在しない場合 / canonicalize 失敗時
@@ -164,19 +171,37 @@ impl SudachiAdapter {
 
 /// `SudachiError` 連鎖に `io::Error` の NotFound が含まれるかを判定する。
 ///
-/// `SudachiError::Io { cause, .. }` か、`source()` chain を辿って `io::Error::kind()`
-/// が `NotFound` の場合に `true` を返す。`from_cfg` が file 欠損を I/O error として
-/// 投げるケースを ModelNotFound に折り畳むために用いる(P2-A hardening item 6)。
+/// `SudachiError` の variant を直接 match で分解し、`SudachiError::Io.cause` または
+/// `SudachiError::ConfigError(ConfigError::Io(_))` の `io::Error::kind()` が
+/// `NotFound` の場合に `true` を返す。`SudachiError::ErrWithContext` は inner
+/// `cause` に対して再帰的に walk する(`with_context` で wrap される経路をカバー)。
+/// `from_cfg` が file 欠損を I/O error として投げるケースを ModelNotFound に
+/// 折り畳むために用いる(P2-A hardening item 6)。
+///
+/// # Limitations
+///
+/// - sudachi.rs の `SudachiError::Io { cause }` および `ConfigError::Io` は
+///   `#[source]` / `#[from]` 注釈が無いため `Error::source()` chain を
+///   辿っても `io::Error` に到達しない(sudachi.rs v0.6.11 error.rs:40-44 で確認)。
+///   そのため本判定では `Error::source()` chain を辿らず、`SudachiError` の
+///   variant を直接 match で分解する。
+/// - 文字列化された I/O エラー(例: `ConfigError::InvalidFormat(String)` に
+///   embed された I/O メッセージ)は構造化されていないため検出しない。
+///   その場合は呼び出し元で `KanjiError::ModelLoadFailed` として伝播する。
+/// - `SudachiError` は `#[non_exhaustive]` のため、将来 sudachi.rs に新 variant が
+///   追加された場合は default arm `_ => false` で素通しされる。新 variant が
+///   I/O 失敗を表す場合は本関数の更新が必要になる。
 fn io_error_is_not_found(err: &sudachi::error::SudachiError) -> bool {
-    let mut current: &dyn std::error::Error = err;
-    loop {
-        if let Some(io_err) = current.downcast_ref::<io::Error>() {
-            return io_err.kind() == io::ErrorKind::NotFound;
+    use sudachi::config::ConfigError;
+    use sudachi::error::SudachiError;
+    match err {
+        SudachiError::Io { cause, .. } => cause.kind() == io::ErrorKind::NotFound,
+        SudachiError::ConfigError(ConfigError::Io(io_err)) => {
+            io_err.kind() == io::ErrorKind::NotFound
         }
-        match current.source() {
-            Some(next) => current = next,
-            None => return false,
-        }
+        SudachiError::ConfigError(ConfigError::FileNotFound(_)) => true,
+        SudachiError::ErrWithContext { cause, .. } => io_error_is_not_found(cause),
+        _ => false,
     }
 }
 
@@ -253,5 +278,72 @@ mod tests {
     fn sudachi_engine_id_label_constant_is_stable() {
         assert!(SUDACHI_ENGINE_ID_LABEL.contains("sudachi"));
         assert!(SUDACHI_ENGINE_ID_LABEL.contains("0.6"));
+    }
+
+    // ======================================================================
+    // io_error_is_not_found unit tests (P2-A hardening item 6 review fix)
+    // ----------------------------------------------------------------------
+    // `SudachiError::Io { cause, .. }` の `cause` field には `#[source]` /
+    // `#[from]` 注釈が無いため、`Error::source()` chain では `io::Error` に
+    // 到達しない(sudachi.rs v0.6.11 error.rs:40-44)。ここでは variant
+    // 直接 match による判定が NotFound を正しく検出すること、および非
+    // NotFound を素通しすることを synthetic error で verify する。
+    // ======================================================================
+
+    fn make_io_error(kind: io::ErrorKind) -> io::Error {
+        io::Error::from(kind)
+    }
+
+    #[test]
+    fn io_error_is_not_found_returns_true_for_io_variant_with_not_found() {
+        let err = sudachi::error::SudachiError::Io {
+            cause: make_io_error(io::ErrorKind::NotFound),
+            context: "test context".to_string(),
+        };
+        assert!(io_error_is_not_found(&err));
+    }
+
+    #[test]
+    fn io_error_is_not_found_returns_false_for_io_variant_with_permission_denied() {
+        let err = sudachi::error::SudachiError::Io {
+            cause: make_io_error(io::ErrorKind::PermissionDenied),
+            context: "test context".to_string(),
+        };
+        assert!(!io_error_is_not_found(&err));
+    }
+
+    #[test]
+    fn io_error_is_not_found_walks_through_err_with_context() {
+        let inner = sudachi::error::SudachiError::Io {
+            cause: make_io_error(io::ErrorKind::NotFound),
+            context: "inner".to_string(),
+        };
+        let wrapped = sudachi::error::SudachiError::ErrWithContext {
+            context: "outer".to_string(),
+            cause: Box::new(inner),
+        };
+        assert!(io_error_is_not_found(&wrapped));
+    }
+
+    #[test]
+    fn io_error_is_not_found_returns_true_for_config_file_not_found() {
+        let err = sudachi::error::SudachiError::ConfigError(
+            sudachi::config::ConfigError::FileNotFound("missing.json".to_string()),
+        );
+        assert!(io_error_is_not_found(&err));
+    }
+
+    #[test]
+    fn io_error_is_not_found_returns_true_for_config_io_not_found() {
+        let err = sudachi::error::SudachiError::ConfigError(sudachi::config::ConfigError::Io(
+            make_io_error(io::ErrorKind::NotFound),
+        ));
+        assert!(io_error_is_not_found(&err));
+    }
+
+    #[test]
+    fn io_error_is_not_found_returns_false_for_unrelated_variant() {
+        let err = sudachi::error::SudachiError::EosBosDisconnect;
+        assert!(!io_error_is_not_found(&err));
     }
 }

--- a/crates/kotoha-core/src/kanji/backend.rs
+++ b/crates/kotoha-core/src/kanji/backend.rs
@@ -536,13 +536,13 @@ mod tests {
 
     #[cfg(feature = "dict")]
     #[test]
+    #[serial_test::serial]
     fn dictionary_config_load_backend_missing_env_errors_backend() {
         use crate::dict::DictionaryConfig;
         // env var も config も無い状態で load_backend を呼ぶと、actionable な
         // hint を含む KanjiError::Backend を返す契約。
-        // 注意: `std::env::remove_var` は process-global state の変更であり、
-        // 並列実行する他 test が同 env var を set した場合 race する。
-        // P2-A 範囲では本 risk を受容する(tasks.md Notes §2)。
+        // `#[serial_test::serial]` で同 env var を読み書きする他 test と直列化し、
+        // process-global state の race を排除する(P2-A hardening item 8)。
         std::env::remove_var("KOTOHA_SYSTEM_DICT_PATH");
         let cfg = BackendConfig::Dictionary {
             config: DictionaryConfig::default(),

--- a/crates/kotoha-core/tests/kanji_dictionary_unit.rs
+++ b/crates/kotoha-core/tests/kanji_dictionary_unit.rs
@@ -13,6 +13,7 @@ use kotoha_core::dict::DictionaryConfig;
 use kotoha_core::kanji::{load_backend, BackendConfig, KanjiError};
 
 #[test]
+#[serial_test::serial]
 fn load_backend_dictionary_without_env_errors_backend_with_actionable_hint() {
     std::env::remove_var("KOTOHA_SYSTEM_DICT_PATH");
     let cfg = BackendConfig::Dictionary {
@@ -39,6 +40,7 @@ fn load_backend_dictionary_without_env_errors_backend_with_actionable_hint() {
 }
 
 #[test]
+#[serial_test::serial]
 fn load_backend_dictionary_with_nonexistent_path_errors_model_not_found() {
     let cfg = BackendConfig::Dictionary {
         config: DictionaryConfig {
@@ -58,6 +60,7 @@ fn load_backend_dictionary_with_nonexistent_path_errors_model_not_found() {
 }
 
 #[test]
+#[serial_test::serial]
 fn dictionary_config_env_var_resolve_fallback_works() {
     // NOTE: env var を直接書き換える test は並列実行で flaky になる可能性
     // があるため、resolve は unit test 側 (dict::config_tests) で検証し、
@@ -79,6 +82,7 @@ fn dictionary_config_env_var_resolve_fallback_works() {
 }
 
 #[test]
+#[serial_test::serial]
 fn dictionary_config_custom_vocab_missing_errors_backend() {
     let cfg = DictionaryConfig {
         system_dict_path: Some(PathBuf::from("/tmp/no-such-system.dic")),

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -50,3 +50,16 @@ pre-push:
         else
           echo "lefthook: skip test (no crates/ yet; enforced from M2)"
         fi
+    # `test` step は default features のみを実行する。`feature = "dict"` 配下の
+    # hardening test (`custom_vocab::tests::*` / `sudachi_adapter::tests::*`) は
+    # default では compile されないため、本 step を別に走らせて pre-push gate で
+    # 保護する(P2-A hardening review Fix 4)。`mock-backend` は default の
+    # `cargo test --workspace` でカバー済みなので含めない。
+    # `dict-smoke` は SudachiDict-core file が必要なため pre-push では走らせない。
+    test-dict:
+      run: |
+        if [ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]; then
+          cargo test --workspace --features dict
+        else
+          echo "lefthook: skip test-dict (no crates/ yet; enforced from M2)"
+        fi

--- a/tools/p2a-fixture-gen/tests/test_sample.py
+++ b/tools/p2a-fixture-gen/tests/test_sample.py
@@ -1,8 +1,13 @@
 """Tests for bulk stratified sampling."""
 
+from pathlib import Path
+
+import pytest
+
 from p2a_fixture_gen.sample import (
     bucket_for_reading_length,
     bulk_as_tsv_rows,
+    load_sample_pairs,
     stratified_sample,
 )
 
@@ -41,3 +46,16 @@ def test_bulk_tsv_rows_have_four_fields() -> None:
     sampled = stratified_sample(pairs, per_bucket=3)
     for row in bulk_as_tsv_rows(sampled):
         assert len(row.split("\t")) == 4
+
+
+def test_load_sample_pairs_raises_when_missing(tmp_path: Path) -> None:
+    """load_sample_pairs must raise FileNotFoundError when the path is absent.
+
+    Regression guard for P2-A hardening item 9: silent failure (returning empty
+    list) hides upstream pipeline misconfiguration. The error message must
+    contain "p5a sample not found" so users can identify the missing artefact
+    without consulting the source.
+    """
+    missing = tmp_path / "nonexistent.tsv"
+    with pytest.raises(FileNotFoundError, match="p5a sample not found"):
+        load_sample_pairs(missing)


### PR DESCRIPTION
## Summary

Closes #97. Applies the 10 hardening findings carved out from #94's P2-B section as a Small/Medium-tier prerequisite to the P2-B code PR (#98).

- **Commit `cb8843f`**: 10 hardening items (CWE-426 / path traversal / supply-chain pin / SHA-256 integrity / CWE-704 / TOCTOU / sync mechanism / serial_test / regression test / error context).
- **Commit `931b535`**: Medium-tier review follow-up — High `#[serial]` coverage gap, `io_error_is_not_found` thiserror source-chain bug fix + 6 new unit tests, lefthook pre-push gate now exercises `--features dict`, honest disclosure of residual `char.def` search path.

## Branch scope

- 9 files changed (`Cargo.lock` auto-generated, 8 hand-edited)
- +547 / -34 (net +513), or +375 net excluding `Cargo.lock`
- Net line count > 200 places this at **Medium tier** per the project PR Review Matrix; size escalation accepted because hardening coverage cannot be safely trimmed.
- Files: `Cargo.toml`, `Cargo.lock`, `README.md`, `lefthook.yml`, `crates/kotoha-core/Cargo.toml`, `crates/kotoha-core/src/dict/{custom_vocab,sudachi_adapter}.rs`, `crates/kotoha-core/src/kanji/backend.rs`, `crates/kotoha-core/tests/kanji_dictionary_unit.rs`, `tools/p2a-fixture-gen/tests/test_sample.py`.

## Hardening summary (10 items + 5 review fixes)

| # | Description | Location |
|---|---|---|
| 1 | CWE-426: `Config::new_embedded()` + `with_system_dic()` avoids sudachi.rs default-config search | `sudachi_adapter.rs` |
| 2 | Path traversal: `canonicalize` + `.dic`/`.tsv` allowlist + 200/64 MiB size cap | `sudachi_adapter.rs`, `custom_vocab.rs` |
| 3 | Supply chain: pin `sudachi.rs` rev to 40-char SHA-1 of v0.6.11 | `Cargo.toml` |
| 4 | Integrity: SHA-256 verify step against SudachiDict-core v20260116 | `README.md` |
| 5 | CWE-704: `#[allow(clippy::cast_precision_loss)]` + rationale | `sudachi_adapter.rs` |
| 6 | TOCTOU: drop `Path::exists()`, fold `from_cfg` NotFound to `ModelNotFound` | `sudachi_adapter.rs` |
| 7 | `SUDACHI_ENGINE_ID_LABEL` cross-reference comments enforce manual sync | `sudachi_adapter.rs`, `Cargo.toml` |
| 8 | `serial_test = "3"` + `#[serial]` on env-var test | `Cargo.toml`, `crates/kotoha-core/Cargo.toml`, `kanji/backend.rs` |
| 9 | `FileNotFoundError` regression test for `load_sample_pairs` | `tools/p2a-fixture-gen/tests/test_sample.py` |
| 10 | Improved `KanjiError::Backend` reason for `CustomVocab::load` | `custom_vocab.rs` |
| Fix-1 | High: `#[serial]` on 4 integration tests reading the same env var | `tests/kanji_dictionary_unit.rs` |
| Fix-2 | Medium: `io_error_is_not_found` rewritten as `match` on `SudachiError` variants (the `Error::source()` chain was non-functional) | `sudachi_adapter.rs` |
| Fix-3 | Medium: 6 unit tests for `io_error_is_not_found` covering NotFound / PermissionDenied / `ErrWithContext` recursion / `ConfigError::FileNotFound` / `ConfigError::Io` / unrelated variant | `sudachi_adapter.rs::tests` |
| Fix-4 | Medium: `lefthook.yml` `pre-push` now runs `cargo test --workspace --features dict` (hardening regression net was previously unprotected) | `lefthook.yml` |
| Fix-5 | Low: doc note for residual `char.def` resolver-anchor search via `Config::complete_path` (full elimination requires `from_cfg_storage_with_embedded_chardef`, deferred) | `sudachi_adapter.rs` |

## Verification

```
cargo fmt --all -- --check                                            # clean
cargo clippy --workspace --all-targets --all-features -- -D warnings  # clean
cargo test --workspace                                                # 175 PASS (default baseline)
cargo test --workspace --features dict                                # 221 PASS (new pre-push gate)
cargo test --workspace --features mock-backend,dict                   # 232 PASS (was 226; +6 io_error tests)
cd tools/p2a-fixture-gen && uv run pytest                             # 7 PASS (was 6; +1 for item 9)
lefthook run pre-push                                                 # all 5 gates pass (incl. new test-dict)
```

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` 175 PASS (default features baseline maintained)
- [x] `cargo test --workspace --features mock-backend,dict` 232 PASS (was 223; +9 from path-traversal & io_error_is_not_found)
- [x] `cd tools/p2a-fixture-gen && uv run pytest` 7 PASS (was 6; +1 for item 9)
- [x] `lefthook run pre-push` all gates pass (build / clippy / manifest-check / test / **test-dict** new)

## Findings deferred to follow-up issue

- DRY extraction of canonicalize/extension/size-cap into a common `validate_dict_path` helper
- `SudachiAdapter::load` SRP split (currently 5 responsibilities in one function)
- `_round_trips_real_file_and_rejects_missing` test split into two single-concern tests
- `unique_tmp_path` collision hardening or `tempfile` crate adoption
- `serial_test = "3"` major-only pin alignment with workspace policy (`thiserror = "1"` etc.)
- spec/ADR short-SHA references (`90fd6068c80c`) update to 40-char SHA
- Size-cap test filesystem portability (`set_len(64 MiB)` may not produce sparse files on Windows / quota-restricted CI)
- Tmp-file leak on regression panic (no RAII guard around `unique_tmp_path` allocations)
- `Config::new_embedded()` Layer-1 regression coverage via fake `.dic` file
- `Config::complete_path` full elimination via `from_cfg_storage_with_embedded_chardef` (requires `SudachiDicData` construction + ADR)

## Predecessors / Related

- Closes: #97
- Parent triage: #94 (P2-A post-merge follow-up)
- Sibling: #95 (P2-B design spec, merged via #96)
- Successor: #98 (P2-B code PR — kotoha-storage crate, blocked on this PR's merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)