### PR TITLE
chore(deps): sync Cargo.lock after dropping tracing (#102)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,6 @@ dependencies = [
  "serial_test",
  "tempfile",
  "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]


### PR DESCRIPTION
Trivial follow-up to PR #103. The arch-M-1 fix in PR #103 removed `tracing` from `kotoha-storage`'s `[dependencies]` in `Cargo.toml`, but the corresponding entry in `Cargo.lock` was not committed (the implementer subagent only ran `cargo build -p kotoha-storage` which regenerated Cargo.lock locally, but only `Cargo.toml` was `git add`'d).

Lefthook `manifest-check` did not catch this because at push time, the working tree was self-consistent — but the committed tree was not.

This PR commits the missing Cargo.lock change to bring origin/develop into a clean state.

Single-line diff: `tracing` entry removed from `kotoha-storage`'s dependency list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)