### PR TITLE
feat(p2-c): LearningCache full impl + arch-M-2 ISP split

### DIFF
--- a/crates/kotoha-cli/src/bin/dict.rs
+++ b/crates/kotoha-cli/src/bin/dict.rs
@@ -27,15 +27,16 @@ fn main() {
             std::process::exit(EXIT_INTERNAL);
         }
     };
-    let store = db.user_vocab_store();
+    let reader = db.user_vocab_reader();
+    let writer = db.user_vocab_writer();
 
     let exit_code = match &cli.command {
-        Command::Add(args) => run_add(store.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL),
+        Command::Add(args) => run_add(writer.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL),
         Command::Remove(args) => {
-            run_remove(store.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL)
+            run_remove(writer.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL)
         }
-        Command::List(args) => run_list(store.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
-        Command::Show(args) => run_show(store.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
+        Command::List(args) => run_list(reader.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
+        Command::Show(args) => run_show(reader.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
     };
     std::process::exit(exit_code);
 }

--- a/crates/kotoha-cli/src/dict_cli.rs
+++ b/crates/kotoha-cli/src/dict_cli.rs
@@ -153,14 +153,14 @@ pub fn normalize_reading(reading: &str) -> Result<String, String> {
 }
 
 use kotoha_storage::error::StorageError;
-use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabStore};
+use kotoha_storage::user_vocab::store::{UserVocabReader, UserVocabRecord, UserVocabWriter};
 
 /// `kotoha-dict add` 実装。
 ///
 /// # Errors
 ///
 /// Exit code を文字列で返す(`Result<exit_code, String>`)。
-pub fn run_add(store: &dyn UserVocabStore, args: &AddArgs, quiet: bool) -> Result<i32, String> {
+pub fn run_add(store: &dyn UserVocabWriter, args: &AddArgs, quiet: bool) -> Result<i32, String> {
     let reading = match normalize_reading(&args.reading) {
         Ok(s) => s,
         Err(e) => {
@@ -212,7 +212,7 @@ pub fn run_add(store: &dyn UserVocabStore, args: &AddArgs, quiet: bool) -> Resul
 ///
 /// Exit code を文字列で返す(`Result<exit_code, String>`)。
 pub fn run_remove(
-    store: &dyn UserVocabStore,
+    store: &dyn UserVocabWriter,
     args: &RemoveArgs,
     quiet: bool,
 ) -> Result<i32, String> {
@@ -266,7 +266,7 @@ pub fn run_remove(
 ///
 /// Exit code を文字列で返す(`Result<exit_code, String>`)。
 pub fn run_list(
-    store: &dyn UserVocabStore,
+    store: &dyn UserVocabReader,
     args: &ListArgs,
     json_global: bool,
 ) -> Result<i32, String> {
@@ -342,7 +342,7 @@ pub fn run_list(
 ///
 /// Exit code を文字列で返す(`Result<exit_code, String>`)。
 pub fn run_show(
-    store: &dyn UserVocabStore,
+    store: &dyn UserVocabReader,
     args: &ShowArgs,
     json_global: bool,
 ) -> Result<i32, String> {

--- a/crates/kotoha-core/src/dict/backend.rs
+++ b/crates/kotoha-core/src/dict/backend.rs
@@ -83,8 +83,8 @@ impl DictionaryBackend {
                         ),
                     }
                 })?;
-                let store = db.user_vocab_store();
-                vocab_sources.push(Box::new(crate::dict::user_vocab::UserVocab::new(store)));
+                let reader = db.user_vocab_reader();
+                vocab_sources.push(Box::new(crate::dict::user_vocab::UserVocab::new(reader)));
             }
         }
         let model_id = format!("dictionary({})", engine.engine_id());

--- a/crates/kotoha-core/src/dict/user_vocab.rs
+++ b/crates/kotoha-core/src/dict/user_vocab.rs
@@ -1,18 +1,22 @@
-//! `UserVocab`: `VocabularyLookup` の SQLite 永続化版実装(spec §6.7、P2-B)。
+//! `UserVocab`: `VocabularyLookup` の SQLite 永続化版実装(spec §6.7、P2-B / P2-C-A)。
 
-use kotoha_storage::user_vocab::store::UserVocabStore;
+use kotoha_storage::user_vocab::store::UserVocabReader;
 
 use crate::dict::vocab::{VocabEntry, VocabularyLookup};
 
-/// User-managed vocabulary、`Box<dyn UserVocabStore>` に依存(DIP、spec §4.2)。
+/// User-managed vocabulary、`Box<dyn UserVocabReader>` に依存(DIP + ISP、spec §4.2 / arch-M-2)。
 pub struct UserVocab {
-    store: Box<dyn UserVocabStore>,
+    store: Box<dyn UserVocabReader>,
     vocab_id: String,
 }
 
 impl UserVocab {
-    /// `Box<dyn UserVocabStore>` を inject して構築する。
-    pub fn new(store: Box<dyn UserVocabStore>) -> Self {
+    /// `Box<dyn UserVocabReader>` を inject して構築する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `store` は `UserVocabReader` を実装した任意の backend を受け付ける
+    pub fn new(store: Box<dyn UserVocabReader>) -> Self {
         Self {
             store,
             vocab_id: "user-vocab".to_string(),
@@ -46,7 +50,7 @@ impl VocabularyLookup for UserVocab {
 mod tests {
     use super::*;
     use kotoha_storage::user_vocab::mock::MockUserVocabStore;
-    use kotoha_storage::user_vocab::store::UserVocabRecord;
+    use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabWriter};
 
     fn seed_mock(store: &MockUserVocabStore, surface: &str, reading: &str, score: f32) {
         store

--- a/crates/kotoha-core/tests/dict_backend_user_vocab.rs
+++ b/crates/kotoha-core/tests/dict_backend_user_vocab.rs
@@ -8,7 +8,7 @@ use kotoha_core::dict::{
 };
 use kotoha_core::kanji::{ConvertOptions, KanjiBackend, KanjiError};
 use kotoha_storage::user_vocab::mock::MockUserVocabStore;
-use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabStore};
+use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabWriter};
 
 struct StubEngine {
     canned: Vec<EngineCandidate>,

--- a/crates/kotoha-core/tests/dict_user_vocab.rs
+++ b/crates/kotoha-core/tests/dict_user_vocab.rs
@@ -4,7 +4,7 @@
 
 use kotoha_core::dict::{UserVocab, VocabularyLookup};
 use kotoha_storage::user_vocab::mock::MockUserVocabStore;
-use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabStore};
+use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabWriter};
 
 fn seed(mock: &MockUserVocabStore, surface: &str, reading: &str, score: f32) {
     mock.insert(UserVocabRecord {

--- a/crates/kotoha-storage/Cargo.toml
+++ b/crates/kotoha-storage/Cargo.toml
@@ -22,3 +22,20 @@ default = ["bundled-sqlite"]
 # `bundled-sqlite` vendors the SQLite C library inside the rusqlite crate.
 # Default ON to avoid distro SQLite version drift (P2-B spec §4.3).
 bundled-sqlite = ["rusqlite/bundled"]
+# `test-helpers` exposes integration-test-only items
+# (`CapOverrideGuard`, `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE`,
+# `CAP_OVERRIDE_LOCK`, `effective_max_rows`) so that test crates under
+# `crates/kotoha-storage/tests/` can drive learning_cache eviction with a
+# small cap. The flag must NOT be enabled in release/production builds:
+# spec §4.5 / §4.6 require these helpers to be compiled out of the
+# production binary. lefthook's pre-push test steps enable the flag
+# explicitly via `--features kotoha-storage/test-helpers`.
+test-helpers = []
+
+[[test]]
+name = "learning_cache_store"
+required-features = ["test-helpers"]
+
+[[test]]
+name = "learning_cache_proptest"
+required-features = ["test-helpers"]

--- a/crates/kotoha-storage/migrations/v002_learning_cache_index.sql
+++ b/crates/kotoha-storage/migrations/v002_learning_cache_index.sql
@@ -1,0 +1,14 @@
+-- v002_learning_cache_index: learning_cache テーブルへの last_used_at index 追加
+-- spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md §4.1
+--
+-- 目的:
+--   evict_lru(ORDER BY last_used_at ASC) および
+--   lookup(ORDER BY frequency DESC, last_used_at DESC) における
+--   last_used_at 列のソートを index seek で高速化する。
+--
+-- 適用条件:
+--   本 migration は forward-only(P2-B §3.6 決定)。
+--   既存 v001 DB を持つ環境では Database::open() が PRAGMA user_version = 1 を検出し、
+--   v002 を自動 apply する。新規 DB では v001 と v002 を順に apply する。
+
+CREATE INDEX idx_learning_cache_last_used ON learning_cache(last_used_at);

--- a/crates/kotoha-storage/src/database.rs
+++ b/crates/kotoha-storage/src/database.rs
@@ -299,6 +299,9 @@ mod tests {
     fn learning_cache_factories_share_same_connection() {
         // writer で record_choice → reader で lookup が同一 DB に到達することを確認する
         // (両 factory が同じ `Arc<Database>` の同一 `Mutex<Connection>` を共有している証拠)。
+        // 並列実行される他 test の `CapOverrideGuard` が record_choice 内の自動 eviction を
+        // 小さな cap で発火させないように `CAP_OVERRIDE_LOCK` を取得する。
+        let _lock = crate::learning_cache::sqlite::CapOverrideGuard::lock_only();
         let db = Database::open_in_memory().expect("memory open");
         let writer = db.learning_cache_writer();
         let reader = db.learning_cache_reader();

--- a/crates/kotoha-storage/src/database.rs
+++ b/crates/kotoha-storage/src/database.rs
@@ -80,15 +80,34 @@ impl Database {
         self.conn.lock().expect("Database mutex poisoned")
     }
 
-    /// `Arc<Database>` を `SqliteUserVocabStore` で wrap し owned `Box<dyn UserVocabStore>` を返す
-    /// (spec §6.4 共有 ownership)。
-    pub fn user_vocab_store(self: &Arc<Self>) -> Box<dyn crate::user_vocab::store::UserVocabStore> {
+    /// `Arc<Database>` を `Box<dyn UserVocabReader>` として公開する(arch-M-2 ISP split)。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持し、
+    ///   同一 `Database` から生成された他の factory の戻り値と同一 SQLite connection を共有する
+    pub fn user_vocab_reader(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::user_vocab::store::UserVocabReader> {
         Box::new(crate::user_vocab::sqlite::SqliteUserVocabStore::new(
             Arc::clone(self),
         ))
     }
 
-    /// (P2-B では unimplemented stub、P2-C で本実装、spec §6.3)
+    /// `Arc<Database>` を `Box<dyn UserVocabWriter>` として公開する(arch-M-2 ISP split)。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持する
+    pub fn user_vocab_writer(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::user_vocab::store::UserVocabWriter> {
+        Box::new(crate::user_vocab::sqlite::SqliteUserVocabStore::new(
+            Arc::clone(self),
+        ))
+    }
+
+    /// (P2-B では unimplemented stub、P2-C-B で本実装 + ISP split、spec §6.3)
     pub fn learning_cache_store(
         self: &Arc<Self>,
     ) -> Box<dyn crate::learning_cache::LearningCacheStore> {
@@ -208,14 +227,14 @@ mod tests {
     #[test]
     fn user_vocab_store_factory_returns_owned_box() {
         let db = Database::open_in_memory().expect("memory open");
-        let _store: Box<dyn crate::user_vocab::store::UserVocabStore> = db.user_vocab_store();
+        let _store: Box<dyn crate::user_vocab::store::UserVocabReader> = db.user_vocab_reader();
     }
 
     #[test]
     fn user_vocab_store_factory_shares_arc() {
         let db = Database::open_in_memory().expect("memory open");
-        let store1 = db.user_vocab_store();
-        let store2 = db.user_vocab_store();
+        let writer = db.user_vocab_writer();
+        let reader = db.user_vocab_reader();
         let r = crate::user_vocab::store::UserVocabRecord {
             id: None,
             surface: "x".to_string(),
@@ -225,8 +244,8 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         };
-        store1.insert(r).expect("insert ok");
-        let result = store2.find_by_reading("あ", 10).expect("find ok");
+        writer.insert(r).expect("insert ok");
+        let result = reader.find_by_reading("あ", 10).expect("find ok");
         assert_eq!(result.len(), 1);
     }
 
@@ -247,10 +266,10 @@ mod tests {
         use std::thread;
 
         let db = Database::open_in_memory().expect("memory open");
-        let store = Arc::new(db.user_vocab_store());
+        let writer = Arc::new(db.user_vocab_writer());
         let handles: Vec<_> = (0..8u32)
             .map(|i| {
-                let store = Arc::clone(&store);
+                let writer = Arc::clone(&writer);
                 thread::spawn(move || {
                     // hiragana を index から計算する(ASCII 数字混入を避ける)。
                     // U+3042 = 'あ' 起点で、あ/い/う/え/お/か/き/く を割り当てる。
@@ -266,14 +285,15 @@ mod tests {
                         created_at: 0,
                         updated_at: 0,
                     };
-                    store.insert(r).expect("insert ok");
+                    writer.insert(r).expect("insert ok");
                 })
             })
             .collect();
         for h in handles {
             h.join().unwrap();
         }
-        let result = store.list_all(100, 0).unwrap();
+        let reader = db.user_vocab_reader();
+        let result = reader.list_all(100, 0).unwrap();
         assert_eq!(result.len(), 8);
     }
 }

--- a/crates/kotoha-storage/src/database.rs
+++ b/crates/kotoha-storage/src/database.rs
@@ -282,6 +282,33 @@ mod tests {
     }
 
     #[test]
+    fn learning_cache_reader_factory_returns_owned_box() {
+        let db = Database::open_in_memory().expect("memory open");
+        let _reader: Box<dyn crate::learning_cache::LearningCacheReader> =
+            db.learning_cache_reader();
+    }
+
+    #[test]
+    fn learning_cache_writer_factory_returns_owned_box() {
+        let db = Database::open_in_memory().expect("memory open");
+        let _writer: Box<dyn crate::learning_cache::LearningCacheWriter> =
+            db.learning_cache_writer();
+    }
+
+    #[test]
+    fn learning_cache_factories_share_same_connection() {
+        // writer で record_choice → reader で lookup が同一 DB に到達することを確認する
+        // (両 factory が同じ `Arc<Database>` の同一 `Mutex<Connection>` を共有している証拠)。
+        let db = Database::open_in_memory().expect("memory open");
+        let writer = db.learning_cache_writer();
+        let reader = db.learning_cache_reader();
+        writer.record_choice("あい", "愛").expect("record ok");
+        let result = reader.lookup("あい", 10).expect("lookup ok");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].chosen_kanji, "愛");
+    }
+
+    #[test]
     fn parallel_inserts_via_arc_share_does_not_deadlock() {
         use std::thread;
 

--- a/crates/kotoha-storage/src/database.rs
+++ b/crates/kotoha-storage/src/database.rs
@@ -85,8 +85,9 @@ impl Database {
     ///
     /// # Postconditions
     ///
-    /// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持し、
-    ///   同一 `Database` から生成された他の factory の戻り値と同一 SQLite connection を共有する
+    /// - 戻り値の trait object は内部で `SqliteUserVocabStore` を `Box` で保持し、
+    ///   その `SqliteUserVocabStore` は `Arc<Database>` を `Arc::clone` で共有する
+    /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
     pub fn user_vocab_reader(
         self: &Arc<Self>,
     ) -> Box<dyn crate::user_vocab::store::UserVocabReader> {
@@ -99,7 +100,9 @@ impl Database {
     ///
     /// # Postconditions
     ///
-    /// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持する
+    /// - 戻り値の trait object は内部で `SqliteUserVocabStore` を `Box` で保持し、
+    ///   その `SqliteUserVocabStore` は `Arc<Database>` を `Arc::clone` で共有する
+    /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
     pub fn user_vocab_writer(
         self: &Arc<Self>,
     ) -> Box<dyn crate::user_vocab::store::UserVocabWriter> {
@@ -112,7 +115,8 @@ impl Database {
     ///
     /// # Postconditions
     ///
-    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    /// - 戻り値の trait object は内部で `SqliteLearningCacheStore` を `Box` で保持し、
+    ///   その `SqliteLearningCacheStore` は `Arc<Database>` を `Arc::clone` で共有する
     /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
     pub fn learning_cache_reader(
         self: &Arc<Self>,
@@ -126,7 +130,8 @@ impl Database {
     ///
     /// # Postconditions
     ///
-    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    /// - 戻り値の trait object は内部で `SqliteLearningCacheStore` を `Box` で保持し、
+    ///   その `SqliteLearningCacheStore` は `Arc<Database>` を `Arc::clone` で共有する
     /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
     pub fn learning_cache_writer(
         self: &Arc<Self>,

--- a/crates/kotoha-storage/src/database.rs
+++ b/crates/kotoha-storage/src/database.rs
@@ -9,8 +9,9 @@ use crate::error::StorageError;
 use crate::migrations::apply_migrations;
 
 /// SQLite Database wrapper(spec §6.4)。`Mutex<Connection>` を内部保持し、
-/// `Arc<Database>` で複数 Store(`UserVocabStore` / `LearningCacheStore`)が
-/// 同一 Connection を共有する(spec §6.4.1 共有 ownership)。
+/// `Arc<Database>` で複数 Store(`UserVocabReader/Writer` /
+/// `LearningCacheReader/Writer`)が同一 Connection を共有する
+/// (spec §6.4.1 共有 ownership)。
 pub struct Database {
     conn: Mutex<Connection>,
 }
@@ -70,8 +71,8 @@ impl Database {
     /// 内部 `Mutex<Connection>` を lock する。Store 実装側で使用。
     ///
     /// `pub(crate)` に絞って、外部 crate からは Connection 直アクセスではなく
-    /// `UserVocabStore` / `LearningCacheStore` 抽象境界を通すことを強制する
-    /// (review A-H2)。
+    /// `UserVocabReader/Writer` / `LearningCacheReader/Writer` 抽象境界を
+    /// 通すことを強制する(review A-H2)。
     ///
     /// # Panics
     ///
@@ -107,10 +108,29 @@ impl Database {
         ))
     }
 
-    /// (P2-B では unimplemented stub、P2-C-B で本実装 + ISP split、spec §6.3)
-    pub fn learning_cache_store(
+    /// `Arc<Database>` を `Box<dyn LearningCacheReader>` として公開する(spec §3.1 / §4.6)。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
+    pub fn learning_cache_reader(
         self: &Arc<Self>,
-    ) -> Box<dyn crate::learning_cache::LearningCacheStore> {
+    ) -> Box<dyn crate::learning_cache::LearningCacheReader> {
+        Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+            Arc::clone(self),
+        ))
+    }
+
+    /// `Arc<Database>` を `Box<dyn LearningCacheWriter>` として公開する(spec §3.1 / §4.6)。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
+    pub fn learning_cache_writer(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::learning_cache::LearningCacheWriter> {
         Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
             Arc::clone(self),
         ))

--- a/crates/kotoha-storage/src/learning_cache/mod.rs
+++ b/crates/kotoha-storage/src/learning_cache/mod.rs
@@ -3,7 +3,16 @@
 
 pub mod sqlite;
 
-pub use sqlite::{CapOverrideGuard, SqliteLearningCacheStore};
+pub use sqlite::SqliteLearningCacheStore;
+
+/// `CapOverrideGuard` is a **test-only** RAII helper that overrides the
+/// learning_cache row cap during tests. It is gated behind the
+/// `test-helpers` feature so that the symbol is compiled out of
+/// production / release builds (spec §4.5 / §4.6). Integration test crates
+/// under `crates/kotoha-storage/tests/` enable the feature via
+/// `[[test]] required-features = ["test-helpers"]`.
+#[cfg(any(test, feature = "test-helpers"))]
+pub use sqlite::CapOverrideGuard;
 
 use crate::error::StorageError;
 

--- a/crates/kotoha-storage/src/learning_cache/mod.rs
+++ b/crates/kotoha-storage/src/learning_cache/mod.rs
@@ -1,4 +1,5 @@
-//! `LearningCacheStore` trait skeleton(spec §6.3、本実装は P2-C)。
+//! `crates/kotoha-storage/src/learning_cache/mod.rs`
+//! LearningCacheReader / LearningCacheWriter trait(spec §3.1、P2-C 本実装)。
 
 pub mod sqlite;
 
@@ -6,23 +7,140 @@ pub use sqlite::SqliteLearningCacheStore;
 
 use crate::error::StorageError;
 
-/// Learning cache store の抽象境界(P2-C で本格使用)。
-pub trait LearningCacheStore: Send + Sync {
+/// Learning cache の read 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+/// - `limit` は 0 より大きい値を推奨する(0 を渡した場合は空 `Vec` を返す)
+///
+/// # Postconditions
+///
+/// - `lookup` の戻り値は `frequency DESC, last_used_at DESC` 順に `limit` 件以下を含む
+/// - 該当 entry が存在しない場合は `Ok(Vec::new())` を返し、`Err` は返さない
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`][]: `kana_input` が validation 違反の場合
+/// - [`StorageError::Sqlite`][]: SQLite backend 障害の場合
+pub trait LearningCacheReader: Send + Sync {
+    /// `kana_input` に対応する変換候補を `frequency DESC, last_used_at DESC` 順で返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+    /// - `limit` は呼び出し元が必要な件数の上限を示す
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の長さは `limit` 以下
+    /// - 戻り値の `frequency` は先頭 ≥ 末尾(単調非増加、同値は `last_used_at DESC` で整列)
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`][]: `kana_input` が hiragana 以外の文字を含む場合
+    /// - [`StorageError::Sqlite`][]: SQLite backend 障害の場合
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use kotoha_storage::learning_cache::LearningCacheReader;
+    /// # fn doc(reader: &dyn LearningCacheReader) -> Result<(), Box<dyn std::error::Error>> {
+    /// let results = reader.lookup("ちょうかん", 5)?;
+    /// // results[0].frequency >= results[1].frequency (先頭が最多)
+    /// # Ok(())
+    /// # }
+    /// ```
     fn lookup(
         &self,
         kana_input: &str,
         limit: usize,
     ) -> Result<Vec<LearningCacheRecord>, StorageError>;
+}
+
+/// Learning cache の write 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+/// - `chosen_kanji` は non-empty / ≤256 bytes / no control char / no bidi / no disallowed PUA
+///
+/// # Postconditions
+///
+/// - `record_choice` 成功後は該当 `(kana_input, chosen_kanji)` の `frequency` が 1 以上増加し、
+///   `last_used_at` が現在時刻(UNIX epoch seconds)以上の値に更新される
+/// - `record_choice` 成功後にキャッシュ行数が cap を超えた場合、`last_used_at` が最も古い entry
+///   から順に削除され、行数が cap に収まる状態を保つ
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`][]: validation 違反の場合
+/// - [`StorageError::Sqlite`][]: SQLite backend 障害の場合
+pub trait LearningCacheWriter: Send + Sync {
+    /// ユーザの変換選択を `learning_cache` table に記録する。
+    ///
+    /// `(kana_input, chosen_kanji)` が既存の場合は `frequency += 1` かつ
+    /// `last_used_at` を現在時刻に更新する。新規の場合は `frequency = 1` で insert する。
+    /// insert / update 後に行数が cap を超えた場合は `last_used_at` が最も古い entry を
+    /// 自動的に削除し、行数を cap 以内に収める。
+    ///
+    /// # Preconditions
+    ///
+    /// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+    /// - `chosen_kanji` は validate_surface の制約を満たす(non-empty / ≤256 bytes /
+    ///   no control char / no bidi / no disallowed PUA)
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値 `Ok(())` の時点でトランザクションがコミットされている
+    /// - 行数は `effective_max_rows()` 以下を維持する
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`][]: `kana_input` / `chosen_kanji` が validation 違反
+    /// - [`StorageError::Sqlite`][]: SQLite backend 障害(disk full / SQLITE_BUSY など)
     fn record_choice(&self, kana_input: &str, chosen_kanji: &str) -> Result<(), StorageError>;
+
+    /// `learning_cache` table から LRU(最終使用が最も古い)entry を削除して行数を `max_entries` 以内に収める。
+    ///
+    /// 呼び出し元が明示的に eviction を要求する場合に使用する。
+    /// 通常の record_choice では内部で `effective_max_rows()` を cap として自動 eviction が動作するため、
+    /// 本 method を明示呼び出しする必要は少ない。本 method は test / 手動 GC /
+    /// Phase 5 personalization での動的 cap 変更を想定して `max_entries` 引数を維持する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `max_entries` は 1 以上を推奨する(0 を渡した場合は全行削除が発生する)
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は削除した行数を示す
+    /// - 行数が `max_entries` 以下の場合は削除を行わず `Ok(0)` を返す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`][]: SQLite backend 障害の場合
     fn evict_lru(&self, max_entries: usize) -> Result<usize, StorageError>;
 }
 
+/// Learning cache の 1 行を表す struct。
+///
+/// # Invariants
+///
+/// - `id` は DB 内の `INTEGER PRIMARY KEY AUTOINCREMENT` 値(DB から取得した場合のみ有効)
+/// - `frequency` は 1 以上(insert 時点で 1、以降 `record_choice` 毎に +1 される)
+/// - `last_used_at` は UNIX epoch seconds 形式の非負整数
 #[derive(Debug, Clone, PartialEq)]
 pub struct LearningCacheRecord {
+    /// `learning_cache.id`(DB 自動採番)。
     pub id: i64,
+    /// 変換前のひらがな入力。
     pub kana_input: String,
+    /// ユーザが選択した変換後文字列。
     pub chosen_kanji: String,
+    /// `(kana_input, chosen_kanji)` の組合せが選ばれた累積回数。
     pub frequency: u32,
+    /// 最後に選択された時刻(UNIX epoch seconds)。
     pub last_used_at: i64,
 }
 

--- a/crates/kotoha-storage/src/learning_cache/mod.rs
+++ b/crates/kotoha-storage/src/learning_cache/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod sqlite;
 
-pub use sqlite::SqliteLearningCacheStore;
+pub use sqlite::{CapOverrideGuard, SqliteLearningCacheStore};
 
 use crate::error::StorageError;
 

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -154,4 +154,61 @@ mod tests {
         let result = store.lookup("あい", 2).expect("ok");
         assert!(result.len() <= 2);
     }
+
+    // --- record_choice tests (B4 red phase) ---
+
+    /// `record_choice` は新規 entry を frequency=1 で insert する。
+    /// (B4) TDD red: stub は Ok(()) を返すが lookup で空 Vec が返るので FAIL。
+    #[test]
+    fn record_choice_inserts_new_entry_with_frequency_one() {
+        let store = fresh_store_b();
+        store.record_choice("かわ", "川").expect("record ok");
+        let result = store.lookup("かわ", 10).expect("ok");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].chosen_kanji, "川");
+        assert_eq!(result[0].frequency, 1);
+    }
+
+    /// `record_choice` は同じ `(kana_input, chosen_kanji)` の重複呼び出しで frequency を +1 する。
+    /// (B4) TDD red: stub は Ok(()) を返すが lookup で正しい frequency が返らない。
+    #[test]
+    fn record_choice_increments_frequency_on_duplicate() {
+        let store = fresh_store_b();
+        store.record_choice("かわ", "川").expect("1st ok");
+        store.record_choice("かわ", "川").expect("2nd ok");
+        let result = store.lookup("かわ", 10).expect("ok");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].frequency, 2);
+    }
+
+    /// `record_choice` は同じ kana_input でも chosen_kanji が異なる場合は別行として insert する。
+    /// (B4) TDD red: stub は Ok(()) を返すが lookup で 1 件しか返らない。
+    #[test]
+    fn record_choice_separates_different_chosen_kanji() {
+        let store = fresh_store_b();
+        store.record_choice("かわ", "川").expect("ok");
+        store.record_choice("かわ", "河").expect("ok");
+        let result = store.lookup("かわ", 10).expect("ok");
+        assert_eq!(result.len(), 2);
+    }
+
+    /// `record_choice` 呼び出し後は `last_used_at` が 0 より大きい値になる。
+    /// (B4) TDD red: stub は Ok(()) を返すが lookup で last_used_at=0 が返る。
+    #[test]
+    fn record_choice_sets_last_used_at_to_nonzero() {
+        let store = fresh_store_b();
+        store.record_choice("かわ", "川").expect("ok");
+        let result = store.lookup("かわ", 10).expect("ok");
+        assert!(!result.is_empty());
+        assert!(result[0].last_used_at > 0);
+    }
+
+    /// `record_choice` はひらがな以外の kana_input を拒否する。
+    /// (B4) TDD red: stub は validation を行わないので Ok(()) を返し FAIL。
+    #[test]
+    fn record_choice_rejects_non_hiragana_kana_input() {
+        let store = fresh_store_b();
+        let err = store.record_choice("abc", "川").unwrap_err();
+        assert!(matches!(err, StorageError::InvalidField { .. }));
+    }
 }

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::database::Database;
 use crate::error::StorageError;
 use crate::learning_cache::{LearningCacheReader, LearningCacheRecord, LearningCacheWriter};
-use crate::validation::validate_reading;
+use crate::validation::{validate_reading, validate_surface};
 
 /// `lookup` SQL(spec §4.3)。`(kana_input)` index を seek して
 /// `frequency DESC, last_used_at DESC` 順に `LIMIT ?2` 件を返す。
@@ -14,6 +14,15 @@ const LOOKUP_SQL: &str = "SELECT id, kana_input, chosen_kanji, frequency, last_u
      WHERE kana_input = ?1
      ORDER BY frequency DESC, last_used_at DESC
      LIMIT ?2";
+
+/// `record_choice` の UPSERT SQL(spec §4.2、SQLite 3.24+ ON CONFLICT UPSERT 構文)。
+const UPSERT_SQL: &str =
+    "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+     VALUES (?1, ?2, 1, ?3)
+     ON CONFLICT(kana_input, chosen_kanji)
+     DO UPDATE SET
+         frequency     = frequency + 1,
+         last_used_at  = excluded.last_used_at";
 
 pub struct SqliteLearningCacheStore {
     pub(crate) db: Arc<Database>,
@@ -61,8 +70,18 @@ impl LearningCacheReader for SqliteLearningCacheStore {
 }
 
 impl LearningCacheWriter for SqliteLearningCacheStore {
-    fn record_choice(&self, _kana_input: &str, _chosen_kanji: &str) -> Result<(), StorageError> {
-        // B5 で本実装する。
+    fn record_choice(&self, kana_input: &str, chosen_kanji: &str) -> Result<(), StorageError> {
+        validate_reading(kana_input)?;
+        validate_surface(chosen_kanji)?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let conn = self.db.lock_conn();
+        // perf-H1: prepare_cached により SQL コンパイルを 1 度きりにする。
+        let mut stmt = conn.prepare_cached(UPSERT_SQL)?;
+        stmt.execute(rusqlite::params![kana_input, chosen_kanji, now])?;
+        // NOTE: eviction は B8 でここに追加する。
         Ok(())
     }
 

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -1,6 +1,5 @@
 //! SqliteLearningCacheStore: P2-C で本実装(spec §3.1 / §4.2-§4.5 / §6.3)。
 
-#[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -14,32 +13,37 @@ pub const LEARNING_CACHE_MAX_ROWS: usize = 10_000;
 
 /// テスト時の行数上限上書き(0 = unset、`LEARNING_CACHE_MAX_ROWS` を使用)。
 ///
-/// `cargo test` ビルドでのみ意味を持ち、production binary には含まれない。
+/// production binary でも static 自体は存在するが、[`CapOverrideGuard`] を使わない限り
+/// 値は 0 のまま変化しないため `effective_max_rows()` の挙動には影響しない。
+/// integration test(`crates/kotoha-storage/tests/*.rs`)からも触れるよう
+/// `#[cfg(test)]` ガードを外して `pub` で公開している(P2-C-D Phase D 対応)。
+///
 /// 10,000 行を実際に挿入するテストは時間 / メモリの観点で非現実的なため、
-/// 単体テストはこの override を介して小さな上限値で eviction 動作を検証する。
-#[cfg(test)]
-pub(crate) static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
+/// 単体テスト / integration テストはこの override を介して小さな上限値で
+/// eviction 動作を検証する。
+pub static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
 
 /// override の直列化用 Mutex(複数 test が同時 override しないよう直列化)。
-#[cfg(test)]
-#[allow(dead_code)] // B7 で test、B8 で record_choice 経由使用開始
-pub(crate) static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+///
+/// production binary でも存在するが、override 自体を変更しない限り
+/// 取得しても何も起こらない。integration test から触れるよう `pub` で公開する。
+pub static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// 行数上限の effective value を返す(`#[cfg(test)]` 時のみ override を考慮)。
+/// 行数上限の effective value を返す。
+///
+/// override が 0(unset)の場合は `LEARNING_CACHE_MAX_ROWS` を返し、
+/// 0 より大きい場合は override 値を返す。production binary では
+/// override は常に 0 のままなので戻り値は常に `LEARNING_CACHE_MAX_ROWS` となる。
 ///
 /// # Postconditions
 ///
-/// - `#[cfg(not(test))]` 時は常に `LEARNING_CACHE_MAX_ROWS` を返す
-/// - `#[cfg(test)]` かつ override が 0 の場合は `LEARNING_CACHE_MAX_ROWS` を返す
-/// - `#[cfg(test)]` かつ override が 0 より大きい場合は override 値を返す
+/// - override が 0 の場合は `LEARNING_CACHE_MAX_ROWS` を返す
+/// - override が 0 より大きい場合は override 値を返す
 #[inline]
-pub(crate) fn effective_max_rows() -> usize {
-    #[cfg(test)]
-    {
-        let v = LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.load(Ordering::SeqCst);
-        if v != 0 {
-            return v;
-        }
+pub fn effective_max_rows() -> usize {
+    let v = LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.load(Ordering::SeqCst);
+    if v != 0 {
+        return v;
     }
     LEARNING_CACHE_MAX_ROWS
 }
@@ -51,24 +55,29 @@ pub(crate) fn effective_max_rows() -> usize {
 /// override を活性化すると競合する。よって `CAP_OVERRIDE_LOCK` を
 /// 取得して直列化する。
 ///
+/// production code では本 struct を構築しないので、override は 0 のまま、
+/// `effective_max_rows()` は常に `LEARNING_CACHE_MAX_ROWS` を返す。
+/// integration test(`tests/*.rs`)からも利用するため `#[cfg(test)]` ガードを
+/// 外して `pub` で公開している(P2-C-D Phase D 対応)。
+///
 /// # Examples
 ///
-/// ```ignore
-/// // tests-only:
+/// ```no_run
+/// use kotoha_storage::learning_cache::sqlite::CapOverrideGuard;
+/// // test 内のみで使用:
 /// let _guard = CapOverrideGuard::new(5);
 /// // このブロック内では cap = 5 で動作する
 /// // _guard が drop されると cap = LEARNING_CACHE_MAX_ROWS に戻る
 /// ```
-#[cfg(test)]
-#[allow(dead_code)] // B7 で eviction tests から使用開始
-pub(crate) struct CapOverrideGuard {
+pub struct CapOverrideGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
 }
 
-#[cfg(test)]
 impl CapOverrideGuard {
-    #[allow(dead_code)] // B7 で eviction tests から呼び出し開始
-    pub(crate) fn new(cap: usize) -> Self {
+    /// override を `cap` に設定し、`CAP_OVERRIDE_LOCK` を取得する。
+    ///
+    /// drop 時に override を 0 に戻す。
+    pub fn new(cap: usize) -> Self {
         // poison していても続行(直前 test の panic でも次 test を回したい)。
         let lock = CAP_OVERRIDE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(cap, Ordering::SeqCst);
@@ -81,15 +90,13 @@ impl CapOverrideGuard {
     /// 並列実行されている他 test の override(`CapOverrideGuard::new(N)`)が
     /// 残っている瞬間に `record_choice` の自動 eviction が小さな cap で走るのを
     /// 避けるための serialization 用 guard。
-    #[allow(dead_code)] // record_choice 系 test の race 回避で使用
-    pub(crate) fn lock_only() -> Self {
+    pub fn lock_only() -> Self {
         let lock = CAP_OVERRIDE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // override は変更しない(0 のまま、effective_max_rows = LEARNING_CACHE_MAX_ROWS)。
         Self { _lock: lock }
     }
 }
 
-#[cfg(test)]
 impl Drop for CapOverrideGuard {
     fn drop(&mut self) {
         LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(0, Ordering::SeqCst);

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -539,6 +539,130 @@ mod tests {
         assert_eq!(total, 3);
     }
 
+    // --- additional validation / cap-guard tests (B-followup, plan §6.2) ---
+
+    /// `record_choice` は空文字列の chosen_kanji を reject する(`validate_surface` empty 判定)。
+    ///
+    /// production は空 kanji を許容してはならない(spec §6.2 / §9.1)。
+    /// CapOverrideGuard::lock_only() は record_choice 系 test の race condition 回避規約。
+    #[test]
+    fn record_choice_rejects_empty_chosen_kanji() {
+        let _lock = CapOverrideGuard::lock_only();
+        let store = fresh_store_b();
+        let err = store.record_choice("あい", "").unwrap_err();
+        match err {
+            StorageError::InvalidField { name, reason } => {
+                assert_eq!(name, "surface");
+                assert_eq!(reason, "empty");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// `record_choice` は PUA(U+E000)を含む chosen_kanji を reject する。
+    ///
+    /// `validate_surface` -> `validate_field` の `is_disallowed_pua` で reject される
+    /// (Phase 5 allowlist U+EE00..=U+EE03 を除く)。
+    #[test]
+    fn record_choice_rejects_pua_in_chosen_kanji() {
+        let _lock = CapOverrideGuard::lock_only();
+        let store = fresh_store_b();
+        let err = store.record_choice("あい", "\u{E000}").unwrap_err();
+        match err {
+            StorageError::InvalidField { name, reason } => {
+                assert_eq!(name, "surface");
+                assert_eq!(reason, "PUA char");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// `record_choice` は 256 byte 上限を超える kana_input を reject する。
+    ///
+    /// "あ" = 3 byte UTF-8 なので 86 文字で 258 byte となり `validate_field` の
+    /// `value.len() > 256` 判定で reject される(spec §9.1 / `validate_reading`)。
+    #[test]
+    fn record_choice_rejects_oversize_kana_input() {
+        let _lock = CapOverrideGuard::lock_only();
+        let store = fresh_store_b();
+        let oversize = "あ".repeat(86); // 86 * 3 = 258 byte > 256
+        assert!(oversize.len() > 256, "test fixture must exceed 256 byte");
+        let err = store.record_choice(&oversize, "愛").unwrap_err();
+        match err {
+            StorageError::InvalidField { name, reason } => {
+                assert_eq!(name, "reading");
+                assert_eq!(reason, "byte size > 256");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// `lookup` はひらがな以外の kana_input を reject する。
+    ///
+    /// `validate_reading` の `is_hiragana_or_long_sound` 判定で
+    /// カタカナは reject される(reason = "non-hiragana reading")。
+    #[test]
+    fn lookup_rejects_non_hiragana() {
+        let store = fresh_store_b();
+        let err = store.lookup("カタカナ", 10).unwrap_err();
+        match err {
+            StorageError::InvalidField { name, reason } => {
+                assert_eq!(name, "reading");
+                assert_eq!(reason, "non-hiragana reading");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// `CapOverrideGuard` は drop 時に override を 0 に戻し、
+    /// `effective_max_rows()` を `LEARNING_CACHE_MAX_ROWS` (10_000) に復元する。
+    ///
+    /// guard scope を限定するために inner block で `_g` を作成し、
+    /// block 終了時の暗黙 drop で復元することを観測する。
+    /// `CAP_OVERRIDE_LOCK` の reentrant 不可制約を遵守し、内側 guard を drop
+    /// してから次の guard を作成する形にしている。
+    #[test]
+    fn cap_override_guard_restores_default_on_drop() {
+        // 1) 初期状態(他 test が override を残していない前提を `lock_only()` で直列化確認)
+        let outer_lock = CapOverrideGuard::lock_only();
+        assert_eq!(effective_max_rows(), LEARNING_CACHE_MAX_ROWS);
+        drop(outer_lock);
+
+        // 2) inner scope で override = 5 を活性化
+        {
+            let _g = CapOverrideGuard::new(5);
+            assert_eq!(effective_max_rows(), 5);
+            // _g は block 終了時に drop され、override は 0 に reset される
+        }
+
+        // 3) drop 後は再び default 値に復元されている
+        let outer_lock_after = CapOverrideGuard::lock_only();
+        assert_eq!(effective_max_rows(), LEARNING_CACHE_MAX_ROWS);
+        drop(outer_lock_after);
+    }
+
+    /// `effective_max_rows()` は `CapOverrideGuard::new(N)` の scope 内で N を返す。
+    ///
+    /// API contract test: `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store()` を
+    /// 直接触らず、`CapOverrideGuard` 経由で override が反映されることを確認する。
+    #[test]
+    fn effective_max_rows_returns_override_in_test() {
+        let _g = CapOverrideGuard::new(42);
+        assert_eq!(effective_max_rows(), 42);
+    }
+
+    /// `effective_max_rows()` は override が 0(unset)の場合 `LEARNING_CACHE_MAX_ROWS` を返す。
+    ///
+    /// `CAP_OVERRIDE_LOCK` を取得して並列 test の override 干渉を排除した上で、
+    /// 明示的に store(0) してから default 復元を確認する。
+    #[test]
+    fn effective_max_rows_returns_default_when_override_zero() {
+        let _lock = CapOverrideGuard::lock_only();
+        // 念のため明示的に override を 0(unset)へ。
+        LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(0, Ordering::SeqCst);
+        assert_eq!(effective_max_rows(), LEARNING_CACHE_MAX_ROWS);
+    }
+
     /// `evict_lru` は last_used_at が同値の場合 id ASC で tie-break する。
     /// (B9) TDD red: stub は Ok(0) を返すので削除されず FAIL する。
     #[test]

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -152,11 +152,11 @@ impl SqliteLearningCacheStore {
     }
 }
 
-/// `SqliteLearningCacheStore` の B3 段階の動作:
+/// `SqliteLearningCacheStore` の本実装(P2-C-B 完了時点):
 ///
-/// - `lookup`: 本実装(`LOOKUP_SQL` + `prepare_cached`)
-/// - `record_choice`: 常に Ok(())(B5 で本実装)
-/// - `evict_lru`: 常に Ok(0)(B10 で本実装)
+/// - `lookup`: `LOOKUP_SQL` + `prepare_cached`、`frequency DESC, last_used_at DESC` 順で `LIMIT ?2` 件
+/// - `record_choice`: `UPSERT_SQL` で UPSERT、その後 `evict_to_cap(effective_max_rows())` で自動 eviction
+/// - `evict_lru`: `evict_to_cap(max_entries)` を直接呼び出して LRU から超過分を削除
 ///
 /// table `learning_cache` schema は v001 migration で同梱済(spec §5.2)。
 impl LearningCacheReader for SqliteLearningCacheStore {

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -445,4 +445,81 @@ mod tests {
         let result_i = store.lookup("い", 10).expect("ok");
         assert!(result_i.is_empty(), "以 must be evicted as the LRU entry");
     }
+
+    // --- evict_lru tests (B9 red phase) ---
+
+    /// `evict_lru` は行数が max_entries 以下の場合 0 を返す。
+    /// (B9) TDD red: stub は Ok(0) を返すので本 test は PASS する。B10 後も PASS を維持する。
+    #[test]
+    fn evict_lru_returns_zero_when_below_cap() {
+        let store = fresh_store_b();
+        store.record_choice("あ", "亜").expect("ok");
+        store.record_choice("い", "以").expect("ok");
+        // 行数 2 < max_entries=5 なので 0 が返る。
+        let deleted = store.evict_lru(5).expect("ok");
+        assert_eq!(deleted, 0);
+    }
+
+    /// `evict_lru` は超過分の行数を削除して削除件数を返す。
+    /// (B9) TDD red: stub は Ok(0) を返すので行数が変化せず FAIL する。
+    #[test]
+    fn evict_lru_deletes_excess_entries_and_returns_count() {
+        let store = fresh_store_b();
+        // 5 件 insert する。
+        for kanji in ["亜", "以", "宇", "江", "尾"] {
+            let kana = match kanji {
+                "亜" => "あ",
+                "以" => "い",
+                "宇" => "う",
+                "江" => "え",
+                "尾" => "お",
+                _ => unreachable!(),
+            };
+            store.record_choice(kana, kanji).expect("ok");
+        }
+        // max_entries=3 で呼び出す。5-3=2 件削除される。
+        let deleted = store.evict_lru(3).expect("ok");
+        assert_eq!(deleted, 2);
+        let conn = store.db.lock_conn();
+        let total: i64 = conn
+            .query_row("SELECT count(*) FROM learning_cache", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(total, 3);
+    }
+
+    /// `evict_lru` は last_used_at が同値の場合 id ASC で tie-break する。
+    /// (B9) TDD red: stub は Ok(0) を返すので削除されず FAIL する。
+    #[test]
+    fn evict_lru_uses_id_asc_as_tiebreak_for_same_last_used_at() {
+        let store = fresh_store_b();
+        // last_used_at を同値(0)に固定して 3 件 insert する。
+        {
+            let conn = store.db.lock_conn();
+            conn.execute(
+                "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+                 VALUES ('あ', '亜', 1, 0)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+                 VALUES ('い', '以', 1, 0)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+                 VALUES ('う', '宇', 1, 0)",
+                [],
+            )
+            .unwrap();
+        }
+        // max_entries=1 で呼び出す。id の小さい順に 2 件が削除される。
+        let deleted = store.evict_lru(1).expect("ok");
+        assert_eq!(deleted, 2);
+        // 残っているのは id が最大の "う/宇" である。
+        let result = store.lookup("う", 10).expect("ok");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].chosen_kanji, "宇");
+    }
 }

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -73,4 +73,60 @@ mod tests {
         let evicted = store.evict_lru(100).expect("noop ok");
         assert_eq!(evicted, 0);
     }
+
+    // --- lookup tests (B2 red phase) ---
+
+    fn fresh_store_b() -> SqliteLearningCacheStore {
+        let db = Database::open_in_memory().expect("memory open");
+        SqliteLearningCacheStore::new(db)
+    }
+
+    /// `lookup` は存在しない kana_input に対して空 Vec を返す。
+    /// (B2) TDD red: stub は Ok(Vec::new()) を返すので本 test は PASS するが、
+    /// B3 実装後も引き続き PASS することを確認する。
+    #[test]
+    fn lookup_returns_empty_for_unknown_kana() {
+        let store = fresh_store_b();
+        let result = store.lookup("みず", 10).expect("ok");
+        assert!(result.is_empty());
+    }
+
+    /// `lookup` は record_choice で記録した entry を返す。
+    /// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
+    #[test]
+    fn lookup_returns_recorded_entry() {
+        let store = fresh_store_b();
+        store.record_choice("あい", "愛").expect("record ok");
+        let result = store.lookup("あい", 10).expect("ok");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].chosen_kanji, "愛");
+        assert_eq!(result[0].frequency, 1);
+    }
+
+    /// `lookup` は frequency DESC 順で複数 entry を返す。
+    /// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
+    #[test]
+    fn lookup_orders_by_frequency_desc() {
+        let store = fresh_store_b();
+        // "愛" を 2 回、"哀" を 1 回記録する。
+        store.record_choice("あい", "愛").expect("record ok");
+        store.record_choice("あい", "愛").expect("record ok");
+        store.record_choice("あい", "哀").expect("record ok");
+        let result = store.lookup("あい", 10).expect("ok");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].chosen_kanji, "愛"); // frequency=2
+        assert_eq!(result[1].chosen_kanji, "哀"); // frequency=1
+    }
+
+    /// `lookup` は limit を超えた件数を返さない。
+    /// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
+    #[test]
+    fn lookup_respects_limit() {
+        let store = fresh_store_b();
+        store.record_choice("あい", "愛").expect("ok");
+        store.record_choice("あい", "哀").expect("ok");
+        store.record_choice("あい", "藍").expect("ok");
+        let result = store.lookup("あい", 2).expect("ok");
+        assert!(result.len() <= 2);
+    }
 }

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -1,13 +1,13 @@
-//! SqliteLearningCacheStore: P2-B では unimplemented stub、P2-C で実装(spec §6.3)。
+//! SqliteLearningCacheStore: P2-C で本実装(spec §3.1 / §4.2-§4.5 / §6.3)。
 
 use std::sync::Arc;
 
 use crate::database::Database;
 use crate::error::StorageError;
-use crate::learning_cache::{LearningCacheRecord, LearningCacheStore};
+use crate::learning_cache::{LearningCacheReader, LearningCacheRecord, LearningCacheWriter};
 
 pub struct SqliteLearningCacheStore {
-    #[allow(dead_code)] // P2-C で使用開始
+    #[allow(dead_code)] // B3 / B5 / B10 で本実装と同時に使用開始
     pub(crate) db: Arc<Database>,
 }
 
@@ -17,30 +17,32 @@ impl SqliteLearningCacheStore {
     }
 }
 
-/// `SqliteLearningCacheStore` の P2-B 動作:
+/// `SqliteLearningCacheStore` の B1 段階の動作:
 ///
-/// - `lookup`: 常に空 `Vec` を返す(LearningCache の lookup 実装は P2-C)
-/// - `record_choice`: 常に Ok(())(record 実装は P2-C)
-/// - `evict_lru`: 常に Ok(0)(eviction 実装は P2-C)
+/// - `lookup`: 常に空 `Vec` を返す(B3 で本実装)
+/// - `record_choice`: 常に Ok(())(B5 で本実装)
+/// - `evict_lru`: 常に Ok(0)(B10 で本実装)
 ///
 /// table `learning_cache` schema は v001 migration で同梱済(spec §5.2)。
-impl LearningCacheStore for SqliteLearningCacheStore {
+impl LearningCacheReader for SqliteLearningCacheStore {
     fn lookup(
         &self,
         _kana_input: &str,
         _limit: usize,
     ) -> Result<Vec<LearningCacheRecord>, StorageError> {
-        // P2-C で実装
+        // B3 で本実装する。
         Ok(Vec::new())
     }
+}
 
+impl LearningCacheWriter for SqliteLearningCacheStore {
     fn record_choice(&self, _kana_input: &str, _chosen_kanji: &str) -> Result<(), StorageError> {
-        // P2-C で実装
+        // B5 で本実装する。
         Ok(())
     }
 
     fn evict_lru(&self, _max_entries: usize) -> Result<usize, StorageError> {
-        // P2-C で実装
+        // B10 で本実装する。
         Ok(0)
     }
 }

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -74,6 +74,19 @@ impl CapOverrideGuard {
         LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(cap, Ordering::SeqCst);
         Self { _lock: lock }
     }
+
+    /// override を変更せずに `CAP_OVERRIDE_LOCK` のみ取得する。
+    ///
+    /// `record_choice` を呼ぶ test が、override を必要としない一方で、
+    /// 並列実行されている他 test の override(`CapOverrideGuard::new(N)`)が
+    /// 残っている瞬間に `record_choice` の自動 eviction が小さな cap で走るのを
+    /// 避けるための serialization 用 guard。
+    #[allow(dead_code)] // record_choice 系 test の race 回避で使用
+    pub(crate) fn lock_only() -> Self {
+        let lock = CAP_OVERRIDE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // override は変更しない(0 のまま、effective_max_rows = LEARNING_CACHE_MAX_ROWS)。
+        Self { _lock: lock }
+    }
 }
 
 #[cfg(test)]
@@ -226,6 +239,7 @@ mod tests {
 
     #[test]
     fn p2b_stub_record_choice_noop() {
+        let _lock = CapOverrideGuard::lock_only();
         let db = Database::open_in_memory().expect("memory open");
         let store = SqliteLearningCacheStore::new(db);
         store.record_choice("あい", "愛").expect("noop ok");
@@ -260,6 +274,7 @@ mod tests {
     /// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
     #[test]
     fn lookup_returns_recorded_entry() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         store.record_choice("あい", "愛").expect("record ok");
         let result = store.lookup("あい", 10).expect("ok");
@@ -272,6 +287,7 @@ mod tests {
     /// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
     #[test]
     fn lookup_orders_by_frequency_desc() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         // "愛" を 2 回、"哀" を 1 回記録する。
         store.record_choice("あい", "愛").expect("record ok");
@@ -287,6 +303,7 @@ mod tests {
     /// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
     #[test]
     fn lookup_respects_limit() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         store.record_choice("あい", "愛").expect("ok");
         store.record_choice("あい", "哀").expect("ok");
@@ -301,6 +318,7 @@ mod tests {
     /// (B4) TDD red: stub は Ok(()) を返すが lookup で空 Vec が返るので FAIL。
     #[test]
     fn record_choice_inserts_new_entry_with_frequency_one() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         store.record_choice("かわ", "川").expect("record ok");
         let result = store.lookup("かわ", 10).expect("ok");
@@ -313,6 +331,7 @@ mod tests {
     /// (B4) TDD red: stub は Ok(()) を返すが lookup で正しい frequency が返らない。
     #[test]
     fn record_choice_increments_frequency_on_duplicate() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         store.record_choice("かわ", "川").expect("1st ok");
         store.record_choice("かわ", "川").expect("2nd ok");
@@ -325,6 +344,7 @@ mod tests {
     /// (B4) TDD red: stub は Ok(()) を返すが lookup で 1 件しか返らない。
     #[test]
     fn record_choice_separates_different_chosen_kanji() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         store.record_choice("かわ", "川").expect("ok");
         store.record_choice("かわ", "河").expect("ok");
@@ -336,6 +356,7 @@ mod tests {
     /// (B4) TDD red: stub は Ok(()) を返すが lookup で last_used_at=0 が返る。
     #[test]
     fn record_choice_sets_last_used_at_to_nonzero() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         store.record_choice("かわ", "川").expect("ok");
         let result = store.lookup("かわ", 10).expect("ok");
@@ -347,6 +368,7 @@ mod tests {
     /// (B4) TDD red: stub は validation を行わないので Ok(()) を返し FAIL。
     #[test]
     fn record_choice_rejects_non_hiragana_kana_input() {
+        let _lock = CapOverrideGuard::lock_only();
         let store = fresh_store_b();
         let err = store.record_choice("abc", "川").unwrap_err();
         assert!(matches!(err, StorageError::InvalidField { .. }));
@@ -449,33 +471,63 @@ mod tests {
     // --- evict_lru tests (B9 red phase) ---
 
     /// `evict_lru` は行数が max_entries 以下の場合 0 を返す。
+    ///
+    /// NOTE: `record_choice` を使うと並列に実行される `eviction_*` test が
+    /// `CapOverrideGuard` で設定した小さい cap で自動 eviction を発火させる
+    /// 可能性がある(`CAP_OVERRIDE_LOCK` は guard 所有者しか直列化しない)。
+    /// 本 test は race を避けるために SQL を直接 INSERT する。
     /// (B9) TDD red: stub は Ok(0) を返すので本 test は PASS する。B10 後も PASS を維持する。
     #[test]
     fn evict_lru_returns_zero_when_below_cap() {
         let store = fresh_store_b();
-        store.record_choice("あ", "亜").expect("ok");
-        store.record_choice("い", "以").expect("ok");
+        {
+            let conn = store.db.lock_conn();
+            conn.execute(
+                "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+                 VALUES ('あ', '亜', 1, 100)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+                 VALUES ('い', '以', 1, 200)",
+                [],
+            )
+            .unwrap();
+        }
         // 行数 2 < max_entries=5 なので 0 が返る。
         let deleted = store.evict_lru(5).expect("ok");
         assert_eq!(deleted, 0);
     }
 
     /// `evict_lru` は超過分の行数を削除して削除件数を返す。
+    ///
+    /// NOTE: `record_choice` の自動 eviction と並列 test の `CapOverrideGuard`
+    /// が干渉するので、本 test も SQL 直 INSERT で 5 件を準備する。
     /// (B9) TDD red: stub は Ok(0) を返すので行数が変化せず FAIL する。
     #[test]
     fn evict_lru_deletes_excess_entries_and_returns_count() {
         let store = fresh_store_b();
-        // 5 件 insert する。
-        for kanji in ["亜", "以", "宇", "江", "尾"] {
-            let kana = match kanji {
-                "亜" => "あ",
-                "以" => "い",
-                "宇" => "う",
-                "江" => "え",
-                "尾" => "お",
-                _ => unreachable!(),
-            };
-            store.record_choice(kana, kanji).expect("ok");
+        {
+            let conn = store.db.lock_conn();
+            // last_used_at を昇順に振って LRU 順序を明示する(同値 tie を回避)。
+            for (i, (kana, kanji)) in [
+                ("あ", "亜"),
+                ("い", "以"),
+                ("う", "宇"),
+                ("え", "江"),
+                ("お", "尾"),
+            ]
+            .iter()
+            .enumerate()
+            {
+                conn.execute(
+                    "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+                     VALUES (?1, ?2, 1, ?3)",
+                    rusqlite::params![kana, kanji, (100 + i) as i64],
+                )
+                .unwrap();
+            }
         }
         // max_entries=3 で呼び出す。5-3=2 件削除される。
         let deleted = store.evict_lru(3).expect("ok");

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -1,5 +1,6 @@
 //! SqliteLearningCacheStore: P2-C で本実装(spec §3.1 / §4.2-§4.5 / §6.3)。
 
+#[cfg(any(test, feature = "test-helpers"))]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -13,38 +14,63 @@ pub const LEARNING_CACHE_MAX_ROWS: usize = 10_000;
 
 /// テスト時の行数上限上書き(0 = unset、`LEARNING_CACHE_MAX_ROWS` を使用)。
 ///
-/// production binary でも static 自体は存在するが、[`CapOverrideGuard`] を使わない限り
-/// 値は 0 のまま変化しないため `effective_max_rows()` の挙動には影響しない。
-/// integration test(`crates/kotoha-storage/tests/*.rs`)からも触れるよう
-/// `#[cfg(test)]` ガードを外して `pub` で公開している(P2-C-D Phase D 対応)。
+/// 本 static は **test-only** であり、`#[cfg(any(test, feature = "test-helpers"))]`
+/// で gate されているため production / release binary には含まれない
+/// (spec §4.5 / §4.6)。
+/// integration test crate(`crates/kotoha-storage/tests/*.rs`)から利用するため、
+/// crate feature `test-helpers` を有効化したときのみ `pub` として可視化する。
+/// 本 feature は `--features kotoha-storage/test-helpers` を渡したテスト時のみ
+/// 有効化する想定で、production binary では常に compile-out される。
 ///
 /// 10,000 行を実際に挿入するテストは時間 / メモリの観点で非現実的なため、
 /// 単体テスト / integration テストはこの override を介して小さな上限値で
 /// eviction 動作を検証する。
+#[cfg(any(test, feature = "test-helpers"))]
 pub static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
 
 /// override の直列化用 Mutex(複数 test が同時 override しないよう直列化)。
 ///
-/// production binary でも存在するが、override 自体を変更しない限り
-/// 取得しても何も起こらない。integration test から触れるよう `pub` で公開する。
+/// 本 static は **test-only** であり、`#[cfg(any(test, feature = "test-helpers"))]`
+/// で gate されているため production / release binary には含まれない。
+/// integration test crate から利用するため、crate feature `test-helpers` を
+/// 有効化したときのみ `pub` として可視化する。
+#[cfg(any(test, feature = "test-helpers"))]
 pub static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// 行数上限の effective value を返す。
 ///
-/// override が 0(unset)の場合は `LEARNING_CACHE_MAX_ROWS` を返し、
-/// 0 より大きい場合は override 値を返す。production binary では
-/// override は常に 0 のままなので戻り値は常に `LEARNING_CACHE_MAX_ROWS` となる。
+/// production build では本関数の本体は `LEARNING_CACHE_MAX_ROWS` を返すだけで、
+/// override の参照を行わない(`LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` 自体が
+/// `#[cfg(any(test, feature = "test-helpers"))]` で compile-out されるため)。
+/// test build (`cargo test` の unit test、または `--features test-helpers` を
+/// 有効化した integration test) では override 値を反映する。
+///
+/// `pub` 公開は test build に限定する(spec §4.5 / §4.6)。production からは
+/// `pub(crate)` でのみ参照可能で、外部 crate に test-only API は露出しない。
 ///
 /// # Postconditions
 ///
-/// - override が 0 の場合は `LEARNING_CACHE_MAX_ROWS` を返す
-/// - override が 0 より大きい場合は override 値を返す
+/// - production build: 常に [`LEARNING_CACHE_MAX_ROWS`] を返す
+/// - test / `test-helpers` build: override が 0 の場合は [`LEARNING_CACHE_MAX_ROWS`]、
+///   それ以外の場合は override 値を返す
+#[cfg(any(test, feature = "test-helpers"))]
 #[inline]
 pub fn effective_max_rows() -> usize {
     let v = LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.load(Ordering::SeqCst);
     if v != 0 {
         return v;
     }
+    LEARNING_CACHE_MAX_ROWS
+}
+
+/// production build 用の `effective_max_rows()`。
+///
+/// override 機構は `#[cfg(any(test, feature = "test-helpers"))]` で
+/// compile-out されるため、production では常に [`LEARNING_CACHE_MAX_ROWS`] を返す。
+/// crate-internal 利用に限定するため `pub(crate)` で公開する。
+#[cfg(not(any(test, feature = "test-helpers")))]
+#[inline]
+pub(crate) fn effective_max_rows() -> usize {
     LEARNING_CACHE_MAX_ROWS
 }
 
@@ -55,24 +81,32 @@ pub fn effective_max_rows() -> usize {
 /// override を活性化すると競合する。よって `CAP_OVERRIDE_LOCK` を
 /// 取得して直列化する。
 ///
-/// production code では本 struct を構築しないので、override は 0 のまま、
-/// `effective_max_rows()` は常に `LEARNING_CACHE_MAX_ROWS` を返す。
-/// integration test(`tests/*.rs`)からも利用するため `#[cfg(test)]` ガードを
-/// 外して `pub` で公開している(P2-C-D Phase D 対応)。
+/// 本 struct は **test-only** であり、`#[cfg(any(test, feature = "test-helpers"))]`
+/// で gate されているため production / release binary には含まれない
+/// (spec §4.5 / §4.6)。integration test crate(`crates/kotoha-storage/tests/*.rs`)
+/// からは `--features kotoha-storage/test-helpers` を有効化したときに限り `pub`
+/// として可視化する。production code では本 struct を構築する手段がないため、
+/// override は常に 0 のまま、`effective_max_rows()` は常に
+/// `LEARNING_CACHE_MAX_ROWS` を返す。
 ///
 /// # Examples
 ///
 /// ```no_run
+/// # #[cfg(any(test, feature = "test-helpers"))]
+/// # {
 /// use kotoha_storage::learning_cache::sqlite::CapOverrideGuard;
 /// // test 内のみで使用:
 /// let _guard = CapOverrideGuard::new(5);
 /// // このブロック内では cap = 5 で動作する
 /// // _guard が drop されると cap = LEARNING_CACHE_MAX_ROWS に戻る
+/// # }
 /// ```
+#[cfg(any(test, feature = "test-helpers"))]
 pub struct CapOverrideGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
 }
 
+#[cfg(any(test, feature = "test-helpers"))]
 impl CapOverrideGuard {
     /// override を `cap` に設定し、`CAP_OVERRIDE_LOCK` を取得する。
     ///
@@ -97,6 +131,7 @@ impl CapOverrideGuard {
     }
 }
 
+#[cfg(any(test, feature = "test-helpers"))]
 impl Drop for CapOverrideGuard {
     fn drop(&mut self) {
         LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(0, Ordering::SeqCst);

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -5,9 +5,17 @@ use std::sync::Arc;
 use crate::database::Database;
 use crate::error::StorageError;
 use crate::learning_cache::{LearningCacheReader, LearningCacheRecord, LearningCacheWriter};
+use crate::validation::validate_reading;
+
+/// `lookup` SQL(spec §4.3)。`(kana_input)` index を seek して
+/// `frequency DESC, last_used_at DESC` 順に `LIMIT ?2` 件を返す。
+const LOOKUP_SQL: &str = "SELECT id, kana_input, chosen_kanji, frequency, last_used_at
+     FROM learning_cache
+     WHERE kana_input = ?1
+     ORDER BY frequency DESC, last_used_at DESC
+     LIMIT ?2";
 
 pub struct SqliteLearningCacheStore {
-    #[allow(dead_code)] // B3 / B5 / B10 で本実装と同時に使用開始
     pub(crate) db: Arc<Database>,
 }
 
@@ -17,9 +25,9 @@ impl SqliteLearningCacheStore {
     }
 }
 
-/// `SqliteLearningCacheStore` の B1 段階の動作:
+/// `SqliteLearningCacheStore` の B3 段階の動作:
 ///
-/// - `lookup`: 常に空 `Vec` を返す(B3 で本実装)
+/// - `lookup`: 本実装(`LOOKUP_SQL` + `prepare_cached`)
 /// - `record_choice`: 常に Ok(())(B5 で本実装)
 /// - `evict_lru`: 常に Ok(0)(B10 で本実装)
 ///
@@ -27,11 +35,28 @@ impl SqliteLearningCacheStore {
 impl LearningCacheReader for SqliteLearningCacheStore {
     fn lookup(
         &self,
-        _kana_input: &str,
-        _limit: usize,
+        kana_input: &str,
+        limit: usize,
     ) -> Result<Vec<LearningCacheRecord>, StorageError> {
-        // B3 で本実装する。
-        Ok(Vec::new())
+        validate_reading(kana_input)?;
+        let conn = self.db.lock_conn();
+        // perf-H1: prepare_cached により Phase 3 IBus engine の打鍵毎呼び出しでも
+        // SQL コンパイルを 1 度きりにする(同一 SQL ⇒ cache hit)。
+        let mut stmt = conn.prepare_cached(LOOKUP_SQL)?;
+        let rows = stmt.query_map(rusqlite::params![kana_input, limit as i64], |row| {
+            Ok(LearningCacheRecord {
+                id: row.get(0)?,
+                kana_input: row.get(1)?,
+                chosen_kanji: row.get(2)?,
+                frequency: row.get::<_, u32>(3)?,
+                last_used_at: row.get(4)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
     }
 }
 

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -206,9 +206,9 @@ impl LearningCacheWriter for SqliteLearningCacheStore {
         Ok(())
     }
 
-    fn evict_lru(&self, _max_entries: usize) -> Result<usize, StorageError> {
-        // B10 で本実装する。
-        Ok(0)
+    fn evict_lru(&self, max_entries: usize) -> Result<usize, StorageError> {
+        let conn = self.db.lock_conn();
+        evict_to_cap(&conn, max_entries)
     }
 }
 

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -33,7 +33,6 @@ pub(crate) static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::ne
 /// - `#[cfg(test)]` かつ override が 0 の場合は `LEARNING_CACHE_MAX_ROWS` を返す
 /// - `#[cfg(test)]` かつ override が 0 より大きい場合は override 値を返す
 #[inline]
-#[allow(dead_code)] // B8 で record_choice / evict_to_cap から呼び出し開始
 pub(crate) fn effective_max_rows() -> usize {
     #[cfg(test)]
     {
@@ -101,6 +100,48 @@ const UPSERT_SQL: &str =
          frequency     = frequency + 1,
          last_used_at  = excluded.last_used_at";
 
+/// 総行数チェック SQL(spec §4.4)。
+const COUNT_SQL: &str = "SELECT count(*) FROM learning_cache";
+
+/// LRU 削除 SQL(spec §4.4)。`last_used_at ASC, id ASC` 順で `LIMIT ?1` 件削除する。
+const EVICT_SQL: &str = "DELETE FROM learning_cache
+     WHERE id IN (
+         SELECT id FROM learning_cache
+         ORDER BY last_used_at ASC, id ASC
+         LIMIT ?1
+     )";
+
+/// `learning_cache` の行数が `cap` を超えている場合、LRU から `count - cap` 行削除する。
+///
+/// `record_choice` の自動 eviction(`effective_max_rows()` を cap に渡す)と
+/// `evict_lru(max_entries)` の明示 eviction の両方から呼ばれる共通 helper。
+///
+/// # Preconditions
+///
+/// - `conn` は `Database::lock_conn()` で取得済の `MutexGuard<Connection>`(または
+///   その deref を経由した `&Connection`)
+/// - `cap` は呼び出し元が指定する行数上限値
+///
+/// # Postconditions
+///
+/// - 戻り値は削除した行数
+/// - 行数 ≤ cap が保証される
+///
+/// # Errors
+///
+/// - [`StorageError::Sqlite`][]: SQLite backend 障害の場合
+pub(crate) fn evict_to_cap(conn: &rusqlite::Connection, cap: usize) -> Result<usize, StorageError> {
+    let total: i64 = conn.query_row(COUNT_SQL, [], |r| r.get(0))?;
+    let total = total as usize;
+    if total <= cap {
+        return Ok(0);
+    }
+    let excess = total - cap;
+    let mut stmt = conn.prepare_cached(EVICT_SQL)?;
+    let deleted = stmt.execute(rusqlite::params![excess as i64])?;
+    Ok(deleted)
+}
+
 pub struct SqliteLearningCacheStore {
     pub(crate) db: Arc<Database>,
 }
@@ -156,9 +197,12 @@ impl LearningCacheWriter for SqliteLearningCacheStore {
             .unwrap_or(0);
         let conn = self.db.lock_conn();
         // perf-H1: prepare_cached により SQL コンパイルを 1 度きりにする。
-        let mut stmt = conn.prepare_cached(UPSERT_SQL)?;
-        stmt.execute(rusqlite::params![kana_input, chosen_kanji, now])?;
-        // NOTE: eviction は B8 でここに追加する。
+        {
+            let mut stmt = conn.prepare_cached(UPSERT_SQL)?;
+            stmt.execute(rusqlite::params![kana_input, chosen_kanji, now])?;
+        }
+        // 行数が effective_max_rows() を超えた場合、LRU entry を自動削除する(spec §4.2)。
+        evict_to_cap(&conn, effective_max_rows())?;
         Ok(())
     }
 
@@ -367,18 +411,30 @@ mod tests {
     }
 
     /// LRU 保護: record_choice で update された entry は eviction 対象から外れる。
+    ///
+    /// last_used_at は秒精度の `SystemTime::now()` のため、同一秒内に複数 record_choice
+    /// が走ると tie となり id ASC で評価されてしまう。本 test はそれを避けるため
+    /// 各 step 間で `std::thread::sleep(Duration::from_secs(1))` を挟み、
+    /// 秒境界を確実に跨ぐようにしている。production code 側の精度問題ではなく
+    /// test 構成の精度問題なので、test 側で吸収する。
     /// (B7) TDD red: B5 実装は eviction を含まないので挙動を検証できず行数超過で FAIL する。
     #[test]
     fn eviction_protects_recently_updated_entry_from_lru() {
+        use std::thread::sleep;
+        use std::time::Duration;
         let _guard = CapOverrideGuard::new(2);
         let store = fresh_store_b();
-        // "亜" を先に insert する(古い entry)。
+        // "亜" を先に insert する(古い entry、last_used_at = T0)。
         store.record_choice("あ", "亜").expect("ok");
-        // "以" を後で insert する(新しい entry)。
+        sleep(Duration::from_secs(1));
+        // "以" を後で insert する(中間 entry、last_used_at = T0 + 1)。
         store.record_choice("い", "以").expect("ok");
-        // "亜" を再度 record_choice して last_used_at を更新する。
+        sleep(Duration::from_secs(1));
+        // "亜" を再度 record_choice して last_used_at を T0 + 2 に更新する。
         store.record_choice("あ", "亜").expect("ok");
-        // 3 件目 insert で cap=2 を超える。"以" のほうが古いので evict される。
+        sleep(Duration::from_secs(1));
+        // "う" を insert(last_used_at = T0 + 3)。これで cap=2 を超える。
+        // "以" の last_used_at が最も古いので evict される。
         store.record_choice("う", "宇").expect("ok");
         // "亜" は残っており、"以" は evict されている。
         let result_a = store.lookup("あ", 10).expect("ok");

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -1,11 +1,88 @@
 //! SqliteLearningCacheStore: P2-C で本実装(spec §3.1 / §4.2-§4.5 / §6.3)。
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::database::Database;
 use crate::error::StorageError;
 use crate::learning_cache::{LearningCacheReader, LearningCacheRecord, LearningCacheWriter};
 use crate::validation::{validate_reading, validate_surface};
+
+/// Learning cache の行数上限(production 値、spec §4.6)。
+pub const LEARNING_CACHE_MAX_ROWS: usize = 10_000;
+
+/// テスト時の行数上限上書き(0 = unset、`LEARNING_CACHE_MAX_ROWS` を使用)。
+///
+/// `cargo test` ビルドでのみ意味を持ち、production binary には含まれない。
+/// 10,000 行を実際に挿入するテストは時間 / メモリの観点で非現実的なため、
+/// 単体テストはこの override を介して小さな上限値で eviction 動作を検証する。
+#[cfg(test)]
+pub(crate) static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
+
+/// override の直列化用 Mutex(複数 test が同時 override しないよう直列化)。
+#[cfg(test)]
+#[allow(dead_code)] // B7 で test、B8 で record_choice 経由使用開始
+pub(crate) static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// 行数上限の effective value を返す(`#[cfg(test)]` 時のみ override を考慮)。
+///
+/// # Postconditions
+///
+/// - `#[cfg(not(test))]` 時は常に `LEARNING_CACHE_MAX_ROWS` を返す
+/// - `#[cfg(test)]` かつ override が 0 の場合は `LEARNING_CACHE_MAX_ROWS` を返す
+/// - `#[cfg(test)]` かつ override が 0 より大きい場合は override 値を返す
+#[inline]
+#[allow(dead_code)] // B8 で record_choice / evict_to_cap から呼び出し開始
+pub(crate) fn effective_max_rows() -> usize {
+    #[cfg(test)]
+    {
+        let v = LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.load(Ordering::SeqCst);
+        if v != 0 {
+            return v;
+        }
+    }
+    LEARNING_CACHE_MAX_ROWS
+}
+
+/// テスト中だけ `LEARNING_CACHE_MAX_ROWS` を `cap` に上書きする RAII guard。
+///
+/// drop 時に自動で 0(無効)に戻すので、test 同士の干渉を防ぐ。
+/// override は process 全体の static なため、複数 test が同時に
+/// override を活性化すると競合する。よって `CAP_OVERRIDE_LOCK` を
+/// 取得して直列化する。
+///
+/// # Examples
+///
+/// ```ignore
+/// // tests-only:
+/// let _guard = CapOverrideGuard::new(5);
+/// // このブロック内では cap = 5 で動作する
+/// // _guard が drop されると cap = LEARNING_CACHE_MAX_ROWS に戻る
+/// ```
+#[cfg(test)]
+#[allow(dead_code)] // B7 で eviction tests から使用開始
+pub(crate) struct CapOverrideGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl CapOverrideGuard {
+    #[allow(dead_code)] // B7 で eviction tests から呼び出し開始
+    pub(crate) fn new(cap: usize) -> Self {
+        // poison していても続行(直前 test の panic でも次 test を回したい)。
+        let lock = CAP_OVERRIDE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(cap, Ordering::SeqCst);
+        Self { _lock: lock }
+    }
+}
+
+#[cfg(test)]
+impl Drop for CapOverrideGuard {
+    fn drop(&mut self) {
+        LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(0, Ordering::SeqCst);
+    }
+}
 
 /// `lookup` SQL(spec §4.3)。`(kana_input)` index を seek して
 /// `frequency DESC, last_used_at DESC` 順に `LIMIT ?2` 件を返す。

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -307,4 +307,86 @@ mod tests {
         let err = store.record_choice("abc", "川").unwrap_err();
         assert!(matches!(err, StorageError::InvalidField { .. }));
     }
+
+    // --- eviction tests (B7 red phase) ---
+
+    /// cap 未満の行数では record_choice 後に削除が発生しない。
+    /// (B7) TDD red: B5 実装は eviction を含まないので本 test は PASS する(eviction なし ⇒ 行数保持)。
+    /// B8 実装後も PASS を維持することを確認する。
+    #[test]
+    fn eviction_does_not_occur_when_below_cap() {
+        let _guard = CapOverrideGuard::new(5);
+        let store = fresh_store_b();
+        // cap=5 に対して 3 件 insert する。
+        for kanji in ["愛", "哀", "藍"] {
+            store.record_choice("あい", kanji).expect("ok");
+        }
+        let result = store.lookup("あい", 10).expect("ok");
+        assert_eq!(result.len(), 3);
+    }
+
+    /// cap を 1 件超過した場合、LRU の 1 件が削除されて行数が cap に収まる。
+    /// (B7) TDD red: B5 実装は eviction を含まないので insert 後に cap+1 件が残り FAIL する。
+    #[test]
+    fn eviction_removes_one_lru_entry_when_cap_exceeded_by_one() {
+        let _guard = CapOverrideGuard::new(3);
+        let store = fresh_store_b();
+        // 3 件 insert して cap ぴったりにする。
+        store.record_choice("あ", "亜").expect("ok");
+        store.record_choice("い", "以").expect("ok");
+        store.record_choice("う", "宇").expect("ok");
+        // 4 件目で cap を 1 超過する。最も ancient な "あ/亜" が evict されるべき。
+        store.record_choice("え", "江").expect("ok");
+        // 総行数が cap=3 以内に収まっていることを確認する。
+        let conn = store.db.lock_conn();
+        let total: i64 = conn
+            .query_row("SELECT count(*) FROM learning_cache", [], |r| r.get(0))
+            .unwrap();
+        assert!(total <= 3, "total={total} must be <= cap 3");
+    }
+
+    /// burst insert で行数が cap を超えない。
+    /// (B7) TDD red: B5 実装は eviction を含まないので cap を超えた行数が残り FAIL する。
+    #[test]
+    fn eviction_keeps_row_count_bounded_on_burst_insert() {
+        let _guard = CapOverrideGuard::new(4);
+        let store = fresh_store_b();
+        // cap=4 に対して 10 件 insert する。
+        let kanjis = ["一", "二", "三", "四", "五", "六", "七", "八", "九", "十"];
+        for (i, kanji) in kanjis.iter().enumerate() {
+            let reading = char::from_u32(0x3041 + i as u32)
+                .expect("valid hiragana")
+                .to_string();
+            store.record_choice(&reading, kanji).expect("ok");
+        }
+        let conn = store.db.lock_conn();
+        let total: i64 = conn
+            .query_row("SELECT count(*) FROM learning_cache", [], |r| r.get(0))
+            .unwrap();
+        assert!(total <= 4, "total={total} must be <= cap 4 after burst");
+    }
+
+    /// LRU 保護: record_choice で update された entry は eviction 対象から外れる。
+    /// (B7) TDD red: B5 実装は eviction を含まないので挙動を検証できず行数超過で FAIL する。
+    #[test]
+    fn eviction_protects_recently_updated_entry_from_lru() {
+        let _guard = CapOverrideGuard::new(2);
+        let store = fresh_store_b();
+        // "亜" を先に insert する(古い entry)。
+        store.record_choice("あ", "亜").expect("ok");
+        // "以" を後で insert する(新しい entry)。
+        store.record_choice("い", "以").expect("ok");
+        // "亜" を再度 record_choice して last_used_at を更新する。
+        store.record_choice("あ", "亜").expect("ok");
+        // 3 件目 insert で cap=2 を超える。"以" のほうが古いので evict される。
+        store.record_choice("う", "宇").expect("ok");
+        // "亜" は残っており、"以" は evict されている。
+        let result_a = store.lookup("あ", 10).expect("ok");
+        assert!(
+            !result_a.is_empty(),
+            "亜 must survive because it was recently updated"
+        );
+        let result_i = store.lookup("い", 10).expect("ok");
+        assert!(result_i.is_empty(), "以 must be evicted as the LRU entry");
+    }
 }

--- a/crates/kotoha-storage/src/lib.rs
+++ b/crates/kotoha-storage/src/lib.rs
@@ -5,9 +5,9 @@
 //!
 //! この crate は永続化詳細層であり、`kotoha-core` の domain layer に依存しない
 //! (spec §4.2 Clean Architecture DIP)。`UserVocabReader` / `UserVocabWriter` /
-//! `LearningCacheStore` trait は本 crate 側に置き、`kotoha-core::dict::user_vocab::UserVocab` が
-//! `Box<dyn UserVocabReader>` を field に保持することで DIP + ISP を成立させる
-//! (arch-M-2、P2-C-A)。
+//! `LearningCacheReader` / `LearningCacheWriter` trait は本 crate 側に置き、
+//! `kotoha-core::dict::user_vocab::UserVocab` が `Box<dyn UserVocabReader>` を
+//! field に保持することで DIP + ISP を成立させる(arch-M-2、P2-C-A / P2-C-B)。
 
 pub mod database;
 pub mod error;

--- a/crates/kotoha-storage/src/lib.rs
+++ b/crates/kotoha-storage/src/lib.rs
@@ -4,9 +4,10 @@
 //! ADR: `docs/adr/0015-kotoha-storage-sqlite-adoption.md`.
 //!
 //! この crate は永続化詳細層であり、`kotoha-core` の domain layer に依存しない
-//! (spec §4.2 Clean Architecture DIP)。`UserVocabStore` / `LearningCacheStore`
-//! trait は本 crate 側に置き、`kotoha-core::dict::user_vocab::UserVocab` が
-//! `Box<dyn UserVocabStore>` を field に保持することで DIP を成立させる。
+//! (spec §4.2 Clean Architecture DIP)。`UserVocabReader` / `UserVocabWriter` /
+//! `LearningCacheStore` trait は本 crate 側に置き、`kotoha-core::dict::user_vocab::UserVocab` が
+//! `Box<dyn UserVocabReader>` を field に保持することで DIP + ISP を成立させる
+//! (arch-M-2、P2-C-A)。
 
 pub mod database;
 pub mod error;

--- a/crates/kotoha-storage/src/migrations.rs
+++ b/crates/kotoha-storage/src/migrations.rs
@@ -115,4 +115,98 @@ mod tests {
             .unwrap();
         assert_eq!(count, 1);
     }
+
+    // ---- v002 migration 検証(spec §4.1)----
+
+    /// v001 + v002 を一括 apply した後、`idx_learning_cache_last_used` index が
+    /// `sqlite_master` に存在することを確認する(spec §4.1)。
+    #[test]
+    fn apply_migrations_v002_creates_learning_cache_index() {
+        let conn = Connection::open_in_memory().expect("memory open");
+        apply_migrations(&conn).expect("apply");
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_learning_cache_last_used'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "idx_learning_cache_last_used must exist after migration"
+        );
+    }
+
+    /// v001 適用済 DB(`PRAGMA user_version = 1`)に対して `apply_migrations` を呼ぶと、
+    /// v002 のみが追加 apply され、`user_version` が 2 へ更新される(spec §4.1 / §6.5)。
+    #[test]
+    fn apply_migrations_upgrades_from_v001_to_v002() {
+        let conn = Connection::open_in_memory().expect("memory open");
+
+        // v001 のみを手動 apply して v001 完了状態を作成する。
+        let (_, v001_sql) = MIGRATIONS
+            .iter()
+            .find(|(v, _)| *v == 1)
+            .expect("v001 must exist in MIGRATIONS");
+        conn.execute_batch(v001_sql).expect("v001 apply");
+        conn.execute_batch("PRAGMA user_version = 1")
+            .expect("set user_version = 1");
+
+        // apply_migrations は v002 のみを apply し user_version を 2 に更新するはずである。
+        apply_migrations(&conn).expect("upgrade v001 -> v002");
+
+        let v: i32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 2, "user_version must be 2 after v001 -> v002 upgrade");
+
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_learning_cache_last_used'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            idx_count, 1,
+            "idx_learning_cache_last_used must be created by v002"
+        );
+    }
+
+    /// v002 完了状態の DB に対して `apply_migrations` を再実行しても
+    /// `user_version` が `LATEST_VERSION` のまま維持され、index が重複作成エラー無く
+    /// no-op となることを確認する(spec §4.1 / §6.5)。
+    ///
+    /// 既存 `migrations_idempotency_on_double_apply` との差別化:
+    /// 本 test は v002 完了状態での re-run に焦点を絞り、index 数が 1 件のまま
+    /// 維持されることまで明示的に assert する。
+    #[test]
+    fn apply_migrations_is_idempotent_at_v002() {
+        let conn = Connection::open_in_memory().expect("memory open");
+        apply_migrations(&conn).expect("first apply");
+        apply_migrations(&conn).expect("second apply must be no-op");
+
+        let v: i32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            v, LATEST_VERSION,
+            "user_version must equal LATEST_VERSION after double apply"
+        );
+
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_learning_cache_last_used'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            idx_count, 1,
+            "index count must remain 1 after idempotent apply at v002"
+        );
+    }
 }

--- a/crates/kotoha-storage/src/migrations.rs
+++ b/crates/kotoha-storage/src/migrations.rs
@@ -3,13 +3,19 @@
 use crate::error::StorageError;
 
 /// 最新 schema version。新 migration を `MIGRATIONS` に追加する際は本値を増やす。
-pub const LATEST_VERSION: i32 = 1;
+pub const LATEST_VERSION: i32 = 2;
 
 /// (version, sql) 配列。version 昇順厳守(spec §10.1.1)。
 ///
 /// `include_str!` でバイナリ同梱するため、distribution 時に migrations
 /// directory を別配布する必要はない(spec §3.6)。
-pub const MIGRATIONS: &[(i32, &str)] = &[(1, include_str!("../migrations/v001_initial.sql"))];
+pub const MIGRATIONS: &[(i32, &str)] = &[
+    (1, include_str!("../migrations/v001_initial.sql")),
+    (
+        2,
+        include_str!("../migrations/v002_learning_cache_index.sql"),
+    ),
+];
 
 /// 未適用 migration を順次 apply する(spec §6.5)。
 ///

--- a/crates/kotoha-storage/src/user_vocab/mock.rs
+++ b/crates/kotoha-storage/src/user_vocab/mock.rs
@@ -3,7 +3,7 @@
 use std::sync::Mutex;
 
 use crate::error::StorageError;
-use crate::user_vocab::store::{UserVocabRecord, UserVocabStore};
+use crate::user_vocab::store::{UserVocabReader, UserVocabRecord, UserVocabWriter};
 use crate::validation::{validate_pos, validate_reading, validate_score, validate_surface};
 
 pub struct MockUserVocabStore {
@@ -26,7 +26,7 @@ impl MockUserVocabStore {
     }
 }
 
-impl UserVocabStore for MockUserVocabStore {
+impl UserVocabReader for MockUserVocabStore {
     fn find_by_reading(
         &self,
         reading: &str,
@@ -48,9 +48,9 @@ impl UserVocabStore for MockUserVocabStore {
         Ok(filtered)
     }
 
-    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError> {
+    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError> {
         let records = self.records.lock().unwrap();
-        Ok(records.iter().skip(offset).take(limit).cloned().collect())
+        Ok(records.iter().find(|r| r.id == Some(id)).cloned())
     }
 
     fn find_by_prefix(
@@ -76,6 +76,13 @@ impl UserVocabStore for MockUserVocabStore {
         Ok(filtered)
     }
 
+    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError> {
+        let records = self.records.lock().unwrap();
+        Ok(records.iter().skip(offset).take(limit).cloned().collect())
+    }
+}
+
+impl UserVocabWriter for MockUserVocabStore {
     fn insert(&self, mut record: UserVocabRecord) -> Result<i64, StorageError> {
         validate_surface(&record.surface)?;
         validate_reading(&record.reading)?;
@@ -129,11 +136,6 @@ impl UserVocabStore for MockUserVocabStore {
             return Err(StorageError::NotFound);
         }
         Ok(())
-    }
-
-    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError> {
-        let records = self.records.lock().unwrap();
-        Ok(records.iter().find(|r| r.id == Some(id)).cloned())
     }
 }
 

--- a/crates/kotoha-storage/src/user_vocab/mod.rs
+++ b/crates/kotoha-storage/src/user_vocab/mod.rs
@@ -1,4 +1,4 @@
-//! `UserVocabStore` trait + `UserVocabRecord` + `Sqlite/Mock` 実装。
+//! `UserVocabReader` / `UserVocabWriter` trait + `UserVocabRecord` + `Sqlite/Mock` 実装。
 
 pub mod mock;
 pub mod sqlite;
@@ -6,4 +6,4 @@ pub mod store;
 
 pub use mock::MockUserVocabStore;
 pub use sqlite::SqliteUserVocabStore;
-pub use store::{UserVocabRecord, UserVocabStore};
+pub use store::{UserVocabReader, UserVocabRecord, UserVocabWriter};

--- a/crates/kotoha-storage/src/user_vocab/sqlite.rs
+++ b/crates/kotoha-storage/src/user_vocab/sqlite.rs
@@ -1,4 +1,4 @@
-//! SqliteUserVocabStore: UserVocabStore の SQLite 実装(spec §6.1 / §6.4)。
+//! SqliteUserVocabStore: UserVocabReader + UserVocabWriter の SQLite 実装(arch-M-2、spec §3.2 / §6.1 / §6.4)。
 
 use std::sync::Arc;
 

--- a/crates/kotoha-storage/src/user_vocab/sqlite.rs
+++ b/crates/kotoha-storage/src/user_vocab/sqlite.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::database::Database;
 use crate::error::StorageError;
-use crate::user_vocab::store::{UserVocabRecord, UserVocabStore};
+use crate::user_vocab::store::{UserVocabReader, UserVocabRecord, UserVocabWriter};
 use crate::validation::{validate_pos, validate_reading, validate_score, validate_surface};
 
 /// User vocab 行数上限(sec-M5、spec §F6)。
@@ -76,7 +76,7 @@ impl SqliteUserVocabStore {
     }
 }
 
-impl UserVocabStore for SqliteUserVocabStore {
+impl UserVocabReader for SqliteUserVocabStore {
     fn find_by_reading(
         &self,
         reading: &str,
@@ -138,6 +138,68 @@ impl UserVocabStore for SqliteUserVocabStore {
         Ok(out)
     }
 
+    fn find_by_prefix(
+        &self,
+        reading_prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError> {
+        // prefix は hiragana / 空文字どちらも許容(空 prefix = 全件)
+        if !reading_prefix.is_empty() {
+            validate_reading(reading_prefix)?;
+        }
+        let conn = self.db.lock_conn();
+        let pattern = format!("{}%", reading_prefix);
+        // perf-H1: prepare_cached で SQL コンパイルを再利用する。
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, surface, reading, pos, score, created_at, updated_at \
+             FROM user_vocab \
+             WHERE reading LIKE ?1 \
+             ORDER BY score DESC, id ASC \
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![pattern, limit as i64], |row| {
+            Ok(UserVocabRecord {
+                id: Some(row.get(0)?),
+                surface: row.get(1)?,
+                reading: row.get(2)?,
+                pos: row.get(3)?,
+                score: row.get::<_, f64>(4)? as f32,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError> {
+        let conn = self.db.lock_conn();
+        // perf-H1: prepare_cached で SQL コンパイルを再利用する。
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, surface, reading, pos, score, created_at, updated_at \
+             FROM user_vocab WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query(rusqlite::params![id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(UserVocabRecord {
+                id: Some(row.get(0)?),
+                surface: row.get(1)?,
+                reading: row.get(2)?,
+                pos: row.get(3)?,
+                score: row.get::<_, f64>(4)? as f32,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl UserVocabWriter for SqliteUserVocabStore {
     fn insert(&self, record: UserVocabRecord) -> Result<i64, StorageError> {
         validate_surface(&record.surface)?;
         validate_reading(&record.reading)?;
@@ -237,66 +299,6 @@ impl UserVocabStore for SqliteUserVocabStore {
             return Err(StorageError::NotFound);
         }
         Ok(())
-    }
-
-    fn find_by_prefix(
-        &self,
-        reading_prefix: &str,
-        limit: usize,
-    ) -> Result<Vec<UserVocabRecord>, StorageError> {
-        // prefix は hiragana / 空文字どちらも許容(空 prefix = 全件)
-        if !reading_prefix.is_empty() {
-            validate_reading(reading_prefix)?;
-        }
-        let conn = self.db.lock_conn();
-        let pattern = format!("{}%", reading_prefix);
-        // perf-H1: prepare_cached で SQL コンパイルを再利用する。
-        let mut stmt = conn.prepare_cached(
-            "SELECT id, surface, reading, pos, score, created_at, updated_at \
-             FROM user_vocab \
-             WHERE reading LIKE ?1 \
-             ORDER BY score DESC, id ASC \
-             LIMIT ?2",
-        )?;
-        let rows = stmt.query_map(rusqlite::params![pattern, limit as i64], |row| {
-            Ok(UserVocabRecord {
-                id: Some(row.get(0)?),
-                surface: row.get(1)?,
-                reading: row.get(2)?,
-                pos: row.get(3)?,
-                score: row.get::<_, f64>(4)? as f32,
-                created_at: row.get(5)?,
-                updated_at: row.get(6)?,
-            })
-        })?;
-        let mut out = Vec::new();
-        for r in rows {
-            out.push(r?);
-        }
-        Ok(out)
-    }
-
-    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError> {
-        let conn = self.db.lock_conn();
-        // perf-H1: prepare_cached で SQL コンパイルを再利用する。
-        let mut stmt = conn.prepare_cached(
-            "SELECT id, surface, reading, pos, score, created_at, updated_at \
-             FROM user_vocab WHERE id = ?1",
-        )?;
-        let mut rows = stmt.query(rusqlite::params![id])?;
-        if let Some(row) = rows.next()? {
-            Ok(Some(UserVocabRecord {
-                id: Some(row.get(0)?),
-                surface: row.get(1)?,
-                reading: row.get(2)?,
-                pos: row.get(3)?,
-                score: row.get::<_, f64>(4)? as f32,
-                created_at: row.get(5)?,
-                updated_at: row.get(6)?,
-            }))
-        } else {
-            Ok(None)
-        }
     }
 }
 

--- a/crates/kotoha-storage/src/user_vocab/store.rs
+++ b/crates/kotoha-storage/src/user_vocab/store.rs
@@ -17,8 +17,8 @@ use crate::error::StorageError;
 ///
 /// # Errors
 ///
-/// - [`StorageError::InvalidField`]: `reading` が validation 違反の場合
-/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+/// - [`StorageError::InvalidField`][]:`reading` が validation 違反の場合
+/// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
 pub trait UserVocabReader: Send + Sync {
     /// `reading` が完全一致する entry を `score DESC` 順で返す。
     ///
@@ -29,8 +29,8 @@ pub trait UserVocabReader: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - [`StorageError::InvalidField`]: `reading` が hiragana 以外を含む場合
-    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    /// - [`StorageError::InvalidField`][]:`reading` が hiragana 以外を含む場合
+    /// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
     fn find_by_reading(
         &self,
         reading: &str,
@@ -45,7 +45,7 @@ pub trait UserVocabReader: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    /// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
     fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError>;
 
     /// `reading` が `reading_prefix` で前方一致する entry を `score DESC` 順で返す。
@@ -58,8 +58,8 @@ pub trait UserVocabReader: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - [`StorageError::InvalidField`]: `reading_prefix` が validation 違反の場合
-    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    /// - [`StorageError::InvalidField`][]:`reading_prefix` が validation 違反の場合
+    /// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
     fn find_by_prefix(
         &self,
         reading_prefix: &str,
@@ -70,7 +70,7 @@ pub trait UserVocabReader: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    /// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
     fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError>;
 }
 
@@ -88,10 +88,10 @@ pub trait UserVocabReader: Send + Sync {
 ///
 /// # Errors
 ///
-/// - [`StorageError::InvalidField`]: validation 違反の場合
-/// - [`StorageError::DuplicateEntry`]: UNIQUE 制約違反の場合
-/// - [`StorageError::NotFound`]: 削除対象が存在しない場合
-/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+/// - [`StorageError::InvalidField`][]:validation 違反の場合
+/// - [`StorageError::DuplicateEntry`][]:UNIQUE 制約違反の場合
+/// - [`StorageError::NotFound`][]:削除対象が存在しない場合
+/// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
 pub trait UserVocabWriter: Send + Sync {
     /// `record` を `user_vocab` table に insert し、採番された `id` を返す。
     ///
@@ -106,26 +106,26 @@ pub trait UserVocabWriter: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - [`StorageError::InvalidField`]: field validation 違反の場合
-    /// - [`StorageError::DuplicateEntry`]: UNIQUE(surface, reading) 違反の場合
-    /// - [`StorageError::QuotaExceeded`]: 行数が `USER_VOCAB_MAX_ROWS` に到達している場合
-    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    /// - [`StorageError::InvalidField`][]:field validation 違反の場合
+    /// - [`StorageError::DuplicateEntry`][]:UNIQUE(surface, reading) 違反の場合
+    /// - [`StorageError::QuotaExceeded`][]:行数が `USER_VOCAB_MAX_ROWS` に到達している場合
+    /// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
     fn insert(&self, record: UserVocabRecord) -> Result<i64, StorageError>;
 
     /// 主キー `id` で entry を 1 件削除する。
     ///
     /// # Errors
     ///
-    /// - [`StorageError::NotFound`]: `id` が存在しない場合
-    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    /// - [`StorageError::NotFound`][]:`id` が存在しない場合
+    /// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
     fn delete_by_id(&self, id: i64) -> Result<(), StorageError>;
 
     /// `(surface, reading)` で entry を 1 件削除する。
     ///
     /// # Errors
     ///
-    /// - [`StorageError::NotFound`]: 対象 entry が存在しない場合
-    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    /// - [`StorageError::NotFound`][]:対象 entry が存在しない場合
+    /// - [`StorageError::Sqlite`][]:SQLite backend 障害の場合
     fn delete_by_surface_reading(&self, surface: &str, reading: &str) -> Result<(), StorageError>;
 }
 

--- a/crates/kotoha-storage/src/user_vocab/store.rs
+++ b/crates/kotoha-storage/src/user_vocab/store.rs
@@ -1,54 +1,141 @@
-//! `UserVocabStore` trait + `UserVocabRecord`(spec §6.1 / §6.2)。
+//! `UserVocabReader` / `UserVocabWriter` trait + `UserVocabRecord`
+//! (arch-M-2 ISP split、spec §3.2 / §6.1 / §6.2)。
 
 use crate::error::StorageError;
 
-/// User-managed vocabulary store の抽象境界。
+/// User vocabulary の read 操作を提供する抽象境界。
 ///
 /// # Preconditions
 ///
-/// - `reading` は hiragana canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
-/// - `surface` / `pos` は non-empty / ≤256 bytes / no control char / no bidi
-/// - `score` は finite + non-negative
+/// - `reading` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
 ///
 /// # Postconditions
 ///
-/// - `find_by_reading` は score 降順で最大 `limit` 件返す
-/// - `insert` 成功時は `id` を返す
-/// - UNIQUE(surface, reading) 違反は [`StorageError::DuplicateEntry`]
+/// - `find_by_reading` は `score DESC` 順で最大 `limit` 件返す
+/// - `find_by_prefix` は `score DESC` 順で最大 `limit` 件返す
+/// - `find_by_id` は不在の場合 `Ok(None)` を返す(エラーではない)
 ///
 /// # Errors
 ///
-/// - [`StorageError::InvalidField`] when validation fails
-/// - [`StorageError::DuplicateEntry`] on UNIQUE conflict
-/// - [`StorageError::NotFound`] on delete miss
-/// - [`StorageError::Sqlite`] on backend failure
-pub trait UserVocabStore: Send + Sync {
+/// - [`StorageError::InvalidField`]: `reading` が validation 違反の場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait UserVocabReader: Send + Sync {
+    /// `reading` が完全一致する entry を `score DESC` 順で返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `reading` はひらがな canonical
+    /// - `limit` は呼び出し元が必要な件数の上限を示す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `reading` が hiragana 以外を含む場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
     fn find_by_reading(
         &self,
         reading: &str,
         limit: usize,
     ) -> Result<Vec<UserVocabRecord>, StorageError>;
-    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError>;
-    fn insert(&self, record: UserVocabRecord) -> Result<i64, StorageError>;
-    fn delete_by_id(&self, id: i64) -> Result<(), StorageError>;
-    fn delete_by_surface_reading(&self, surface: &str, reading: &str) -> Result<(), StorageError>;
-    /// `reading` の prefix match で entries を返す(spec §7.4 `--reading <PREFIX>`)。
+
+    /// 主キー `id` で entry 1 件を引く。
     ///
-    /// SQL `reading LIKE 'PREFIX%'` を使用し、score 降順で `limit` 件返す。
+    /// # Postconditions
+    ///
+    /// - 不在の場合は `Ok(None)` を返す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError>;
+
+    /// `reading` が `reading_prefix` で前方一致する entry を `score DESC` 順で返す。
+    ///
+    /// SQL `reading LIKE 'PREFIX%'` を使用する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `reading_prefix` はひらがな canonical
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `reading_prefix` が validation 違反の場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
     fn find_by_prefix(
         &self,
         reading_prefix: &str,
         limit: usize,
     ) -> Result<Vec<UserVocabRecord>, StorageError>;
-    /// 主キー `id` で entry 1 件を引く(review A-H3)。
+
+    /// 全 entry を `id ASC` 順でページネーション付きで返す。
     ///
-    /// CLI `kotoha-dict show <id>` 経路を `list_all(usize::MAX, 0)` の
-    /// linear scan から PK 直引きに置き換えるための専用 API。
-    /// 不在時は `Ok(None)` を返し、エラーではない。
-    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError>;
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError>;
 }
 
-/// User vocabulary の row(spec §6.2)。
+/// User vocabulary の write 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `record.surface` / `record.reading` / `record.pos` / `record.score` は各 validation を通過
+///
+/// # Postconditions
+///
+/// - `insert` 成功時は採番された `id` を返す
+/// - UNIQUE(surface, reading) 違反は [`StorageError::DuplicateEntry`]
+/// - `delete_by_id` / `delete_by_surface_reading` の対象不在は [`StorageError::NotFound`]
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: validation 違反の場合
+/// - [`StorageError::DuplicateEntry`]: UNIQUE 制約違反の場合
+/// - [`StorageError::NotFound`]: 削除対象が存在しない場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait UserVocabWriter: Send + Sync {
+    /// `record` を `user_vocab` table に insert し、採番された `id` を返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `record.surface` / `record.reading` / `record.pos` は各 validate_* を通過
+    /// - `record.score` は finite + non-negative
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は `AUTOINCREMENT` で採番された `id`
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: field validation 違反の場合
+    /// - [`StorageError::DuplicateEntry`]: UNIQUE(surface, reading) 違反の場合
+    /// - [`StorageError::QuotaExceeded`]: 行数が `USER_VOCAB_MAX_ROWS` に到達している場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn insert(&self, record: UserVocabRecord) -> Result<i64, StorageError>;
+
+    /// 主キー `id` で entry を 1 件削除する。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`]: `id` が存在しない場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn delete_by_id(&self, id: i64) -> Result<(), StorageError>;
+
+    /// `(surface, reading)` で entry を 1 件削除する。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`]: 対象 entry が存在しない場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn delete_by_surface_reading(&self, surface: &str, reading: &str) -> Result<(), StorageError>;
+}
+
+/// User vocabulary の row。
+///
+/// # Invariants
+///
+/// - `id` は insert 前は `None`、DB から取得した場合は `Some`
+/// - `score` は finite + non-negative(`validate_score` 通過後に保証)
+/// - `created_at` / `updated_at` は UNIX epoch seconds
 #[derive(Debug, Clone, PartialEq)]
 pub struct UserVocabRecord {
     /// insert 前は None、find / list は Some。

--- a/crates/kotoha-storage/tests/learning_cache_proptest.rs
+++ b/crates/kotoha-storage/tests/learning_cache_proptest.rs
@@ -1,0 +1,162 @@
+//! proptest — `LearningCache` の 3 invariant を property-based で検証する。
+//!
+//! spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md §6.5
+//!
+//! `PROPTEST_CASES = 64`(`ProptestConfig::with_cases(64)`)で実行する。
+//!
+//! Strategy 設計方針:
+//! - `hiragana_string()`: ひらがな Unicode ブロック `'\u{3041}'..='\u{309F}'` から
+//!   1〜32 文字を生成する。`validate_reading` を必ず通過する。
+//! - `kanji_string()`: 実用漢字集合 10 種から 1〜10 文字を選択生成する。
+//!   `validate_surface` を必ず通過する。
+//! - 上記により Invariant 3(valid 入力に対して `record_choice` は `Ok(())` を返す)
+//!   は strategy-level で保証される。
+
+use kotoha_storage::database::Database;
+use kotoha_storage::learning_cache::CapOverrideGuard;
+use proptest::prelude::*;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// strategy 定義
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// ひらがな 1〜32 文字からなる文字列を生成する。
+///
+/// 生成される全文字列は `validate_reading` を通過する(spec §9.2、
+/// `U+3040..=U+309F` は hiragana block、本 strategy はそのうち
+/// `U+3041..=U+3096` に限定して生成する。`U+3097`〜`U+309F` には未割り当て /
+/// 結合用文字が含まれるため、ASCII 互換の安定範囲のみを使う。
+/// `validation.rs` 側の既存 proptest と同等の regex strategy を採用する)。
+fn hiragana_string() -> impl Strategy<Value = String> {
+    // proptest の regex strategy は `Strategy<Value = String>` を返すため、
+    // 追加の prop_map は不要(`&str` は `Strategy` に対する `Arbitrary`-like
+    // shorthand として展開される)。
+    "[\u{3041}-\u{3096}]{1,32}"
+}
+
+/// 実用漢字集合 10 種から 1〜10 文字を選択して文字列を生成する。
+///
+/// 生成される全文字列は `validate_surface` を通過する(spec §9.1、
+/// 漢字は control char / bidi / PUA / Variation Selector / Tag char に
+/// 該当しないため、共通 validate_field 制約を必ず通過する)。
+fn kanji_string() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        proptest::sample::select(vec![
+            '愛', '夢', '空', '花', '光', '山', '川', '海', '月', '日',
+        ]),
+        1..=10,
+    )
+    .prop_map(|chars: Vec<char>| chars.into_iter().collect::<String>())
+}
+
+/// `(kana_input, chosen_kanji)` のペアを 0〜200 件含む `Vec` を生成する。
+fn record_sequence() -> impl Strategy<Value = Vec<(String, String)>> {
+    proptest::collection::vec((hiragana_string(), kanji_string()), 0..=200)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// proptest
+// ──────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Invariant 1: 任意の record sequence 後も行数が cap 以下である。
+    ///
+    /// `CapOverrideGuard::new(20)` で cap=20 を設定し、`record_choice` の
+    /// 自動 eviction(spec §4.2)により行数が常に 20 以下に収まることを確認する。
+    /// 検証手順: sequence を全 record したあと `evict_lru(20)` が `Ok(0)` を返す
+    /// ことを確認する(行数 ≤ cap が成立していれば evict_lru は何も削除しないため)。
+    #[test]
+    fn invariant_row_count_stays_within_cap(records in record_sequence()) {
+        let db = Database::open_in_memory().expect("open_in_memory must succeed");
+        let _guard = CapOverrideGuard::new(20);
+        let writer = db.learning_cache_writer();
+
+        for (kana, kanji) in &records {
+            // strategy が valid 入力のみを生成するため、Ok 以外は発生しないはず。
+            writer
+                .record_choice(kana, kanji)
+                .expect("record_choice must succeed for strategy-generated valid inputs");
+        }
+
+        // evict_lru(20) が Ok(0) を返すと、record_choice の自動 eviction が
+        // すでに行数を 20 以下に収めていることを示す。
+        let evicted = writer
+            .evict_lru(20)
+            .expect("evict_lru must succeed");
+        prop_assert_eq!(
+            evicted,
+            0,
+            "row count must be <= cap=20 after the record sequence; \
+             follow-up evict_lru(20) returned {} which means auto-eviction did not enforce the cap",
+            evicted
+        );
+    }
+
+    /// Invariant 2: lookup 結果が frequency DESC で単調非増加である。
+    ///
+    /// record sequence 後に sequence の先頭 kana_input に対して `lookup(_, 100)`
+    /// を呼び出し、結果 `results[i].frequency >= results[i + 1].frequency` が
+    /// 全 i で成立することを確認する(spec §4.3 一次キー frequency DESC)。
+    /// 同 frequency 内 last_used_at DESC の二次キーは本 invariant に含めない
+    /// (SQL 仕様にゆだねる、L2 integration test 5 で別途検証)。
+    #[test]
+    fn invariant_lookup_result_is_frequency_desc(records in record_sequence()) {
+        // sequence が空の場合は lookup 対象が存在しないので skip する。
+        prop_assume!(!records.is_empty());
+
+        let db = Database::open_in_memory().expect("open_in_memory must succeed");
+        let _guard = CapOverrideGuard::new(20);
+        let writer = db.learning_cache_writer();
+        let reader = db.learning_cache_reader();
+
+        for (kana, kanji) in &records {
+            writer
+                .record_choice(kana, kanji)
+                .expect("record_choice must succeed for strategy-generated valid inputs");
+        }
+
+        let target_kana = &records[0].0;
+        let results = reader
+            .lookup(target_kana, 100)
+            .expect("lookup must succeed");
+
+        for i in 0..results.len().saturating_sub(1) {
+            prop_assert!(
+                results[i].frequency >= results[i + 1].frequency,
+                "lookup results must be non-increasing on frequency: \
+                 results[{}].frequency={} < results[{}].frequency={}",
+                i,
+                results[i].frequency,
+                i + 1,
+                results[i + 1].frequency
+            );
+        }
+    }
+
+    /// Invariant 3: strategy が生成した全入力に対して `record_choice` が `Ok(())` を返す。
+    ///
+    /// `hiragana_string` / `kanji_string` は `validate_reading` / `validate_surface`
+    /// を通過する文字列のみを生成するため、`record_choice` は `Err(InvalidField)` を
+    /// 返さないはずである。万が一 `Err` が観測された場合は strategy の生成ロジックか
+    /// validation 実装のいずれかにバグがあると判定する。
+    #[test]
+    fn invariant_valid_inputs_always_succeed(records in record_sequence()) {
+        let db = Database::open_in_memory().expect("open_in_memory must succeed");
+        let _guard = CapOverrideGuard::new(20);
+        let writer = db.learning_cache_writer();
+
+        for (kana, kanji) in &records {
+            let result = writer.record_choice(kana, kanji);
+            prop_assert!(
+                result.is_ok(),
+                "record_choice must return Ok for strategy-generated valid inputs: \
+                 kana={:?}, kanji={:?}, err={:?}",
+                kana,
+                kanji,
+                result
+            );
+        }
+    }
+}

--- a/crates/kotoha-storage/tests/learning_cache_store.rs
+++ b/crates/kotoha-storage/tests/learning_cache_store.rs
@@ -1,0 +1,334 @@
+//! L2 integration tests — `LearningCache` factory wiring / concurrency / persistence
+//! / UPSERT path / lookup ordering tie-break.
+//!
+//! spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md §6.3
+//!
+//! Test 1〜3: factory wiring / concurrency / eviction persistence(plan §D1)。
+//! Test 4〜5: Phase B reviewer の content-gap 指摘 2 件を Phase D で吸収する
+//! 補完 test(`record_choice_updates_last_used_at_on_duplicate`,
+//! `lookup_orders_by_frequency_desc_then_last_used_at_desc`)。
+
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use kotoha_storage::database::Database;
+use kotoha_storage::learning_cache::{CapOverrideGuard, LearningCacheReader, LearningCacheWriter};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// in-memory `Database` を開いて reader / writer factory pair を返す。
+///
+/// 同一 `Arc<Database>` から生成しているため、両 factory は同一
+/// `Mutex<Connection>` を共有する(spec §6.4.1)。
+fn open_factory_pair() -> (
+    Arc<Database>,
+    Box<dyn LearningCacheReader>,
+    Box<dyn LearningCacheWriter>,
+) {
+    let db = Database::open_in_memory().expect("open_in_memory must succeed");
+    let reader = db.learning_cache_reader();
+    let writer = db.learning_cache_writer();
+    (db, reader, writer)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test 1: factory wiring
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// writer で記録した entry を reader が観測できることを確認する(plan §D1-1)。
+///
+/// `Database::learning_cache_reader` / `learning_cache_writer` が同一
+/// `Arc<Database>` 経由で同一 `Mutex<Connection>` を共有していることを
+/// factory wiring レベルで検証する(spec §6.4.1)。
+#[test]
+fn factory_returns_reader_and_writer_sharing_same_data() {
+    let (_db, reader, writer) = open_factory_pair();
+
+    writer
+        .record_choice("あいう", "愛")
+        .expect("record_choice must succeed");
+
+    let results = reader.lookup("あいう", 10).expect("lookup must succeed");
+
+    assert_eq!(
+        results.len(),
+        1,
+        "reader must see the entry written by writer through the shared connection"
+    );
+    assert_eq!(results[0].chosen_kanji, "愛");
+    assert_eq!(results[0].frequency, 1);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test 2: concurrent UPSERT (frequency loss check)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// 10 thread が同一 `(kana_input, chosen_kanji)` 対して record_choice を並列実行しても
+/// `Mutex<Connection>` 直列化により全件が UPSERT-merge され `frequency = 10` になる
+/// ことを確認する(plan §D1-2 / spec §4.2 / E9)。
+///
+/// この test は process 単独実行(integration test crate ごとに別 process)であり、
+/// `learning_cache::sqlite` の unit test との `CAP_OVERRIDE_LOCK` 競合は発生しない。
+/// override は使用せず、production cap = 10_000 のもとで実行する。
+#[test]
+fn concurrent_record_choice_is_serialized() {
+    let db = Database::open_in_memory().expect("open_in_memory must succeed");
+
+    const THREAD_COUNT: usize = 10;
+    let mut handles = Vec::with_capacity(THREAD_COUNT);
+
+    for _ in 0..THREAD_COUNT {
+        let db_for_thread = Arc::clone(&db);
+        handles.push(thread::spawn(move || {
+            // thread ごとに writer を生成する。同 `Arc<Database>` を共有しているため
+            // 同一 `Mutex<Connection>` 経由で直列化される。
+            let writer = db_for_thread.learning_cache_writer();
+            writer
+                .record_choice("きょう", "今日")
+                .expect("record_choice must not fail under concurrency");
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("worker thread must not panic");
+    }
+
+    let reader = db.learning_cache_reader();
+    let results = reader.lookup("きょう", 10).expect("lookup must succeed");
+
+    assert_eq!(
+        results.len(),
+        1,
+        "concurrent inserts for the same (kana, kanji) must be UPSERT-merged into a single row"
+    );
+    assert_eq!(
+        u64::from(results[0].frequency),
+        THREAD_COUNT as u64,
+        "frequency must equal the number of concurrent record_choice calls without loss"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test 3: eviction persistence across reopens
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// file-backed `Database` で auto eviction が発生したあと、`Database` を drop して
+/// 同 path で再 open しても、削除済 entry は復活せず行数が cap 以内であることを
+/// 確認する(plan §D1-3 / spec §6.3)。
+///
+/// `CapOverrideGuard::new(5)` で auto eviction の cap を 5 に縮小し、6 件目の
+/// record_choice で 1 件 evict されることを検証する。再 open 後、削除された
+/// kana_input(LRU)に対する lookup が空 `Vec` を返し、残った kana_input に
+/// 対する lookup は entry を返すことを確認する。
+#[test]
+fn eviction_persists_across_factory_reopens() {
+    let dir = tempfile::tempdir().expect("tempdir must succeed");
+    let db_path = dir.path().join("test_eviction.db");
+
+    // Phase 1: cap=5 で 6 件 record して 1 件 eviction を発火させる。
+    {
+        let db = Database::open(&db_path).expect("open phase1 must succeed");
+        // CapOverrideGuard は process 全体の static を変更するため、必ず scope 内に
+        // 留めて drop で復元する。本 test は integration test の単独 process で実行され、
+        // unit test の `CAP_OVERRIDE_LOCK` とは別 process なので競合しない。
+        let _guard = CapOverrideGuard::new(5);
+        let writer = db.learning_cache_writer();
+
+        // 0 番目を最古の last_used_at にする。同一秒内に 6 件 insert すると
+        // last_used_at がすべて同値になり LRU 判定が `id ASC` の二次キーに依存して
+        // しまうため、最初の 1 件のみ十分に古い時刻になるよう sleep を挟む。
+        // SystemTime::now() が秒単位で前進すれば LRU は確実に 0 番目になる。
+        let kanas = ["あ", "い", "う", "え", "お", "か"];
+        writer
+            .record_choice(kanas[0], "愛")
+            .expect("record_choice must succeed");
+        // last_used_at が次の秒に進むまで待つ。
+        thread::sleep(Duration::from_millis(1100));
+
+        for kana in &kanas[1..] {
+            writer
+                .record_choice(kana, "愛")
+                .expect("record_choice must succeed");
+        }
+
+        // cap=5 に収まっていることを確認する(auto eviction で 1 件削除済)。
+        let evicted_again = writer
+            .evict_lru(5)
+            .expect("evict_lru must succeed in phase1");
+        assert_eq!(
+            evicted_again, 0,
+            "row count must already be <= cap=5 after the auto-eviction triggered by record_choice"
+        );
+
+        // guard を drop して override を 0 に戻し、production cap に復元する。
+        drop(_guard);
+        // db を drop して SQLite connection を close する。
+    }
+
+    // Phase 2: 再 open して LRU で削除されたであろう entry が復活していないことを確認する。
+    {
+        let db = Database::open(&db_path).expect("open phase2 must succeed");
+        let reader = db.learning_cache_reader();
+
+        // 最古に record した "あ" は LRU で削除されているはず。
+        let evicted_lookup = reader
+            .lookup("あ", 10)
+            .expect("lookup must succeed for evicted kana");
+        assert!(
+            evicted_lookup.is_empty(),
+            "the LRU entry must remain deleted across Database reopen, got {:?}",
+            evicted_lookup
+        );
+
+        // 残った 5 件は再 open 後も lookup 可能なはず。
+        for kana in ["い", "う", "え", "お", "か"] {
+            let surviving = reader
+                .lookup(kana, 10)
+                .expect("lookup must succeed for surviving kana");
+            assert_eq!(
+                surviving.len(),
+                1,
+                "kana {kana:?} must survive eviction and persist across reopen"
+            );
+            assert_eq!(surviving[0].chosen_kanji, "愛");
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test 4: UPSERT updates last_used_at on duplicate (Phase B reviewer gap fill)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Phase B reviewer 指摘の content gap を Phase D で吸収する。
+///
+/// `record_choice` の UPSERT path(`ON CONFLICT DO UPDATE SET last_used_at = excluded.last_used_at`)
+/// が duplicate insert 時に `last_used_at` を実際に更新することを直接検証する。
+/// 既存 unit test `record_choice_sets_last_used_at_to_nonzero` は新規 insert 時の
+/// `last_used_at != 0` のみ確認し、UPDATE branch を直接検証していない。
+///
+/// 本 test は次を確認する:
+/// - 1 回目 record 後の `last_used_at = t1`
+/// - 1 秒以上 sleep して時刻を前進させる
+/// - 2 回目 record 後の `last_used_at = t2`
+/// - `t2 > t1`(UPDATE 経由で last_used_at が前進している)
+/// - frequency が 2 に増加(UPSERT の `frequency = frequency + 1` path)
+#[test]
+fn record_choice_updates_last_used_at_on_duplicate() {
+    let (_db, reader, writer) = open_factory_pair();
+
+    writer
+        .record_choice("あい", "愛")
+        .expect("first record_choice must succeed");
+    let first = reader
+        .lookup("あい", 10)
+        .expect("lookup after first record must succeed");
+    assert_eq!(first.len(), 1);
+    let t1 = first[0].last_used_at;
+    assert_eq!(first[0].frequency, 1, "first record must yield frequency=1");
+
+    // last_used_at は 1 秒精度の UNIX epoch seconds なので 1 秒以上待つ。
+    thread::sleep(Duration::from_millis(1100));
+
+    writer
+        .record_choice("あい", "愛")
+        .expect("second record_choice must succeed");
+    let second = reader
+        .lookup("あい", 10)
+        .expect("lookup after second record must succeed");
+    assert_eq!(second.len(), 1);
+    let t2 = second[0].last_used_at;
+
+    assert!(
+        t2 > t1,
+        "duplicate UPSERT must advance last_used_at: t1={t1}, t2={t2}"
+    );
+    assert_eq!(
+        second[0].frequency, 2,
+        "duplicate UPSERT must increment frequency by 1"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test 5: lookup tie-break on last_used_at DESC (Phase B reviewer gap fill)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Phase B reviewer 指摘の content gap を Phase D で吸収する。
+///
+/// `LOOKUP_SQL` の `ORDER BY frequency DESC, last_used_at DESC` のうち、
+/// 二次キー `last_used_at DESC` 経路を直接検証する。既存 unit test
+/// `lookup_orders_by_frequency_desc` は frequency 一次キーのみ確認しており、
+/// frequency tie 時の last_used_at tie-break path を検証していない。
+///
+/// 本 test は次の 3 entry を準備する:
+/// - A: frequency=2, last_used_at = t_A
+/// - B: frequency=2, last_used_at = t_B (> t_A)
+/// - C: frequency=1, last_used_at = t_C (> t_B)
+///
+/// 期待される lookup 順序: B → A → C
+/// (一次キー frequency DESC で {A,B} > C、frequency tie の {A,B} 内では
+///  二次キー last_used_at DESC で B > A)。
+#[test]
+fn lookup_orders_by_frequency_desc_then_last_used_at_desc() {
+    let (_db, reader, writer) = open_factory_pair();
+
+    // Step 1: A を 1 回 record(frequency=1, last_used_at=t0)。
+    writer
+        .record_choice("おなじ", "Aかんじ")
+        .expect("record A first time");
+
+    // Step 2: 1 秒以上 sleep してから B を 1 回 record(frequency=1, last_used_at=t1 > t0)。
+    thread::sleep(Duration::from_millis(1100));
+    writer
+        .record_choice("おなじ", "Bかんじ")
+        .expect("record B first time");
+
+    // Step 3: 1 秒以上 sleep してから A を 2 回目 record
+    // (UPSERT で frequency=2 / last_used_at=t2 > t1)。
+    thread::sleep(Duration::from_millis(1100));
+    writer
+        .record_choice("おなじ", "Aかんじ")
+        .expect("record A second time");
+
+    // Step 4: 1 秒以上 sleep してから B を 2 回目 record
+    // (UPSERT で frequency=2 / last_used_at=t3 > t2)。
+    thread::sleep(Duration::from_millis(1100));
+    writer
+        .record_choice("おなじ", "Bかんじ")
+        .expect("record B second time");
+
+    // Step 5: 1 秒以上 sleep してから C を 1 回だけ record(frequency=1, last_used_at=t4 > t3)。
+    thread::sleep(Duration::from_millis(1100));
+    writer
+        .record_choice("おなじ", "Cかんじ")
+        .expect("record C only once");
+
+    // 結果: A.freq=2 (t2), B.freq=2 (t3), C.freq=1 (t4)
+    // 期待 lookup 順序: B (freq=2, t3) → A (freq=2, t2) → C (freq=1, t4)
+    let results = reader.lookup("おなじ", 10).expect("lookup must succeed");
+
+    assert_eq!(
+        results.len(),
+        3,
+        "expected exactly 3 distinct chosen_kanji entries"
+    );
+    assert_eq!(
+        results[0].chosen_kanji, "Bかんじ",
+        "first result must be the higher-frequency entry with the most recent last_used_at"
+    );
+    assert_eq!(results[0].frequency, 2);
+
+    assert_eq!(
+        results[1].chosen_kanji, "Aかんじ",
+        "second result must be the higher-frequency entry with the older last_used_at (tie-break)"
+    );
+    assert_eq!(results[1].frequency, 2);
+
+    assert_eq!(
+        results[2].chosen_kanji, "Cかんじ",
+        "third result must be the lower-frequency entry"
+    );
+    assert_eq!(results[2].frequency, 1);
+}

--- a/docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md
+++ b/docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md
@@ -1,0 +1,3520 @@
+# Phase 2-C — LearningCache 本実装 + arch-M-2 ISP split 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** P2-B で skeleton として配置した `LearningCacheStore` の 3 method を `SqliteLearningCacheStore` に本実装し、同時に arch-M-2(ISP split: Reader/Writer 分離)を消化する。
+
+**Architecture:** kotoha-storage 内で `UserVocabStore` / `LearningCacheStore` を 4 trait(`*Reader` / `*Writer`)に分割、`Database` factory を 4 method 化、`SqliteLearningCacheStore` に UPSERT(`ON CONFLICT DO UPDATE`)+ 自動 LRU eviction(`evict_to_cap` 共通 helper)+ exact-match lookup を実装し、v002 migration で `idx_learning_cache_last_used` を追加する。Branch Scope Policy 20 file / 1000 line 上限を意識した単一 PR を目指す。
+
+**Tech Stack:** Rust 1.80(edition 2021)、rusqlite 0.32(bundled)、proptest、tempfile、Cargo workspace、lefthook、cargo-audit
+
+---
+
+## 全体構成
+
+| Phase | 内容 | 推定 | task 数 |
+|---|---|---|---|
+| P2-C-A | UserVocab ISP split 先行(機械換装、退行ゼロ) | ~1 day | 8 |
+| P2-C-B | LearningCache 本実装(UPSERT + auto eviction + lookup) | ~1 day | 11 |
+| P2-C-C | v002 migration + idx_learning_cache_last_used | 半日 | 3 |
+| P2-C-D | test 整備(L1 23 unit + L2 3 integration + proptest 3 invariant) | ~1 day | 4 |
+| P2-C-E | review fix + WBS + PR | 半日〜1 day | 7 |
+
+合計 33 task、~3-4 day。Branch Scope Policy 20 file / 1000 line 内に収める。
+
+## File 構造マッピング(Phase 着地後)
+
+**Modify:**
+- `crates/kotoha-storage/src/user_vocab/store.rs`(trait split: `UserVocabStore` → `UserVocabReader` + `UserVocabWriter`)
+- `crates/kotoha-storage/src/user_vocab/sqlite.rs`(両 trait impl 分離)
+- `crates/kotoha-storage/src/user_vocab/mock.rs`(両 trait impl 分離)
+- `crates/kotoha-storage/src/learning_cache/mod.rs`(trait split: `LearningCacheStore` → `LearningCacheReader` + `LearningCacheWriter`)
+- `crates/kotoha-storage/src/learning_cache/sqlite.rs`(stub → 本実装)
+- `crates/kotoha-storage/src/database.rs`(factory 2 → 4 method、旧 method 削除)
+- `crates/kotoha-storage/src/migrations.rs`(MIGRATIONS array に v002 追加、LATEST_VERSION = 2)
+- `crates/kotoha-core/src/dict/user_vocab.rs`(依存 trait を `UserVocabStore` → `UserVocabReader` に変更)
+- `crates/kotoha-cli/src/dict_cli.rs`(依存 trait を `UserVocabStore` → `UserVocabReader` + `UserVocabWriter` に変更)
+- `crates/kotoha-cli/src/bin/dict.rs`(factory 呼出し `user_vocab_store()` → `user_vocab_reader()` / `user_vocab_writer()` に変更)
+- `crates/kotoha-core/tests/dict_user_vocab.rs`(factory/trait 変更に追従)
+- `crates/kotoha-cli/tests/dict_cli.rs`(factory 変更に追従)
+
+**Create:**
+- `crates/kotoha-storage/migrations/v002_learning_cache_index.sql`
+- `crates/kotoha-storage/tests/learning_cache_store.rs`(L2 integration、新規)
+- `crates/kotoha-storage/tests/learning_cache_proptest.rs`(proptest、新規)
+- `docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md`(WBS、P2-C-E で作成)
+
+## 共通実装規約
+
+- **TDD**: red → green → commit を最小単位とする
+- **commit boundary**: 1 task 1 commit 原則(step 内で複数 commit が必要な場合は step 内で明示)
+- **test 退行禁止**: 各 phase の最後で `cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict-persist` を実行し全 PASS 確認
+- **lefthook gate**: phase 切替時に `lefthook run pre-push --commands rust-test-default,rust-test-dict,rust-test-dict-persist` で 3 構成 PASS を確認
+- **doc comment**: 新設 pub trait method には Preconditions / Postconditions / Errors を `///` で記載(global CLAUDE.md `lang-rust.md` 厳守)
+- **subagent dispatch 時の verbatim output 要求**: 大規模 task を subagent に dispatch する場合、subagent prompt で「最終 verification command の出力 head/tail 5 行を verbatim で報告」を必須化(global CLAUDE.md「Sub-agent Self-Report is Untrusted」)
+- **commit message 言語**: 英語(global CLAUDE.md 例外、Kotoha プロジェクト規約)、issue ref `Refs: #105` を末尾付与
+
+---
+
+## Phase P2-C-A: UserVocab ISP split
+
+ISP split は LearningCache 本実装の前提条件である。`UserVocabStore` を `UserVocabReader` / `UserVocabWriter` の 2 trait に分割し、全 consumer を書換える。本 Phase 完了時点でビルドエラーゼロ・退行ゼロを必須とする。
+
+### Task A1: `UserVocabReader` / `UserVocabWriter` trait 分割(`store.rs`)
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/user_vocab/store.rs`
+
+- [ ] **Step 1: 旧 `UserVocabStore` trait 全体を削除し、`UserVocabReader` / `UserVocabWriter` の 2 trait と `UserVocabRecord` struct に置換する**
+
+`crates/kotoha-storage/src/user_vocab/store.rs` の全内容を以下に置換する。
+
+```rust
+//! `UserVocabReader` / `UserVocabWriter` trait + `UserVocabRecord`
+//! (arch-M-2 ISP split、spec §3.2 / §6.1 / §6.2)。
+
+use crate::error::StorageError;
+
+/// User vocabulary の read 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `reading` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+///
+/// # Postconditions
+///
+/// - `find_by_reading` は `score DESC` 順で最大 `limit` 件返す
+/// - `find_by_prefix` は `score DESC` 順で最大 `limit` 件返す
+/// - `find_by_id` は不在の場合 `Ok(None)` を返す(エラーではない)
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: `reading` が validation 違反の場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait UserVocabReader: Send + Sync {
+    /// `reading` が完全一致する entry を `score DESC` 順で返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `reading` はひらがな canonical
+    /// - `limit` は呼び出し元が必要な件数の上限を示す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `reading` が hiragana 以外を含む場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn find_by_reading(
+        &self,
+        reading: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError>;
+
+    /// 主キー `id` で entry 1 件を引く。
+    ///
+    /// # Postconditions
+    ///
+    /// - 不在の場合は `Ok(None)` を返す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError>;
+
+    /// `reading` が `reading_prefix` で前方一致する entry を `score DESC` 順で返す。
+    ///
+    /// SQL `reading LIKE 'PREFIX%'` を使用する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `reading_prefix` はひらがな canonical
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `reading_prefix` が validation 違反の場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn find_by_prefix(
+        &self,
+        reading_prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError>;
+
+    /// 全 entry を `id ASC` 順でページネーション付きで返す。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError>;
+}
+
+/// User vocabulary の write 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `record.surface` / `record.reading` / `record.pos` / `record.score` は各 validation を通過
+///
+/// # Postconditions
+///
+/// - `insert` 成功時は採番された `id` を返す
+/// - UNIQUE(surface, reading) 違反は [`StorageError::DuplicateEntry`]
+/// - `delete_by_id` / `delete_by_surface_reading` の対象不在は [`StorageError::NotFound`]
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: validation 違反の場合
+/// - [`StorageError::DuplicateEntry`]: UNIQUE 制約違反の場合
+/// - [`StorageError::NotFound`]: 削除対象が存在しない場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait UserVocabWriter: Send + Sync {
+    /// `record` を `user_vocab` table に insert し、採番された `id` を返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `record.surface` / `record.reading` / `record.pos` は各 validate_* を通過
+    /// - `record.score` は finite + non-negative
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は `AUTOINCREMENT` で採番された `id`
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: field validation 違反の場合
+    /// - [`StorageError::DuplicateEntry`]: UNIQUE(surface, reading) 違反の場合
+    /// - [`StorageError::QuotaExceeded`]: 行数が `USER_VOCAB_MAX_ROWS` に到達している場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn insert(&self, record: UserVocabRecord) -> Result<i64, StorageError>;
+
+    /// 主キー `id` で entry を 1 件削除する。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`]: `id` が存在しない場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn delete_by_id(&self, id: i64) -> Result<(), StorageError>;
+
+    /// `(surface, reading)` で entry を 1 件削除する。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`]: 対象 entry が存在しない場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn delete_by_surface_reading(&self, surface: &str, reading: &str) -> Result<(), StorageError>;
+}
+
+/// User vocabulary の row。
+///
+/// # Invariants
+///
+/// - `id` は insert 前は `None`、DB から取得した場合は `Some`
+/// - `score` は finite + non-negative(`validate_score` 通過後に保証)
+/// - `created_at` / `updated_at` は UNIX epoch seconds
+#[derive(Debug, Clone, PartialEq)]
+pub struct UserVocabRecord {
+    /// insert 前は None、find / list は Some。
+    pub id: Option<i64>,
+    pub surface: String,
+    pub reading: String,
+    pub pos: String,
+    pub score: f32,
+    /// UNIX epoch seconds。
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_vocab_record_holds_all_fields() {
+        let r = UserVocabRecord {
+            id: Some(1),
+            surface: "日野岡".to_string(),
+            reading: "ひのおか".to_string(),
+            pos: "名詞-固有名詞-人名".to_string(),
+            score: 1.0,
+            created_at: 1745529600,
+            updated_at: 1745529600,
+        };
+        assert_eq!(r.id, Some(1));
+        assert_eq!(r.surface, "日野岡");
+    }
+
+    #[test]
+    fn user_vocab_record_clone_preserves_fields() {
+        let r = UserVocabRecord {
+            id: None,
+            surface: "test".to_string(),
+            reading: "てすと".to_string(),
+            pos: "名詞".to_string(),
+            score: 0.5,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let c = r.clone();
+        assert_eq!(r, c);
+    }
+
+    #[test]
+    fn user_vocab_record_partial_eq_works() {
+        let a = UserVocabRecord {
+            id: Some(1),
+            surface: "a".to_string(),
+            reading: "あ".to_string(),
+            pos: "p".to_string(),
+            score: 0.0,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+        let c = UserVocabRecord {
+            id: Some(2),
+            ..a.clone()
+        };
+        assert_ne!(a, c);
+    }
+}
+```
+
+- [ ] **Step 2: commit**
+
+```bash
+git add crates/kotoha-storage/src/user_vocab/store.rs
+git commit -m "refactor(storage): split UserVocabStore into UserVocabReader + UserVocabWriter (arch-M-2)
+
+Refs: #105"
+```
+
+---
+
+### Task A2: `SqliteUserVocabStore` の trait impl 分離(`sqlite.rs`)
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/user_vocab/sqlite.rs`
+
+- [ ] **Step 1: import を `UserVocabStore` から `UserVocabReader` + `UserVocabWriter` に切り替え、`impl UserVocabStore for SqliteUserVocabStore` を 2 つの impl block に分割する**
+
+`sqlite.rs` の冒頭 import を以下に変更する。
+
+```rust
+use crate::user_vocab::store::{UserVocabReader, UserVocabRecord, UserVocabWriter};
+```
+
+旧 `impl UserVocabStore for SqliteUserVocabStore { ... }` の 1 ブロックを削除し、以下の 2 ブロックに置換する。
+
+```rust
+impl UserVocabReader for SqliteUserVocabStore {
+    fn find_by_reading(
+        &self,
+        reading: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError> {
+        validate_reading(reading)?;
+        let conn = self.db.lock_conn();
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, surface, reading, pos, score, created_at, updated_at \
+             FROM user_vocab \
+             WHERE reading = ?1 \
+             ORDER BY score DESC \
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![reading, limit as i64], |row| {
+            Ok(UserVocabRecord {
+                id: Some(row.get(0)?),
+                surface: row.get(1)?,
+                reading: row.get(2)?,
+                pos: row.get(3)?,
+                score: row.get::<_, f64>(4)? as f32,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError> {
+        let conn = self.db.lock_conn();
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, surface, reading, pos, score, created_at, updated_at \
+             FROM user_vocab WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query(rusqlite::params![id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(UserVocabRecord {
+                id: Some(row.get(0)?),
+                surface: row.get(1)?,
+                reading: row.get(2)?,
+                pos: row.get(3)?,
+                score: row.get::<_, f64>(4)? as f32,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn find_by_prefix(
+        &self,
+        reading_prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError> {
+        if !reading_prefix.is_empty() {
+            validate_reading(reading_prefix)?;
+        }
+        let conn = self.db.lock_conn();
+        let pattern = format!("{}%", reading_prefix);
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, surface, reading, pos, score, created_at, updated_at \
+             FROM user_vocab \
+             WHERE reading LIKE ?1 \
+             ORDER BY score DESC, id ASC \
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![pattern, limit as i64], |row| {
+            Ok(UserVocabRecord {
+                id: Some(row.get(0)?),
+                surface: row.get(1)?,
+                reading: row.get(2)?,
+                pos: row.get(3)?,
+                score: row.get::<_, f64>(4)? as f32,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError> {
+        let conn = self.db.lock_conn();
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, surface, reading, pos, score, created_at, updated_at \
+             FROM user_vocab \
+             ORDER BY id ASC \
+             LIMIT ?1 OFFSET ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![limit as i64, offset as i64], |row| {
+            Ok(UserVocabRecord {
+                id: Some(row.get(0)?),
+                surface: row.get(1)?,
+                reading: row.get(2)?,
+                pos: row.get(3)?,
+                score: row.get::<_, f64>(4)? as f32,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+}
+
+impl UserVocabWriter for SqliteUserVocabStore {
+    fn insert(&self, record: UserVocabRecord) -> Result<i64, StorageError> {
+        validate_surface(&record.surface)?;
+        validate_reading(&record.reading)?;
+        validate_pos(&record.pos)?;
+        validate_score(record.score)?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let created_at = if record.created_at == 0 { now } else { record.created_at };
+        let updated_at = if record.updated_at == 0 { now } else { record.updated_at };
+
+        let conn = self.db.lock_conn();
+        let max_rows = effective_max_rows();
+        {
+            let mut count_stmt =
+                conn.prepare_cached("SELECT EXISTS(SELECT 1 FROM user_vocab LIMIT 1 OFFSET ?1)")?;
+            let at_or_over_cap: i64 =
+                count_stmt.query_row(rusqlite::params![max_rows as i64 - 1], |r| r.get(0))?;
+            if at_or_over_cap != 0 {
+                return Err(StorageError::QuotaExceeded {
+                    table: "user_vocab".to_string(),
+                    max: max_rows,
+                });
+            }
+        }
+        let result = {
+            let mut insert_stmt = conn.prepare_cached(
+                "INSERT INTO user_vocab (surface, reading, pos, score, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )?;
+            insert_stmt.execute(rusqlite::params![
+                record.surface,
+                record.reading,
+                record.pos,
+                record.score as f64,
+                created_at,
+                updated_at,
+            ])
+        };
+        match result {
+            Ok(_) => Ok(conn.last_insert_rowid()),
+            Err(rusqlite::Error::SqliteFailure(e, _))
+                if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                Err(StorageError::DuplicateEntry {
+                    surface: record.surface,
+                    reading: record.reading,
+                })
+            }
+            Err(e) => Err(StorageError::Sqlite(e)),
+        }
+    }
+
+    fn delete_by_id(&self, id: i64) -> Result<(), StorageError> {
+        let conn = self.db.lock_conn();
+        let mut stmt = conn.prepare_cached("DELETE FROM user_vocab WHERE id = ?1")?;
+        let affected = stmt.execute(rusqlite::params![id])?;
+        if affected == 0 {
+            return Err(StorageError::NotFound);
+        }
+        Ok(())
+    }
+
+    fn delete_by_surface_reading(&self, surface: &str, reading: &str) -> Result<(), StorageError> {
+        validate_surface(surface)?;
+        validate_reading(reading)?;
+        let conn = self.db.lock_conn();
+        let mut stmt =
+            conn.prepare_cached("DELETE FROM user_vocab WHERE surface = ?1 AND reading = ?2")?;
+        let affected = stmt.execute(rusqlite::params![surface, reading])?;
+        if affected == 0 {
+            return Err(StorageError::NotFound);
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 2: `#[cfg(test)] mod tests` 内の helper `fresh_store` が `SqliteUserVocabStore` を直接使う部分はそのまま維持する。ただし test 内で `UserVocabStore` trait の method を呼ぶ箇所は、`UserVocabReader` / `UserVocabWriter` の各 method として呼び出す形で変更が不要(具体型に対して dereference で両 trait の method が利用可能)であることを `cargo check --workspace` で確認する**
+
+```bash
+cargo check --workspace
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/src/user_vocab/sqlite.rs
+git commit -m "refactor(storage): migrate SqliteUserVocabStore to UserVocabReader + UserVocabWriter impls
+
+Refs: #105"
+```
+
+---
+
+### Task A3: `MockUserVocabStore` の trait impl 分離(`mock.rs`)
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/user_vocab/mock.rs`
+
+- [ ] **Step 1: import を `UserVocabStore` から `UserVocabReader` + `UserVocabWriter` に切り替え、`impl UserVocabStore for MockUserVocabStore` を 2 つの impl block に分割する**
+
+`mock.rs` の冒頭 import を以下に変更する。
+
+```rust
+use crate::user_vocab::store::{UserVocabReader, UserVocabRecord, UserVocabWriter};
+```
+
+旧 `impl UserVocabStore for MockUserVocabStore { ... }` を削除し、以下の 2 ブロックに置換する。
+
+```rust
+impl UserVocabReader for MockUserVocabStore {
+    fn find_by_reading(
+        &self,
+        reading: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError> {
+        validate_reading(reading)?;
+        let records = self.records.lock().unwrap();
+        let mut filtered: Vec<UserVocabRecord> = records
+            .iter()
+            .filter(|r| r.reading == reading)
+            .cloned()
+            .collect();
+        filtered.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        filtered.truncate(limit);
+        Ok(filtered)
+    }
+
+    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError> {
+        let records = self.records.lock().unwrap();
+        Ok(records.iter().find(|r| r.id == Some(id)).cloned())
+    }
+
+    fn find_by_prefix(
+        &self,
+        reading_prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError> {
+        if !reading_prefix.is_empty() {
+            validate_reading(reading_prefix)?;
+        }
+        let records = self.records.lock().unwrap();
+        let mut filtered: Vec<UserVocabRecord> = records
+            .iter()
+            .filter(|r| r.reading.starts_with(reading_prefix))
+            .cloned()
+            .collect();
+        filtered.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        filtered.truncate(limit);
+        Ok(filtered)
+    }
+
+    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError> {
+        let records = self.records.lock().unwrap();
+        Ok(records.iter().skip(offset).take(limit).cloned().collect())
+    }
+}
+
+impl UserVocabWriter for MockUserVocabStore {
+    fn insert(&self, mut record: UserVocabRecord) -> Result<i64, StorageError> {
+        validate_surface(&record.surface)?;
+        validate_reading(&record.reading)?;
+        validate_pos(&record.pos)?;
+        validate_score(record.score)?;
+
+        let mut records = self.records.lock().unwrap();
+        let max_rows = crate::user_vocab::sqlite::effective_max_rows();
+        if records.len() >= max_rows {
+            return Err(StorageError::QuotaExceeded {
+                table: "user_vocab".to_string(),
+                max: max_rows,
+            });
+        }
+        if records
+            .iter()
+            .any(|r| r.surface == record.surface && r.reading == record.reading)
+        {
+            return Err(StorageError::DuplicateEntry {
+                surface: record.surface,
+                reading: record.reading,
+            });
+        }
+        let mut next_id = self.next_id.lock().unwrap();
+        let id = *next_id;
+        *next_id += 1;
+        record.id = Some(id);
+        records.push(record);
+        Ok(id)
+    }
+
+    fn delete_by_id(&self, id: i64) -> Result<(), StorageError> {
+        let mut records = self.records.lock().unwrap();
+        let before = records.len();
+        records.retain(|r| r.id != Some(id));
+        if records.len() == before {
+            return Err(StorageError::NotFound);
+        }
+        Ok(())
+    }
+
+    fn delete_by_surface_reading(&self, surface: &str, reading: &str) -> Result<(), StorageError> {
+        validate_surface(surface)?;
+        validate_reading(reading)?;
+        let mut records = self.records.lock().unwrap();
+        let before = records.len();
+        records.retain(|r| !(r.surface == surface && r.reading == reading));
+        if records.len() == before {
+            return Err(StorageError::NotFound);
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 2: `#[cfg(test)] mod tests` 内と `mod prop_tests` 内の `UserVocabStore` 使用箇所が存在しないことを確認する。`MockUserVocabStore` の各 test は具体型を直接使うため、trait import は不要**
+
+```bash
+cargo check --workspace
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/src/user_vocab/mock.rs
+git commit -m "refactor(storage): migrate MockUserVocabStore to UserVocabReader + UserVocabWriter impls
+
+Refs: #105"
+```
+
+---
+
+### Task A4: `Database` factory 4 method 化 + 旧 `user_vocab_store` 削除(`database.rs`)
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/database.rs`
+
+- [ ] **Step 1: 旧 `user_vocab_store` method と旧 `learning_cache_store` method を削除し、4 つの新 factory method を追加する**
+
+`database.rs` の以下の 2 method を削除する。
+
+```rust
+// 削除対象 (before)
+pub fn user_vocab_store(self: &Arc<Self>) -> Box<dyn crate::user_vocab::store::UserVocabStore> {
+    Box::new(crate::user_vocab::sqlite::SqliteUserVocabStore::new(
+        Arc::clone(self),
+    ))
+}
+
+pub fn learning_cache_store(
+    self: &Arc<Self>,
+) -> Box<dyn crate::learning_cache::LearningCacheStore> {
+    Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+        Arc::clone(self),
+    ))
+}
+```
+
+削除した位置に以下の 4 method を追加する。
+
+```rust
+/// `Arc<Database>` を `Box<dyn UserVocabReader>` として公開する。
+///
+/// # Postconditions
+///
+/// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持し、
+///   同一 `Database` から生成された他の factory の戻り値と同一 SQLite connection を共有する
+pub fn user_vocab_reader(
+    self: &Arc<Self>,
+) -> Box<dyn crate::user_vocab::store::UserVocabReader> {
+    Box::new(crate::user_vocab::sqlite::SqliteUserVocabStore::new(
+        Arc::clone(self),
+    ))
+}
+
+/// `Arc<Database>` を `Box<dyn UserVocabWriter>` として公開する。
+///
+/// # Postconditions
+///
+/// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持する
+pub fn user_vocab_writer(
+    self: &Arc<Self>,
+) -> Box<dyn crate::user_vocab::store::UserVocabWriter> {
+    Box::new(crate::user_vocab::sqlite::SqliteUserVocabStore::new(
+        Arc::clone(self),
+    ))
+}
+
+/// `Arc<Database>` を `Box<dyn LearningCacheReader>` として公開する。
+///
+/// # Postconditions
+///
+/// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+pub fn learning_cache_reader(
+    self: &Arc<Self>,
+) -> Box<dyn crate::learning_cache::LearningCacheReader> {
+    Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+        Arc::clone(self),
+    ))
+}
+
+/// `Arc<Database>` を `Box<dyn LearningCacheWriter>` として公開する。
+///
+/// # Postconditions
+///
+/// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+pub fn learning_cache_writer(
+    self: &Arc<Self>,
+) -> Box<dyn crate::learning_cache::LearningCacheWriter> {
+    Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+        Arc::clone(self),
+    ))
+}
+```
+
+- [ ] **Step 2: `database.rs` の `#[cfg(test)] mod tests` 内で旧 factory method を参照する 2 件の test を新 factory method に書換える**
+
+変更前後の diff を以下に示す。
+
+```rust
+// before (test: user_vocab_store_factory_returns_owned_box)
+let _store: Box<dyn crate::user_vocab::store::UserVocabStore> = db.user_vocab_store();
+
+// after
+let _store: Box<dyn crate::user_vocab::store::UserVocabReader> = db.user_vocab_reader();
+```
+
+```rust
+// before (test: user_vocab_store_factory_shares_arc)
+let store1 = db.user_vocab_store();
+let store2 = db.user_vocab_store();
+// ...
+store1.insert(r).expect("insert ok");
+let result = store2.find_by_reading("あ", 10).expect("find ok");
+
+// after: writer で insert、reader で find
+let store1 = db.user_vocab_writer();
+let store2 = db.user_vocab_reader();
+// ...
+store1.insert(r).expect("insert ok");
+let result = store2.find_by_reading("あ", 10).expect("find ok");
+```
+
+`parallel_inserts_via_arc_share_does_not_deadlock` test 内の `db.user_vocab_store()` は `db.user_vocab_writer()` に書換え、`store.insert(r)` / `store.list_all(100, 0)` の呼出し側も `UserVocabWriter` / `UserVocabReader` に分離する。具体的には `Arc::new(db.user_vocab_writer())` で writer を共有し、`list_all` 呼出しは `db.user_vocab_reader().list_all(...)` に変更する。
+
+- [ ] **Step 3: `cargo check --workspace` でビルドエラーがゼロであることを確認する**
+
+```bash
+cargo check --workspace
+```
+
+- [ ] **Step 4: commit**
+
+```bash
+git add crates/kotoha-storage/src/database.rs
+git commit -m "refactor(storage): replace user_vocab_store/learning_cache_store with 4-method factory (arch-M-2)
+
+Refs: #105"
+```
+
+---
+
+### Task A5: `kotoha-cli/src/dict_cli.rs` と `kotoha-cli/src/bin/dict.rs` 書換
+
+**Files:**
+- Modify: `crates/kotoha-cli/src/dict_cli.rs`
+- Modify: `crates/kotoha-cli/src/bin/dict.rs`
+
+- [ ] **Step 1: `dict_cli.rs` の `UserVocabStore` 依存を `UserVocabReader` / `UserVocabWriter` に分離する**
+
+`dict_cli.rs` の import を以下に変更する。
+
+```rust
+// before
+use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabStore};
+
+// after
+use kotoha_storage::user_vocab::store::{UserVocabReader, UserVocabRecord, UserVocabWriter};
+```
+
+`run_add` の引数型を変更する。
+
+```rust
+// before (line 163)
+pub fn run_add(store: &dyn UserVocabStore, args: &AddArgs, quiet: bool) -> Result<i32, String> {
+
+// after
+pub fn run_add(store: &dyn UserVocabWriter, args: &AddArgs, quiet: bool) -> Result<i32, String> {
+```
+
+`run_remove` の引数型を変更する。
+
+```rust
+// before (line 214)
+pub fn run_remove(
+    store: &dyn UserVocabStore,
+    args: &RemoveArgs,
+    quiet: bool,
+) -> Result<i32, String> {
+
+// after
+pub fn run_remove(
+    store: &dyn UserVocabWriter,
+    args: &RemoveArgs,
+    quiet: bool,
+) -> Result<i32, String> {
+```
+
+`run_list` の引数型を変更する。
+
+```rust
+// before (line 268)
+pub fn run_list(
+    store: &dyn UserVocabStore,
+    args: &ListArgs,
+    json_global: bool,
+) -> Result<i32, String> {
+
+// after
+pub fn run_list(
+    store: &dyn UserVocabReader,
+    args: &ListArgs,
+    json_global: bool,
+) -> Result<i32, String> {
+```
+
+`run_show` の引数型を変更する。
+
+```rust
+// before (line 344)
+pub fn run_show(
+    store: &dyn UserVocabStore,
+    args: &ShowArgs,
+    json_global: bool,
+) -> Result<i32, String> {
+
+// after
+pub fn run_show(
+    store: &dyn UserVocabReader,
+    args: &ShowArgs,
+    json_global: bool,
+) -> Result<i32, String> {
+```
+
+- [ ] **Step 2: `bin/dict.rs` の `user_vocab_store()` 呼出しを reader / writer に分割し、各 subcommand に適切な trait object を渡す**
+
+`bin/dict.rs` の変更対象行(30〜39 行目)を以下のように書換える。
+
+```rust
+// before
+let store = db.user_vocab_store();
+
+let exit_code = match &cli.command {
+    Command::Add(args) => run_add(store.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL),
+    Command::Remove(args) => {
+        run_remove(store.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL)
+    }
+    Command::List(args) => run_list(store.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
+    Command::Show(args) => run_show(store.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
+};
+
+// after
+let reader = db.user_vocab_reader();
+let writer = db.user_vocab_writer();
+
+let exit_code = match &cli.command {
+    Command::Add(args) => run_add(writer.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL),
+    Command::Remove(args) => {
+        run_remove(writer.as_ref(), args, cli.quiet).unwrap_or(EXIT_INTERNAL)
+    }
+    Command::List(args) => run_list(reader.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
+    Command::Show(args) => run_show(reader.as_ref(), args, cli.json).unwrap_or(EXIT_INTERNAL),
+};
+```
+
+- [ ] **Step 3: `cargo check --workspace` でビルドエラーがゼロであることを確認する**
+
+```bash
+cargo check --workspace
+```
+
+- [ ] **Step 4: commit**
+
+```bash
+git add crates/kotoha-cli/src/dict_cli.rs crates/kotoha-cli/src/bin/dict.rs
+git commit -m "refactor(cli): adapt dict_cli.rs and bin/dict.rs to UserVocabReader/Writer split
+
+Refs: #105"
+```
+
+---
+
+### Task A6: `kotoha-core/src/dict/user_vocab.rs` 書換
+
+**Files:**
+- Modify: `crates/kotoha-core/src/dict/user_vocab.rs`
+
+- [ ] **Step 1: `UserVocabStore` 依存を `UserVocabReader` に変更する**
+
+`user_vocab.rs` の変更対象箇所を以下のように書換える。
+
+```rust
+// before (line 3)
+use kotoha_storage::user_vocab::store::UserVocabStore;
+
+// after
+use kotoha_storage::user_vocab::store::UserVocabReader;
+```
+
+```rust
+// before (line 7〜9)
+/// User-managed vocabulary、`Box<dyn UserVocabStore>` に依存(DIP、spec §4.2)。
+pub struct UserVocab {
+    store: Box<dyn UserVocabStore>,
+
+// after
+/// User-managed vocabulary、`Box<dyn UserVocabReader>` に依存(DIP、spec §4.2)。
+pub struct UserVocab {
+    store: Box<dyn UserVocabReader>,
+```
+
+```rust
+// before (line 14〜16)
+/// `Box<dyn UserVocabStore>` を inject して構築する。
+pub fn new(store: Box<dyn UserVocabStore>) -> Self {
+
+// after
+/// `Box<dyn UserVocabReader>` を inject して構築する。
+///
+/// # Preconditions
+///
+/// - `store` は `UserVocabReader` を実装した任意の backend を受け付ける
+pub fn new(store: Box<dyn UserVocabReader>) -> Self {
+```
+
+`#[cfg(test)] mod tests` 内の `use kotoha_storage::user_vocab::mock::MockUserVocabStore;` の行は変更不要(`MockUserVocabStore` が `UserVocabReader` を impl しているため、`Box::new(MockUserVocabStore::new())` は `Box<dyn UserVocabReader>` として渡せる)。
+
+- [ ] **Step 2: `crates/kotoha-core/tests/dict_user_vocab.rs` の `UserVocabStore` 参照を `UserVocabReader` / `UserVocabWriter` に変更する**
+
+```rust
+// before (line 7)
+use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabStore};
+
+// after
+use kotoha_storage::user_vocab::store::{UserVocabRecord, UserVocabWriter};
+```
+
+`seed` 関数の引数型を変更する。
+
+```rust
+// before (line 9)
+fn seed(mock: &MockUserVocabStore, surface: &str, reading: &str, score: f32) {
+    mock.insert(UserVocabRecord { ... }).unwrap();
+}
+
+// after: MockUserVocabStore が UserVocabWriter を impl しているため、
+// 関数内の mock.insert() 呼出しは型変更なしに動作する。
+// ただし `UserVocab::new(mock)` の引数型が `Box<dyn UserVocabReader>` になるため、
+// test 内の mock 生成を以下のように変更する。
+```
+
+各 test 内で `Box::new(MockUserVocabStore::new())` を `UserVocab::new` に渡す箇所はそのまま動作する。`seed` 関数が `&MockUserVocabStore` を受けて直接 `insert` を呼ぶ箇所も、`MockUserVocabStore` が `UserVocabWriter` を impl しているため変更不要。ただし `UserVocabStore` の import だけ削除し、`UserVocabWriter` は `seed` 内の `mock.insert()` 呼出しに必要なため明示 import が必要かどうか `cargo check` で確認する。
+
+```bash
+cargo check --workspace
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-core/src/dict/user_vocab.rs crates/kotoha-core/tests/dict_user_vocab.rs
+git commit -m "refactor(core): update UserVocab to depend on UserVocabReader (ISP, arch-M-2)
+
+Refs: #105"
+```
+
+---
+
+### Task A7: `kotoha-cli/tests/dict_cli.rs` 書換
+
+**Files:**
+- Modify: `crates/kotoha-cli/tests/dict_cli.rs`
+
+- [ ] **Step 1: `kotoha-cli/tests/dict_cli.rs` は binary `kotoha-dict` を `assert_cmd::Command` 経由で起動するため、factory API 変更の影響は `bin/dict.rs` 側で既に吸収済である。`dict_cli.rs` test ファイル自体は trait 名を直接参照していないことを確認し、`cargo check --workspace --features kotoha-cli/dict-persist` が通ることだけ検証する**
+
+```bash
+cargo check --workspace
+```
+
+もし `dict_cli.rs` test 内で `UserVocabStore` を直接参照する行が存在する場合は、`UserVocabReader` / `UserVocabWriter` に差し替える。現行ファイルには直接参照は存在しないため変更不要。
+
+- [ ] **Step 2: commit(変更なしの場合はスキップし、Task A8 に進む)**
+
+変更が発生した場合のみ commit する。
+
+```bash
+git add crates/kotoha-cli/tests/dict_cli.rs
+git commit -m "refactor(cli-test): adapt dict_cli integration tests to ISP split factory
+
+Refs: #105"
+```
+
+---
+
+### Task A8: Phase A 退行ゼロ確認
+
+**Files:**
+- (変更なし、確認のみ)
+
+- [ ] **Step 1: `kotoha-storage` の `lib.rs` が `UserVocabStore` を pub re-export している場合は削除し、`UserVocabReader` / `UserVocabWriter` を pub re-export するよう更新する**
+
+`kotoha-storage/src/lib.rs` 内の `pub use user_vocab::store::UserVocabStore` の行が存在する場合は削除する。`UserVocabReader` / `UserVocabWriter` / `UserVocabRecord` を re-export する行を追加する。
+
+```bash
+grep -n "UserVocabStore" /home/kohshiro/develops/student/kotoha-ime/crates/kotoha-storage/src/lib.rs
+```
+
+- [ ] **Step 2: `cargo clippy --workspace --all-targets -- -D warnings` を実行し、警告ゼロを確認する**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+- [ ] **Step 3: `cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict-persist` を実行し、P2-B baseline 355 件以上 PASS を確認する。実行結果の head/tail 各 10 行を verbatim で記録する**
+
+```bash
+cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict-persist 2>&1 | tee /tmp/p2c-a-test-result.txt
+head -10 /tmp/p2c-a-test-result.txt
+tail -10 /tmp/p2c-a-test-result.txt
+```
+
+- [ ] **Step 4: commit(clippy / test の両方が PASS した場合のみ)**
+
+```bash
+git add -u
+git commit -m "chore(storage): verify Phase A ISP split — zero regression, all tests PASS
+
+Refs: #105"
+```
+
+---
+
+## Phase P2-C-B: LearningCache 本実装
+
+Phase A の ISP split が完了していることを前提とする。本 Phase では `LearningCacheReader` / `LearningCacheWriter` trait の本実装を TDD サイクル(red → green)で進め、cap const + RAII guard による eviction 制御を組み込む。最終 task B11 で `Database` factory を整備し、旧 `learning_cache_store()` を削除する。
+
+---
+
+### Task B1: `LearningCacheReader` / `LearningCacheWriter` trait 分割(`learning_cache/mod.rs`)
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/learning_cache/mod.rs`
+
+- [ ] **Step 1: `mod.rs` を以下の内容に全体置換する**
+
+旧 `LearningCacheStore` trait と旧 `LearningCacheRecord` struct を削除し、`LearningCacheReader` / `LearningCacheWriter` / `LearningCacheRecord` を定義する。
+
+```rust
+//! `crates/kotoha-storage/src/learning_cache/mod.rs`
+//! LearningCacheReader / LearningCacheWriter trait(spec §3.1、P2-C 本実装)。
+
+pub mod sqlite;
+
+pub use sqlite::SqliteLearningCacheStore;
+
+use crate::error::StorageError;
+
+/// Learning cache の read 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+/// - `limit` は 0 より大きい値を推奨する(0 を渡した場合は空 `Vec` を返す)
+///
+/// # Postconditions
+///
+/// - `lookup` の戻り値は `frequency DESC, last_used_at DESC` 順に `limit` 件以下を含む
+/// - 該当 entry が存在しない場合は `Ok(Vec::new())` を返し、`Err` は返さない
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: `kana_input` が validation 違反の場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait LearningCacheReader: Send + Sync {
+    /// `kana_input` に対応する変換候補を `frequency DESC, last_used_at DESC` 順で返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+    /// - `limit` は呼び出し元が必要な件数の上限を示す
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の長さは `limit` 以下
+    /// - 戻り値の `frequency` は先頭 ≥ 末尾(単調非増加、同値は `last_used_at DESC` で整列)
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `kana_input` が hiragana 以外の文字を含む場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use kotoha_storage::learning_cache::LearningCacheReader;
+    /// # fn doc(reader: &dyn LearningCacheReader) -> Result<(), Box<dyn std::error::Error>> {
+    /// let results = reader.lookup("ちょうかん", 5)?;
+    /// // results[0].frequency >= results[1].frequency (先頭が最多)
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn lookup(
+        &self,
+        kana_input: &str,
+        limit: usize,
+    ) -> Result<Vec<LearningCacheRecord>, StorageError>;
+}
+
+/// Learning cache の write 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+/// - `chosen_kanji` は non-empty / ≤256 bytes / no control char / no bidi / no disallowed PUA
+///
+/// # Postconditions
+///
+/// - `record_choice` 成功後は該当 `(kana_input, chosen_kanji)` の `frequency` が 1 以上増加し、
+///   `last_used_at` が現在時刻(UNIX epoch seconds)以上の値に更新される
+/// - `record_choice` 成功後にキャッシュ行数が cap を超えた場合、`last_used_at` が最も古い entry
+///   から順に削除され、行数が cap に収まる状態を保つ
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: validation 違反の場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait LearningCacheWriter: Send + Sync {
+    /// ユーザの変換選択を `learning_cache` table に記録する。
+    ///
+    /// `(kana_input, chosen_kanji)` が既存の場合は `frequency += 1` かつ
+    /// `last_used_at` を現在時刻に更新する。新規の場合は `frequency = 1` で insert する。
+    /// insert / update 後に行数が cap を超えた場合は `last_used_at` が最も古い entry を
+    /// 自動的に削除し、行数を cap 以内に収める。
+    ///
+    /// # Preconditions
+    ///
+    /// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+    /// - `chosen_kanji` は validate_surface の制約を満たす(non-empty / ≤256 bytes /
+    ///   no control char / no bidi / no disallowed PUA)
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値 `Ok(())` の時点でトランザクションがコミットされている
+    /// - 行数は `effective_max_rows()` 以下を維持する
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `kana_input` / `chosen_kanji` が validation 違反
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害(disk full / SQLITE_BUSY など)
+    fn record_choice(&self, kana_input: &str, chosen_kanji: &str) -> Result<(), StorageError>;
+
+    /// `learning_cache` table から LRU(最終使用が最も古い)entry を削除して行数を `max_entries` 以内に収める。
+    ///
+    /// 呼び出し元が明示的に eviction を要求する場合に使用する。
+    /// 通常の record_choice では内部で `effective_max_rows()` を cap として自動 eviction が動作するため、
+    /// 本 method を明示呼び出しする必要は少ない。本 method は test / 手動 GC /
+    /// Phase 5 personalization での動的 cap 変更を想定して `max_entries` 引数を維持する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `max_entries` は 1 以上を推奨する(0 を渡した場合は全行削除が発生する)
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は削除した行数を示す
+    /// - 行数が `max_entries` 以下の場合は削除を行わず `Ok(0)` を返す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn evict_lru(&self, max_entries: usize) -> Result<usize, StorageError>;
+}
+
+/// Learning cache の 1 行を表す struct。
+///
+/// # Invariants
+///
+/// - `id` は DB 内の `INTEGER PRIMARY KEY AUTOINCREMENT` 値(DB から取得した場合のみ有効)
+/// - `frequency` は 1 以上(insert 時点で 1、以降 `record_choice` 毎に +1 される)
+/// - `last_used_at` は UNIX epoch seconds 形式の非負整数
+#[derive(Debug, Clone, PartialEq)]
+pub struct LearningCacheRecord {
+    /// `learning_cache.id`(DB 自動採番)。
+    pub id: i64,
+    /// 変換前のひらがな入力。
+    pub kana_input: String,
+    /// ユーザが選択した変換後文字列。
+    pub chosen_kanji: String,
+    /// `(kana_input, chosen_kanji)` の組合せが選ばれた累積回数。
+    pub frequency: u32,
+    /// 最後に選択された時刻(UNIX epoch seconds)。
+    pub last_used_at: i64,
+}
+```
+
+- [ ] **Step 2: `cargo clippy -p kotoha-storage -- -D warnings` を実行し、警告ゼロを確認する**
+
+```bash
+cargo clippy -p kotoha-storage -- -D warnings
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/mod.rs
+git commit -m "refactor(storage): split LearningCacheStore into Reader/Writer traits (ISP)
+
+Removes the monolithic LearningCacheStore trait and introduces
+LearningCacheReader / LearningCacheWriter following the Interface
+Segregation Principle. LearningCacheRecord is preserved verbatim.
+
+Refs: #105"
+```
+
+---
+
+### Task B2: TDD red — `lookup` 単体 test 4 件を記述する
+
+**Files:**
+- Test: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `sqlite.rs` の `#[cfg(test)] mod tests` 内に以下の 4 件の test 関数を追加する**
+
+既存の P2-B stub test 3 件(p2b_stub_*)はこの時点ではまだ残す。新規 test は stub impl に対して RED(失敗)になることを確認するための記述である。
+
+```rust
+// --- lookup tests (B2 red phase) ---
+
+fn fresh_store_b() -> SqliteLearningCacheStore {
+    let db = Database::open_in_memory().expect("memory open");
+    SqliteLearningCacheStore::new(db)
+}
+
+/// `lookup` は存在しない kana_input に対して空 Vec を返す。
+/// (B2) TDD red: stub は Ok(Vec::new()) を返すので本 test は PASS するが、
+/// B3 実装後も引き続き PASS することを確認する。
+#[test]
+fn lookup_returns_empty_for_unknown_kana() {
+    let store = fresh_store_b();
+    let result = store.lookup("みず", 10).expect("ok");
+    assert!(result.is_empty());
+}
+
+/// `lookup` は record_choice で記録した entry を返す。
+/// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
+#[test]
+fn lookup_returns_recorded_entry() {
+    let store = fresh_store_b();
+    store.record_choice("あい", "愛").expect("record ok");
+    let result = store.lookup("あい", 10).expect("ok");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].chosen_kanji, "愛");
+    assert_eq!(result[0].frequency, 1);
+}
+
+/// `lookup` は frequency DESC 順で複数 entry を返す。
+/// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
+#[test]
+fn lookup_orders_by_frequency_desc() {
+    let store = fresh_store_b();
+    // "愛" を 2 回、"哀" を 1 回記録する。
+    store.record_choice("あい", "愛").expect("record ok");
+    store.record_choice("あい", "愛").expect("record ok");
+    store.record_choice("あい", "哀").expect("record ok");
+    let result = store.lookup("あい", 10).expect("ok");
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].chosen_kanji, "愛"); // frequency=2
+    assert_eq!(result[1].chosen_kanji, "哀"); // frequency=1
+}
+
+/// `lookup` は limit を超えた件数を返さない。
+/// (B2) TDD red: stub は常に空 Vec を返すので本 test は FAIL する。
+#[test]
+fn lookup_respects_limit() {
+    let store = fresh_store_b();
+    store.record_choice("あい", "愛").expect("ok");
+    store.record_choice("あい", "哀").expect("ok");
+    store.record_choice("あい", "藍").expect("ok");
+    let result = store.lookup("あい", 2).expect("ok");
+    assert!(result.len() <= 2);
+}
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage learning_cache::sqlite::tests::lookup` を実行し、`lookup_returns_recorded_entry` / `lookup_orders_by_frequency_desc` / `lookup_respects_limit` が FAIL(red)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::lookup 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::lookup_returns_empty_for_unknown_kana ... ok
+test learning_cache::sqlite::tests::lookup_returns_recorded_entry ... FAILED
+test learning_cache::sqlite::tests::lookup_orders_by_frequency_desc ... FAILED
+test learning_cache::sqlite::tests::lookup_respects_limit ... FAILED
+```
+
+- [ ] **Step 3: commit(red phase 記録)**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "test(storage): add lookup unit tests — TDD red phase (B2)
+
+Four tests covering empty result, entry retrieval, frequency ordering,
+and limit enforcement. Three tests are currently FAIL (stub returns empty).
+
+Refs: #105"
+```
+
+---
+
+### Task B3: TDD green — `lookup` 本実装
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `sqlite.rs` に `LOOKUP_SQL` const と `LearningCacheReader` impl を追加する**
+
+```rust
+// lookup SQL(spec §4.3)
+const LOOKUP_SQL: &str =
+    "SELECT id, kana_input, chosen_kanji, frequency, last_used_at
+     FROM learning_cache
+     WHERE kana_input = ?1
+     ORDER BY frequency DESC, last_used_at DESC
+     LIMIT ?2";
+
+impl LearningCacheReader for SqliteLearningCacheStore {
+    fn lookup(
+        &self,
+        kana_input: &str,
+        limit: usize,
+    ) -> Result<Vec<LearningCacheRecord>, StorageError> {
+        use crate::validation::validate_reading;
+        validate_reading(kana_input)?;
+        let conn = self.db.lock_conn();
+        // perf-H1: prepare_cached により Phase 3 IBus engine の打鍵毎呼び出しでも
+        // SQL コンパイルを 1 度きりにする。
+        let mut stmt = conn.prepare_cached(LOOKUP_SQL)?;
+        let rows = stmt.query_map(rusqlite::params![kana_input, limit as i64], |row| {
+            Ok(LearningCacheRecord {
+                id: row.get(0)?,
+                kana_input: row.get(1)?,
+                chosen_kanji: row.get(2)?,
+                frequency: row.get::<_, u32>(3)?,
+                last_used_at: row.get(4)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+}
+```
+
+`LearningCacheReader` を `mod.rs` から import するため、`sqlite.rs` の use 宣言に以下を追加する。
+
+```rust
+use crate::learning_cache::{LearningCacheReader, LearningCacheRecord};
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage learning_cache::sqlite::tests::lookup` を実行し、4 件すべてが PASS(green)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::lookup 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::lookup_returns_empty_for_unknown_kana ... ok
+test learning_cache::sqlite::tests::lookup_returns_recorded_entry ... ok
+test learning_cache::sqlite::tests::lookup_orders_by_frequency_desc ... ok
+test learning_cache::sqlite::tests::lookup_respects_limit ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "feat(storage): implement LearningCacheReader::lookup (B3)
+
+Uses prepare_cached + LOOKUP_SQL (ORDER BY frequency DESC, last_used_at DESC
+LIMIT ?2). All 4 lookup unit tests now pass.
+
+Refs: #105"
+```
+
+---
+
+### Task B4: TDD red — `record_choice` 基本 UPSERT 単体 test 5 件を記述する
+
+**Files:**
+- Test: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `tests` mod に以下の 5 件の test 関数を追加する**
+
+eviction なし(cap は production の 10_000 行のままで、5 件 insert 程度では eviction が発生しない)前提で動作を検証する。
+
+```rust
+// --- record_choice tests (B4 red phase) ---
+
+/// `record_choice` は新規 entry を frequency=1 で insert する。
+/// (B4) TDD red: stub は Ok(()) を返すが lookup で空 Vec が返るので FAIL。
+#[test]
+fn record_choice_inserts_new_entry_with_frequency_one() {
+    let store = fresh_store_b();
+    store.record_choice("かわ", "川").expect("record ok");
+    let result = store.lookup("かわ", 10).expect("ok");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].chosen_kanji, "川");
+    assert_eq!(result[0].frequency, 1);
+}
+
+/// `record_choice` は同じ `(kana_input, chosen_kanji)` の重複呼び出しで frequency を +1 する。
+/// (B4) TDD red: stub は Ok(()) を返すが lookup で正しい frequency が返らない。
+#[test]
+fn record_choice_increments_frequency_on_duplicate() {
+    let store = fresh_store_b();
+    store.record_choice("かわ", "川").expect("1st ok");
+    store.record_choice("かわ", "川").expect("2nd ok");
+    let result = store.lookup("かわ", 10).expect("ok");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].frequency, 2);
+}
+
+/// `record_choice` は同じ kana_input でも chosen_kanji が異なる場合は別行として insert する。
+/// (B4) TDD red: stub は Ok(()) を返すが lookup で 1 件しか返らない。
+#[test]
+fn record_choice_separates_different_chosen_kanji() {
+    let store = fresh_store_b();
+    store.record_choice("かわ", "川").expect("ok");
+    store.record_choice("かわ", "河").expect("ok");
+    let result = store.lookup("かわ", 10).expect("ok");
+    assert_eq!(result.len(), 2);
+}
+
+/// `record_choice` 呼び出し後は `last_used_at` が 0 より大きい値になる。
+/// (B4) TDD red: stub は Ok(()) を返すが lookup で last_used_at=0 が返る。
+#[test]
+fn record_choice_sets_last_used_at_to_nonzero() {
+    let store = fresh_store_b();
+    store.record_choice("かわ", "川").expect("ok");
+    let result = store.lookup("かわ", 10).expect("ok");
+    assert!(!result.is_empty());
+    assert!(result[0].last_used_at > 0);
+}
+
+/// `record_choice` はひらがな以外の kana_input を拒否する。
+/// (B4) TDD red: stub は validation を行わないので Ok(()) を返し FAIL。
+#[test]
+fn record_choice_rejects_non_hiragana_kana_input() {
+    let store = fresh_store_b();
+    let err = store.record_choice("abc", "川").unwrap_err();
+    assert!(matches!(err, StorageError::InvalidField { .. }));
+}
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage learning_cache::sqlite::tests::record_choice` を実行し、上記 5 件の大部分が FAIL(red)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::record_choice 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::record_choice_inserts_new_entry_with_frequency_one ... FAILED
+test learning_cache::sqlite::tests::record_choice_increments_frequency_on_duplicate ... FAILED
+test learning_cache::sqlite::tests::record_choice_separates_different_chosen_kanji ... FAILED
+test learning_cache::sqlite::tests::record_choice_sets_last_used_at_to_nonzero ... FAILED
+test learning_cache::sqlite::tests::record_choice_rejects_non_hiragana_kana_input ... FAILED
+```
+
+- [ ] **Step 3: commit(red phase 記録)**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "test(storage): add record_choice unit tests — TDD red phase (B4)
+
+Five tests covering new insert, frequency increment, kanji separation,
+last_used_at timestamp, and validation rejection. All five currently FAIL.
+
+Refs: #105"
+```
+
+---
+
+### Task B5: TDD green — `record_choice` UPSERT 実装(eviction なし)
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `sqlite.rs` に `UPSERT_SQL` const と `LearningCacheWriter` の `record_choice` 実装を追加する**
+
+この段階では eviction 呼び出しを含まない。eviction は B8 で統合する。
+
+```rust
+use crate::learning_cache::{LearningCacheReader, LearningCacheRecord, LearningCacheWriter};
+use crate::validation::{validate_reading, validate_surface};
+
+// record_choice の UPSERT SQL(spec §4.2、SQLite 3.24+ ON CONFLICT UPSERT 構文)
+const UPSERT_SQL: &str =
+    "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+     VALUES (?1, ?2, 1, ?3)
+     ON CONFLICT(kana_input, chosen_kanji)
+     DO UPDATE SET
+         frequency     = frequency + 1,
+         last_used_at  = excluded.last_used_at";
+
+impl LearningCacheWriter for SqliteLearningCacheStore {
+    fn record_choice(&self, kana_input: &str, chosen_kanji: &str) -> Result<(), StorageError> {
+        validate_reading(kana_input)?;
+        validate_surface(chosen_kanji)?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let conn = self.db.lock_conn();
+        // perf-H1: prepare_cached により SQL コンパイルを 1 度きりにする。
+        let mut stmt = conn.prepare_cached(UPSERT_SQL)?;
+        stmt.execute(rusqlite::params![kana_input, chosen_kanji, now])?;
+        // NOTE: eviction は B8 でここに追加する。
+        Ok(())
+    }
+
+    fn evict_lru(&self, _max_entries: usize) -> Result<usize, StorageError> {
+        // B10 で実装する。
+        Ok(0)
+    }
+}
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage learning_cache::sqlite::tests::record_choice` を実行し、5 件すべてが PASS(green)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::record_choice 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::record_choice_inserts_new_entry_with_frequency_one ... ok
+test learning_cache::sqlite::tests::record_choice_increments_frequency_on_duplicate ... ok
+test learning_cache::sqlite::tests::record_choice_separates_different_chosen_kanji ... ok
+test learning_cache::sqlite::tests::record_choice_sets_last_used_at_to_nonzero ... ok
+test learning_cache::sqlite::tests::record_choice_rejects_non_hiragana_kana_input ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "feat(storage): implement record_choice UPSERT without eviction (B5)
+
+Uses ON CONFLICT(kana_input, chosen_kanji) DO UPDATE to increment
+frequency and update last_used_at. Eviction hook will be added in B8.
+
+Refs: #105"
+```
+
+---
+
+### Task B6: cap const + RAII guard 実装
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `sqlite.rs` の先頭(use 宣言の直後、`SqliteLearningCacheStore` struct 定義の前)に cap override 一式を追加する**
+
+P2-B `user_vocab/sqlite.rs` の `QuotaOverrideGuard` パターンを踏襲し、命名だけ `LearningCache` 用に変更する。
+
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Learning cache の行数上限(production 値、spec §4.6)。
+pub const LEARNING_CACHE_MAX_ROWS: usize = 10_000;
+
+/// テスト時の行数上限上書き(0 = unset、`LEARNING_CACHE_MAX_ROWS` を使用)。
+///
+/// `cargo test` ビルドでのみ意味を持ち、production binary には含まれない。
+/// 10,000 行を実際に挿入するテストは時間 / メモリの観点で非現実的なため、
+/// 単体テストはこの override を介して小さな上限値で eviction 動作を検証する。
+#[cfg(test)]
+pub(crate) static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
+
+/// override の直列化用 Mutex(複数 test が同時 override しないよう直列化)。
+#[cfg(test)]
+pub(crate) static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// 行数上限の effective value を返す(`#[cfg(test)]` 時のみ override を考慮)。
+///
+/// # Postconditions
+///
+/// - `#[cfg(not(test))]` 時は常に `LEARNING_CACHE_MAX_ROWS` を返す
+/// - `#[cfg(test)]` かつ override が 0 の場合は `LEARNING_CACHE_MAX_ROWS` を返す
+/// - `#[cfg(test)]` かつ override が 0 より大きい場合は override 値を返す
+#[inline]
+pub(crate) fn effective_max_rows() -> usize {
+    #[cfg(test)]
+    {
+        let v = LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.load(Ordering::SeqCst);
+        if v != 0 {
+            return v;
+        }
+    }
+    LEARNING_CACHE_MAX_ROWS
+}
+
+/// テスト中だけ `LEARNING_CACHE_MAX_ROWS` を `cap` に上書きする RAII guard。
+///
+/// drop 時に自動で 0(無効)に戻すので、test 同士の干渉を防ぐ。
+/// override は process 全体の static なため、複数 test が同時に
+/// override を活性化すると競合する。よって `CAP_OVERRIDE_LOCK` を
+/// 取得して直列化する。
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(test)]
+/// # fn example() {
+/// let _guard = CapOverrideGuard::new(5);
+/// // このブロック内では cap = 5 で動作する
+/// // _guard が drop されると cap = LEARNING_CACHE_MAX_ROWS に戻る
+/// # }
+/// ```
+#[cfg(test)]
+pub(crate) struct CapOverrideGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl CapOverrideGuard {
+    pub(crate) fn new(cap: usize) -> Self {
+        // poison していても続行(直前 test の panic でも次 test を回したい)。
+        let lock = CAP_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(cap, Ordering::SeqCst);
+        Self { _lock: lock }
+    }
+}
+
+#[cfg(test)]
+impl Drop for CapOverrideGuard {
+    fn drop(&mut self) {
+        LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(0, Ordering::SeqCst);
+    }
+}
+```
+
+- [ ] **Step 2: `cargo clippy -p kotoha-storage -- -D warnings` を実行し、警告ゼロを確認する**
+
+```bash
+cargo clippy -p kotoha-storage -- -D warnings
+```
+
+- [ ] **Step 3: `cargo test -p kotoha-storage learning_cache::sqlite::tests` を実行し、既存 test が引き続き PASS することを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests 2>&1
+```
+
+- [ ] **Step 4: commit**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "feat(storage): add LEARNING_CACHE_MAX_ROWS cap const + CapOverrideGuard RAII (B6)
+
+Mirrors the QuotaOverrideGuard pattern from user_vocab/sqlite.rs.
+Production cap is 10_000 rows; test override uses AtomicUsize + Mutex
+for serialization. effective_max_rows() selects the active limit.
+
+Refs: #105"
+```
+
+---
+
+### Task B7: TDD red — 自動 eviction の test 4 件を記述する
+
+**Files:**
+- Test: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `tests` mod に以下の 4 件の test 関数を追加する**
+
+各 test は `CapOverrideGuard` で cap を小さな値に設定し、eviction 動作を検証する。
+
+```rust
+// --- eviction tests (B7 red phase) ---
+
+/// cap 未満の行数では record_choice 後に削除が発生しない。
+/// (B7) TDD red: B5 実装は eviction を含まないので本 test は PASS する(eviction なし ⇒ 行数保持)。
+/// B8 実装後も PASS を維持することを確認する。
+#[test]
+fn eviction_does_not_occur_when_below_cap() {
+    let _guard = CapOverrideGuard::new(5);
+    let store = fresh_store_b();
+    // cap=5 に対して 3 件 insert する。
+    for kanji in ["愛", "哀", "藍"] {
+        store.record_choice("あい", kanji).expect("ok");
+    }
+    let result = store.lookup("あい", 10).expect("ok");
+    assert_eq!(result.len(), 3);
+}
+
+/// cap を 1 件超過した場合、LRU の 1 件が削除されて行数が cap に収まる。
+/// (B7) TDD red: B5 実装は eviction を含まないので insert 後に cap+1 件が残り FAIL する。
+#[test]
+fn eviction_removes_one_lru_entry_when_cap_exceeded_by_one() {
+    let _guard = CapOverrideGuard::new(3);
+    let store = fresh_store_b();
+    // 3 件 insert して cap ぴったりにする。
+    store.record_choice("あ", "亜").expect("ok");
+    store.record_choice("い", "以").expect("ok");
+    store.record_choice("う", "宇").expect("ok");
+    // 4 件目で cap を 1 超過する。最も ancient な "あ/亜" が evict されるべき。
+    store.record_choice("え", "江").expect("ok");
+    // 総行数が cap=3 以内に収まっていることを確認する。
+    let conn = store.db.lock_conn();
+    let total: i64 = conn
+        .query_row("SELECT count(*) FROM learning_cache", [], |r| r.get(0))
+        .unwrap();
+    assert!(total <= 3, "total={total} must be <= cap 3");
+}
+
+/// burst insert で行数が cap を超えない。
+/// (B7) TDD red: B5 実装は eviction を含まないので cap を超えた行数が残り FAIL する。
+#[test]
+fn eviction_keeps_row_count_bounded_on_burst_insert() {
+    let _guard = CapOverrideGuard::new(4);
+    let store = fresh_store_b();
+    // cap=4 に対して 10 件 insert する。
+    let kanjis = ["一", "二", "三", "四", "五", "六", "七", "八", "九", "十"];
+    for (i, kanji) in kanjis.iter().enumerate() {
+        let reading = char::from_u32(0x3041 + i as u32)
+            .expect("valid hiragana")
+            .to_string();
+        store.record_choice(&reading, kanji).expect("ok");
+    }
+    let conn = store.db.lock_conn();
+    let total: i64 = conn
+        .query_row("SELECT count(*) FROM learning_cache", [], |r| r.get(0))
+        .unwrap();
+    assert!(total <= 4, "total={total} must be <= cap 4 after burst");
+}
+
+/// LRU 保護: record_choice で update された entry は eviction 対象から外れる。
+/// (B7) TDD red: B5 実装は eviction を含まないので挙動を検証できず行数超過で FAIL する。
+#[test]
+fn eviction_protects_recently_updated_entry_from_lru() {
+    let _guard = CapOverrideGuard::new(2);
+    let store = fresh_store_b();
+    // "亜" を先に insert する(古い entry)。
+    store.record_choice("あ", "亜").expect("ok");
+    // "以" を後で insert する(新しい entry)。
+    store.record_choice("い", "以").expect("ok");
+    // "亜" を再度 record_choice して last_used_at を更新する。
+    store.record_choice("あ", "亜").expect("ok");
+    // 3 件目 insert で cap=2 を超える。"以" のほうが古いので evict される。
+    store.record_choice("う", "宇").expect("ok");
+    // "亜" は残っており、"以" は evict されている。
+    let result_a = store.lookup("あ", 10).expect("ok");
+    assert!(
+        !result_a.is_empty(),
+        "亜 must survive because it was recently updated"
+    );
+    let result_i = store.lookup("い", 10).expect("ok");
+    assert!(
+        result_i.is_empty(),
+        "以 must be evicted as the LRU entry"
+    );
+}
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage learning_cache::sqlite::tests::eviction` を実行し、cap 超過に関する test が FAIL(red)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::eviction 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::eviction_does_not_occur_when_below_cap ... ok
+test learning_cache::sqlite::tests::eviction_removes_one_lru_entry_when_cap_exceeded_by_one ... FAILED
+test learning_cache::sqlite::tests::eviction_keeps_row_count_bounded_on_burst_insert ... FAILED
+test learning_cache::sqlite::tests::eviction_protects_recently_updated_entry_from_lru ... FAILED
+```
+
+- [ ] **Step 3: commit(red phase 記録)**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "test(storage): add auto-eviction unit tests — TDD red phase (B7)
+
+Four tests covering: below-cap no-op, single-excess eviction,
+burst insert bounded, and LRU protection for recently-updated entries.
+Three tests are currently FAIL (no eviction in B5 impl).
+
+Refs: #105"
+```
+
+---
+
+### Task B8: TDD green — `evict_to_cap` 共通 helper 抽出 + `record_choice` 内自動 eviction 統合
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `sqlite.rs` に `COUNT_SQL` / `EVICT_SQL` const と `evict_to_cap` 共通 helper を追加する**
+
+`evict_to_cap` は `pub(crate)` とし、`record_choice` と `evict_lru` の両方から呼び出す。
+
+```rust
+// 総行数チェック SQL(spec §4.4)
+const COUNT_SQL: &str = "SELECT count(*) FROM learning_cache";
+
+// LRU 削除 SQL(spec §4.4)
+const EVICT_SQL: &str =
+    "DELETE FROM learning_cache
+     WHERE id IN (
+         SELECT id FROM learning_cache
+         ORDER BY last_used_at ASC, id ASC
+         LIMIT ?1
+     )";
+
+/// `learning_cache` の行数が `cap` を超えている場合、LRU から `count - cap` 行削除する。
+///
+/// # Preconditions
+///
+/// - `conn` は `lock_conn()` で取得済の `MutexGuard<Connection>`
+/// - `cap` は呼び出し元が指定する行数上限値。`record_choice` からは `effective_max_rows()` を渡し、
+///   `evict_lru` からは呼び出し元が引数として指定した `max_entries` を渡す
+///
+/// # Postconditions
+///
+/// - 戻り値は削除した行数
+/// - 行数 ≤ cap が保証される
+///
+/// # Errors
+///
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub(crate) fn evict_to_cap(
+    conn: &rusqlite::Connection,
+    cap: usize,
+) -> Result<usize, StorageError> {
+    let total: i64 = conn.query_row(COUNT_SQL, [], |r| r.get(0))?;
+    let total = total as usize;
+    if total <= cap {
+        return Ok(0);
+    }
+    let excess = total - cap;
+    let mut stmt = conn.prepare_cached(EVICT_SQL)?;
+    let deleted = stmt.execute(rusqlite::params![excess as i64])?;
+    Ok(deleted)
+}
+```
+
+- [ ] **Step 2: `LearningCacheWriter::record_choice` の末尾に eviction 呼び出しを追加する**
+
+B5 で追加した `record_choice` 実装の `// NOTE: eviction は B8 でここに追加する。` の行を以下に置き換える。
+
+```rust
+        // 行数が effective_max_rows() を超えた場合、LRU entry を自動削除する(spec §4.2)。
+        evict_to_cap(&conn, effective_max_rows())?;
+```
+
+- [ ] **Step 3: `cargo test -p kotoha-storage learning_cache::sqlite::tests::eviction` を実行し、4 件すべてが PASS(green)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::eviction 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::eviction_does_not_occur_when_below_cap ... ok
+test learning_cache::sqlite::tests::eviction_removes_one_lru_entry_when_cap_exceeded_by_one ... ok
+test learning_cache::sqlite::tests::eviction_keeps_row_count_bounded_on_burst_insert ... ok
+test learning_cache::sqlite::tests::eviction_protects_recently_updated_entry_from_lru ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured
+```
+
+- [ ] **Step 4: commit**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "feat(storage): extract evict_to_cap helper + integrate auto-eviction in record_choice (B8)
+
+evict_to_cap(conn, cap) counts rows and deletes excess LRU entries via
+ORDER BY last_used_at ASC, id ASC. record_choice now calls it with
+effective_max_rows() after each UPSERT. All 4 eviction tests pass.
+
+Refs: #105"
+```
+
+---
+
+### Task B9: TDD red — `evict_lru(max_entries)` 単体 test 3 件を記述する
+
+**Files:**
+- Test: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: `tests` mod に以下の 3 件の test 関数を追加する**
+
+`evict_lru` は `LearningCacheWriter` を経由して呼び出す。B5 の stub impl は `Ok(0)` を返すため、行数が cap を超えた場合に 0 を返す test は FAIL になる。
+
+```rust
+// --- evict_lru tests (B9 red phase) ---
+
+/// `evict_lru` は行数が max_entries 以下の場合 0 を返す。
+/// (B9) TDD red: stub は Ok(0) を返すので本 test は PASS する。B10 後も PASS を維持する。
+#[test]
+fn evict_lru_returns_zero_when_below_cap() {
+    let store = fresh_store_b();
+    store.record_choice("あ", "亜").expect("ok");
+    store.record_choice("い", "以").expect("ok");
+    // 行数 2 < max_entries=5 なので 0 が返る。
+    let deleted = store.evict_lru(5).expect("ok");
+    assert_eq!(deleted, 0);
+}
+
+/// `evict_lru` は超過分の行数を削除して削除件数を返す。
+/// (B9) TDD red: stub は Ok(0) を返すので行数が変化せず FAIL する。
+#[test]
+fn evict_lru_deletes_excess_entries_and_returns_count() {
+    let store = fresh_store_b();
+    // 5 件 insert する。
+    for kanji in ["亜", "以", "宇", "江", "尾"] {
+        let kana = match kanji {
+            "亜" => "あ",
+            "以" => "い",
+            "宇" => "う",
+            "江" => "え",
+            "尾" => "お",
+            _ => unreachable!(),
+        };
+        store.record_choice(kana, kanji).expect("ok");
+    }
+    // max_entries=3 で呼び出す。5-3=2 件削除される。
+    let deleted = store.evict_lru(3).expect("ok");
+    assert_eq!(deleted, 2);
+    let conn = store.db.lock_conn();
+    let total: i64 = conn
+        .query_row("SELECT count(*) FROM learning_cache", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(total, 3);
+}
+
+/// `evict_lru` は last_used_at が同値の場合 id ASC で tie-break する。
+/// (B9) TDD red: stub は Ok(0) を返すので削除されず FAIL する。
+#[test]
+fn evict_lru_uses_id_asc_as_tiebreak_for_same_last_used_at() {
+    let store = fresh_store_b();
+    // last_used_at を同値(0)に固定して 3 件 insert する。
+    {
+        let conn = store.db.lock_conn();
+        conn.execute(
+            "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+             VALUES ('あ', '亜', 1, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+             VALUES ('い', '以', 1, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+             VALUES ('う', '宇', 1, 0)",
+            [],
+        )
+        .unwrap();
+    }
+    // max_entries=1 で呼び出す。id の小さい順に 2 件が削除される。
+    let deleted = store.evict_lru(1).expect("ok");
+    assert_eq!(deleted, 2);
+    // 残っているのは id が最大の "う/宇" である。
+    let result = store.lookup("う", 10).expect("ok");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].chosen_kanji, "宇");
+}
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage learning_cache::sqlite::tests::evict_lru` を実行し、超過系 test が FAIL(red)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::evict_lru 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::evict_lru_returns_zero_when_below_cap ... ok
+test learning_cache::sqlite::tests::evict_lru_deletes_excess_entries_and_returns_count ... FAILED
+test learning_cache::sqlite::tests::evict_lru_uses_id_asc_as_tiebreak_for_same_last_used_at ... FAILED
+```
+
+- [ ] **Step 3: commit(red phase 記録)**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "test(storage): add evict_lru unit tests — TDD red phase (B9)
+
+Three tests: below-cap zero, excess deletion with count, and id ASC
+tie-break when last_used_at is equal. Two tests currently FAIL.
+
+Refs: #105"
+```
+
+---
+
+### Task B10: TDD green — `evict_lru(max_entries)` 実装
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/learning_cache/sqlite.rs`
+
+- [ ] **Step 1: B5 で追加した `LearningCacheWriter::evict_lru` stub を本実装に置き換える**
+
+`evict_to_cap` 共通 helper を `max_entries` を cap として呼び出す(spec §4.4)。
+
+```rust
+impl LearningCacheWriter for SqliteLearningCacheStore {
+    // ... record_choice は B8 で完成済み ...
+
+    fn evict_lru(&self, max_entries: usize) -> Result<usize, StorageError> {
+        let conn = self.db.lock_conn();
+        evict_to_cap(&conn, max_entries)
+    }
+}
+```
+
+B5 の stub `fn evict_lru(&self, _max_entries: usize) -> Result<usize, StorageError> { Ok(0) }` を上記で置き換える。
+
+- [ ] **Step 2: `cargo test -p kotoha-storage learning_cache::sqlite::tests::evict_lru` を実行し、3 件すべてが PASS(green)であることを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests::evict_lru 2>&1
+```
+
+期待する末尾出力(例):
+```
+test learning_cache::sqlite::tests::evict_lru_returns_zero_when_below_cap ... ok
+test learning_cache::sqlite::tests::evict_lru_deletes_excess_entries_and_returns_count ... ok
+test learning_cache::sqlite::tests::evict_lru_uses_id_asc_as_tiebreak_for_same_last_used_at ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured
+```
+
+- [ ] **Step 3: `cargo test -p kotoha-storage learning_cache::sqlite::tests` を実行し、全 test(lookup + record_choice + eviction + evict_lru + p2b_stub = 4+5+4+3+3 = 19 件以上)が PASS することを確認する**
+
+```bash
+cargo test -p kotoha-storage learning_cache::sqlite::tests 2>&1
+```
+
+- [ ] **Step 4: commit**
+
+```bash
+git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+git commit -m "feat(storage): implement evict_lru via evict_to_cap helper (B10)
+
+evict_lru(max_entries) delegates to evict_to_cap(conn, max_entries).
+All 3 evict_lru tests pass. evict_to_cap is reused by record_choice
+(auto-eviction) and evict_lru (explicit eviction) from a single impl.
+
+Refs: #105"
+```
+
+---
+
+### Task B11: `Database::learning_cache_reader/writer` factory 追加 + 旧 `learning_cache_store` 削除(`database.rs`)
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/database.rs`
+
+- [ ] **Step 1: `database.rs` の旧 `learning_cache_store` method を削除し、`learning_cache_reader` / `learning_cache_writer` factory を追加する**
+
+変更前(削除する箇所):
+
+```rust
+    /// (P2-B では unimplemented stub、P2-C で本実装、spec §6.3)
+    pub fn learning_cache_store(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::learning_cache::LearningCacheStore> {
+        Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+            Arc::clone(self),
+        ))
+    }
+```
+
+変更後(追加する箇所):
+
+```rust
+    /// `Arc<Database>` を `Box<dyn LearningCacheReader>` として公開する(spec §3.1 / §4.6)。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
+    pub fn learning_cache_reader(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::learning_cache::LearningCacheReader> {
+        Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+            Arc::clone(self),
+        ))
+    }
+
+    /// `Arc<Database>` を `Box<dyn LearningCacheWriter>` として公開する(spec §3.1 / §4.6)。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    /// - 同一 `Arc<Database>` から生成した reader / writer は同一 `Mutex<Connection>` を共有する
+    pub fn learning_cache_writer(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::learning_cache::LearningCacheWriter> {
+        Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+            Arc::clone(self),
+        ))
+    }
+```
+
+- [ ] **Step 2: `learning_cache_store()` を参照していた箇所をすべて `learning_cache_reader()` / `learning_cache_writer()` に置き換える**
+
+```bash
+grep -rn "learning_cache_store" /home/kohshiro/develops/student/kotoha-ime/
+```
+
+発見した箇所を確認し、用途が read のみであれば `learning_cache_reader()`、write が必要であれば `learning_cache_writer()` に書き換える。
+
+- [ ] **Step 3: `cargo build -p kotoha-storage` を実行し、コンパイルエラーなしを確認する**
+
+```bash
+cargo build -p kotoha-storage 2>&1
+```
+
+期待する出力(例):
+```
+   Compiling kotoha-storage v0.1.0 (.../crates/kotoha-storage)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in X.XXs
+```
+
+- [ ] **Step 4: `cargo build -p kotoha-cli` を実行し、コンパイルエラーなしを確認する**
+
+```bash
+cargo build -p kotoha-cli 2>&1
+```
+
+期待する出力(例):
+```
+   Compiling kotoha-cli v0.1.0 (.../crates/kotoha-cli)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in X.XXs
+```
+
+- [ ] **Step 5: `cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict-persist` を実行し、P2-B baseline 355 件以上 PASS を確認する。実行結果の head/tail 各 10 行を verbatim で記録する**
+
+```bash
+cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict-persist 2>&1 | tee /tmp/p2c-b-test-result.txt
+head -10 /tmp/p2c-b-test-result.txt
+tail -10 /tmp/p2c-b-test-result.txt
+```
+
+- [ ] **Step 6: commit**
+
+```bash
+git add crates/kotoha-storage/src/database.rs
+git commit -m "feat(storage): add learning_cache_reader/writer factory methods, remove learning_cache_store (B11)
+
+Replaces the monolithic learning_cache_store() with ISP-split factories:
+learning_cache_reader() -> Box<dyn LearningCacheReader>
+learning_cache_writer() -> Box<dyn LearningCacheWriter>
+Both return Arc<SqliteLearningCacheStore> sharing the same Mutex<Connection>.
+
+Refs: #105"
+```
+
+---
+
+## Phase P2-C-C: v002 migration
+
+### Task C1: v002 migration SQL ファイル作成
+
+**Files:**
+- Create: `crates/kotoha-storage/migrations/v002_learning_cache_index.sql`
+
+- [ ] **Step 1: `crates/kotoha-storage/migrations/v002_learning_cache_index.sql` を作成する**
+
+下記の SQL を記述する。`idx_learning_cache_last_used` index は `evict_lru` の `ORDER BY last_used_at ASC` および `lookup` の `ORDER BY frequency DESC, last_used_at DESC` における `last_used_at` 列のソートを index seek で高速化する目的で追加する(spec §4.1)。
+
+```sql
+-- v002_learning_cache_index: learning_cache テーブルへの last_used_at index 追加
+-- spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md §4.1
+--
+-- 目的:
+--   evict_lru(ORDER BY last_used_at ASC) および
+--   lookup(ORDER BY frequency DESC, last_used_at DESC) における
+--   last_used_at 列のソートを index seek で高速化する。
+--
+-- 適用条件:
+--   本 migration は forward-only(P2-B §3.6 決定)。
+--   既存 v001 DB を持つ環境では Database::open() が PRAGMA user_version = 1 を検出し、
+--   v002 を自動 apply する。新規 DB では v001 と v002 を順に apply する。
+
+CREATE INDEX idx_learning_cache_last_used ON learning_cache(last_used_at);
+```
+
+- [ ] **Step 2: SQL の文法妥当性をローカルで確認する**
+
+```bash
+sqlite3 /tmp/v002_syntax_check.db < /dev/null
+sqlite3 /tmp/v002_syntax_check.db "
+CREATE TABLE learning_cache (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    kana_input   TEXT    NOT NULL,
+    chosen_kanji TEXT    NOT NULL,
+    frequency    INTEGER NOT NULL DEFAULT 1,
+    last_used_at INTEGER NOT NULL,
+    UNIQUE(kana_input, chosen_kanji)
+);
+CREATE INDEX idx_learning_cache_last_used ON learning_cache(last_used_at);
+SELECT name FROM sqlite_master WHERE type='index' AND name='idx_learning_cache_last_used';
+"
+rm -f /tmp/v002_syntax_check.db
+```
+
+期待する出力:
+```
+idx_learning_cache_last_used
+```
+
+---
+
+### Task C2: `migrations.rs` へ v002 追加 + `LATEST_VERSION` 更新
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/migrations.rs`
+
+- [ ] **Step 1: `LATEST_VERSION` を `2` に更新し、`MIGRATIONS` 配列に v002 エントリを追加する**
+
+`crates/kotoha-storage/src/migrations.rs` の定数部分を以下のとおり修正する。
+
+修正前:
+```rust
+pub const LATEST_VERSION: i32 = 1;
+
+pub const MIGRATIONS: &[(i32, &str)] = &[(1, include_str!("../migrations/v001_initial.sql"))];
+```
+
+修正後:
+```rust
+/// 最新 schema version。新 migration を `MIGRATIONS` に追加する際は本値を増やす。
+pub const LATEST_VERSION: i32 = 2;
+
+/// (version, sql) 配列。version 昇順厳守(spec §10.1.1)。
+///
+/// `include_str!` でバイナリ同梱するため、distribution 時に migrations
+/// directory を別配布する必要はない(spec §3.6)。
+pub const MIGRATIONS: &[(i32, &str)] = &[
+    (1, include_str!("../migrations/v001_initial.sql")),
+    (2, include_str!("../migrations/v002_learning_cache_index.sql")),
+];
+```
+
+- [ ] **Step 2: `cargo build -p kotoha-storage` を実行し、コンパイルエラーなしを確認する**
+
+```bash
+cargo build -p kotoha-storage 2>&1
+```
+
+期待する出力(例):
+```
+   Compiling kotoha-storage v0.1.0 (.../crates/kotoha-storage)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in X.XXs
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/migrations/v002_learning_cache_index.sql \
+        crates/kotoha-storage/src/migrations.rs
+git commit -m "feat(storage): add v002 migration — idx_learning_cache_last_used (C1-C2)
+
+Adds migrations/v002_learning_cache_index.sql which creates
+idx_learning_cache_last_used on learning_cache(last_used_at).
+Updates LATEST_VERSION to 2 and appends the v002 entry to MIGRATIONS.
+
+The index accelerates evict_lru (ORDER BY last_used_at ASC) and
+lookup (ORDER BY frequency DESC, last_used_at DESC) (spec §4.1).
+
+Refs: #105"
+```
+
+---
+
+### Task C3: migrations runner test 拡張
+
+**Files:**
+- Modify: `crates/kotoha-storage/src/migrations.rs`(`#[cfg(test)] mod tests` 内に追加)
+
+- [ ] **Step 1: 既存の `#[cfg(test)] mod tests` ブロック末尾に 3 件の test 関数を追加する**
+
+追加する test 関数の完全コードを以下に示す。
+
+```rust
+    // ---- v002 migration 検証 ----
+
+    #[test]
+    fn apply_migrations_creates_learning_cache_last_used_index() {
+        // v001 + v002 を一括 apply した後に idx_learning_cache_last_used が存在することを確認する。
+        let conn = Connection::open_in_memory().expect("memory open");
+        apply_migrations(&conn).expect("apply");
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_learning_cache_last_used'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "idx_learning_cache_last_used must exist after migration");
+    }
+
+    #[test]
+    fn apply_migrations_upgrades_from_v001_to_v002() {
+        // v001 を apply 済みの DB に対して apply_migrations を再実行すると
+        // v002 だけが追加で apply され user_version が 2 になることを確認する。
+        let conn = Connection::open_in_memory().expect("memory open");
+
+        // v001 のみを手動 apply して v001 相当の初期状態を作る。
+        let (_, v001_sql) = MIGRATIONS
+            .iter()
+            .find(|(v, _)| *v == 1)
+            .expect("v001 must exist");
+        conn.execute_batch(v001_sql).expect("v001 apply");
+        conn.execute_batch("PRAGMA user_version = 1").expect("set user_version = 1");
+
+        // apply_migrations は v002 のみを適用し、user_version を 2 に更新するはずである。
+        apply_migrations(&conn).expect("upgrade v001 -> v002");
+
+        let v: i32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 2, "user_version must be 2 after upgrade");
+
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_learning_cache_last_used'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx_count, 1, "idx_learning_cache_last_used must be created by v002");
+    }
+
+    #[test]
+    fn apply_migrations_v002_is_idempotent() {
+        // apply_migrations を 2 回連続で呼び出しても user_version と index 数が変わらないことを確認する。
+        let conn = Connection::open_in_memory().expect("memory open");
+        apply_migrations(&conn).expect("first apply");
+        apply_migrations(&conn).expect("second apply must be no-op");
+
+        let v: i32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, LATEST_VERSION, "user_version must equal LATEST_VERSION after double apply");
+
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_learning_cache_last_used'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx_count, 1, "index count must remain 1 after idempotent apply");
+    }
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage` を実行し、追加した 3 件を含む全 test が PASS することを確認する**
+
+```bash
+cargo test -p kotoha-storage 2>&1 | tail -10
+```
+
+期待する出力(例、行数は前後の test 数に依存する):
+```
+test migrations::tests::apply_migrations_creates_learning_cache_last_used_index ... ok
+test migrations::tests::apply_migrations_upgrades_from_v001_to_v002 ... ok
+test migrations::tests::apply_migrations_v002_is_idempotent ... ok
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/src/migrations.rs
+git commit -m "test(storage): add v002 migration runner tests — upgrade + idempotency (C3)
+
+Adds 3 tests to migrations::tests:
+- apply_migrations_creates_learning_cache_last_used_index
+- apply_migrations_upgrades_from_v001_to_v002
+- apply_migrations_v002_is_idempotent
+
+Verifies that idx_learning_cache_last_used is created by v002,
+that an existing v001 DB is correctly upgraded to v002,
+and that double-apply is a no-op.
+
+Refs: #105"
+```
+
+---
+
+## Phase P2-C-D: test 整備
+
+### Task D1: L2 integration test 新規作成
+
+**Files:**
+- Create: `crates/kotoha-storage/tests/learning_cache_store.rs`
+
+- [ ] **Step 1: `crates/kotoha-storage/tests/learning_cache_store.rs` を新規作成する**
+
+以下の完全コードを記述する。
+
+```rust
+//! L2 integration tests — LearningCache factory wiring / concurrency / persistence.
+//! spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md §6.3
+
+use kotoha_storage::{Database, LearningCacheReader, LearningCacheWriter};
+use std::sync::Arc;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// helper
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// in-memory Database を開いて learning_cache_reader / learning_cache_writer を返す。
+fn open_factory() -> (
+    Box<dyn LearningCacheReader>,
+    Box<dyn LearningCacheWriter>,
+) {
+    let db = Database::open_in_memory().expect("open_in_memory");
+    let reader = db.learning_cache_reader();
+    let writer = db.learning_cache_writer();
+    (reader, writer)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// writer で記録した entry を reader が参照できることを確認する。
+///
+/// `learning_cache_reader` と `learning_cache_writer` が同一の SQLite Connection
+/// (Mutex<Connection> 経由)を共有していることを factory wiring レベルで検証する。
+#[test]
+fn factory_returns_reader_and_writer_sharing_same_data() {
+    let (reader, writer) = open_factory();
+
+    writer
+        .record_choice("あいう", "愛")
+        .expect("record_choice must succeed");
+
+    let results = reader
+        .lookup("あいう", 10)
+        .expect("lookup must succeed");
+
+    assert_eq!(results.len(), 1, "reader must see the entry written by writer");
+    assert_eq!(results[0].chosen_kanji, "愛");
+    assert_eq!(results[0].frequency, 1);
+}
+
+/// 10 スレッドが同時に record_choice を呼び出しても deadlock が発生せず
+/// 全件が記録されることを確認する。
+///
+/// `Mutex<Connection>` による直列化が正しく機能することを検証する(spec §4.2 / E9)。
+/// 同一 entry を 10 スレッドが record するため、完了後の frequency が 10 になるはずである。
+#[test]
+fn concurrent_record_choice_is_serialized() {
+    let db = Database::open_in_memory().expect("open_in_memory");
+    // Arc で writer を複数スレッドに共有する。
+    let writer: Arc<dyn LearningCacheWriter> =
+        Arc::from(db.learning_cache_writer());
+    let reader = db.learning_cache_reader();
+
+    const THREAD_COUNT: usize = 10;
+    let mut handles = Vec::with_capacity(THREAD_COUNT);
+
+    for _ in 0..THREAD_COUNT {
+        let w = Arc::clone(&writer);
+        handles.push(std::thread::spawn(move || {
+            w.record_choice("きょう", "今日")
+                .expect("record_choice must not fail under concurrency");
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread must not panic");
+    }
+
+    let results = reader
+        .lookup("きょう", 10)
+        .expect("lookup must succeed");
+
+    assert_eq!(results.len(), 1, "concurrent inserts for the same entry must be UPSERT-merged");
+    assert_eq!(
+        results[0].frequency, THREAD_COUNT as i64,
+        "frequency must equal the number of concurrent record_choice calls"
+    );
+}
+
+/// file-backed DB で eviction 後に Database を再 open しても行数が cap 以下であることを確認する。
+///
+/// 永続ファイルを使い、record + cap 超過 eviction + close + 再 open の後に
+/// 削除済 entry が消えていることを検証する(spec §6.3)。
+#[test]
+fn eviction_persists_across_factory_reopens() {
+    use kotoha_storage::learning_cache::CapOverrideGuard;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("test_eviction.db");
+
+    // --- フェーズ 1: cap=3 で 5 件 record して eviction を発生させる ---
+    {
+        let db = Database::open(&db_path).expect("open phase1");
+        let _guard = CapOverrideGuard::new(3);
+        let writer = db.learning_cache_writer();
+
+        // 5 件を順に record する。5 件目の insert 後に eviction が走り行数が 3 になるはずである。
+        for i in 0u32..5 {
+            let kana = format!("あ{i:02}");
+            writer
+                .record_choice(&kana, "愛")
+                .expect("record_choice must succeed");
+        }
+
+        let writer2 = db.learning_cache_writer();
+        // cap=3 に収まっていることをフェーズ 1 内で確認する。
+        // evict_lru(3) が Ok(0) を返す = 既に cap 以内であることを確認する。
+        let evicted = writer2.evict_lru(3).expect("evict_lru must succeed");
+        assert_eq!(evicted, 0, "row count must already be <= cap after auto-eviction");
+        drop(writer);
+    } // db を drop して SQLite connection を close する。
+
+    // --- フェーズ 2: 再 open して行数が 3 以下であることを確認する ---
+    {
+        let db = Database::open(&db_path).expect("open phase2");
+        let writer = db.learning_cache_writer();
+
+        // cap 以内であれば evict_lru(3) は Ok(0) を返すはずである。
+        let evicted = writer.evict_lru(3).expect("evict_lru must succeed in phase2");
+        assert_eq!(
+            evicted, 0,
+            "eviction result must persist across Database reopen"
+        );
+    }
+}
+```
+
+`tempfile` crate が `kotoha-storage` の dev-dependency に含まれているかを確認し、含まれていない場合は `Cargo.toml` に追加する。
+
+```bash
+grep "tempfile" /home/kohshiro/develops/student/kotoha-ime/crates/kotoha-storage/Cargo.toml
+```
+
+含まれていない場合は `kotoha-storage/Cargo.toml` の `[dev-dependencies]` セクションに以下を追加する。
+
+```toml
+tempfile = { workspace = true }
+```
+
+workspace root `Cargo.toml` の `[workspace.dependencies]` に `tempfile` が存在しない場合は以下を追加する。
+
+```toml
+tempfile = "3"
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage --test learning_cache_store` を実行し、3 件全 PASS を確認する**
+
+```bash
+cargo test -p kotoha-storage --test learning_cache_store 2>&1
+```
+
+期待する出力:
+```
+running 3 tests
+test concurrent_record_choice_is_serialized ... ok
+test eviction_persists_across_factory_reopens ... ok
+test factory_returns_reader_and_writer_sharing_same_data ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/tests/learning_cache_store.rs \
+        crates/kotoha-storage/Cargo.toml \
+        Cargo.toml \
+        Cargo.lock
+git commit -m "test(storage): add L2 integration tests for LearningCache factory (D1)
+
+Adds tests/learning_cache_store.rs with 3 integration tests:
+- factory_returns_reader_and_writer_sharing_same_data
+- concurrent_record_choice_is_serialized (10 threads, UPSERT merge)
+- eviction_persists_across_factory_reopens (tempfile, reopen check)
+
+Refs: #105"
+```
+
+---
+
+### Task D2: proptest 新規作成
+
+**Files:**
+- Create: `crates/kotoha-storage/tests/learning_cache_proptest.rs`
+
+`proptest` が `kotoha-storage` の dev-dependency に登録されていることを確認する。
+
+```bash
+grep "proptest" /home/kohshiro/develops/student/kotoha-ime/crates/kotoha-storage/Cargo.toml
+```
+
+含まれていない場合は `kotoha-storage/Cargo.toml` の `[dev-dependencies]` に以下を追加する。
+
+```toml
+proptest = { workspace = true }
+```
+
+- [ ] **Step 1: `crates/kotoha-storage/tests/learning_cache_proptest.rs` を新規作成する**
+
+以下の完全コードを記述する。
+
+strategy の設計方針:
+- `hiragana_string()`: ひらがな Unicode ブロック `'\u{3041}'..='\u{309F}'` から 1〜32 文字を生成する。`validate_reading` が通過する入力のみを生成するため、ASCII 等の reject 文字を含まない。
+- `kanji_string()`: 実用的な漢字集合として `['愛', '夢', '空', '花', '光', '山', '川', '海', '月', '日']` から 1〜10 文字を生成する。`validate_surface` が通過する文字列のみを生成するため、Invariant 3 において `record_choice` が `Err(InvalidField)` を返す分岐は strategy 上発生しない。
+- Invariant 3 は strategy が valid 入力のみを生成することで保証するアプローチ(strategy-level guarantee)を採用し、`Result::Err` ケースを test 内で許容する方式は採用しない。
+
+```rust
+//! proptest — LearningCache の 3 invariant を property-based で検証する。
+//! spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md §6.5
+//!
+//! PROPTEST_CASES=64 で実行する(ProptestConfig::with_cases(64))。
+
+use kotoha_storage::{Database, LearningCacheReader, LearningCacheWriter};
+use kotoha_storage::learning_cache::CapOverrideGuard;
+use proptest::prelude::*;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// strategy 定義
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// ひらがな 1〜32 文字からなる文字列を生成する。
+/// 生成される全文字列は validate_reading を通過する。
+fn hiragana_string() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        '\u{3041}'..='\u{309F}',
+        1..=32,
+    )
+    .prop_map(|chars| chars.into_iter().collect())
+}
+
+/// 実用漢字集合 10 種から 1〜10 文字を繰り返し生成する。
+/// 生成される全文字列は validate_surface を通過する。
+fn kanji_string() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        proptest::sample::select(vec![
+            '愛', '夢', '空', '花', '光', '山', '川', '海', '月', '日',
+        ]),
+        1..=10,
+    )
+    .prop_map(|chars| chars.into_iter().collect())
+}
+
+/// (kana_input, chosen_kanji) のペアを 0〜200 件生成する。
+fn record_sequence() -> impl Strategy<Value = Vec<(String, String)>> {
+    proptest::collection::vec(
+        (hiragana_string(), kanji_string()),
+        0..=200,
+    )
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// proptest
+// ──────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Invariant 1: 任意の record sequence 後も行数が cap 以下である。
+    ///
+    /// CapOverrideGuard で cap=20 を設定し、record_choice の自動 eviction により
+    /// 行数が 20 を超えないことを確認する。
+    #[test]
+    fn invariant_row_count_stays_within_cap(
+        records in record_sequence()
+    ) {
+        let db = Database::open_in_memory().expect("open_in_memory");
+        let _guard = CapOverrideGuard::new(20);
+        let writer = db.learning_cache_writer();
+
+        for (kana, kanji) in &records {
+            // strategy が valid 入力のみを生成するため、Ok 以外は発生しない。
+            writer.record_choice(kana, kanji)
+                .expect("record_choice must succeed for valid inputs");
+        }
+
+        // evict_lru(20) が Ok(0) を返す = 行数が 20 以下であることを確認する。
+        let evicted = writer.evict_lru(20)
+            .expect("evict_lru must succeed");
+        prop_assert_eq!(
+            evicted, 0,
+            "row count must be <= cap=20 after record sequence; evicted={evicted}"
+        );
+    }
+
+    /// Invariant 2: lookup 結果が frequency DESC で単調非増加である。
+    ///
+    /// record sequence 後に kana_input を 1 件取り出して lookup を呼び出し、
+    /// 結果 results[i].frequency >= results[i+1].frequency が全 i で成立することを確認する。
+    #[test]
+    fn invariant_lookup_result_is_frequency_desc(
+        records in record_sequence()
+    ) {
+        // records が空の場合は lookup 対象が存在しないため、1 件以上を前提とする。
+        prop_assume!(!records.is_empty());
+
+        let db = Database::open_in_memory().expect("open_in_memory");
+        let _guard = CapOverrideGuard::new(20);
+        let writer = db.learning_cache_writer();
+        let reader = db.learning_cache_reader();
+
+        for (kana, kanji) in &records {
+            writer.record_choice(kana, kanji)
+                .expect("record_choice must succeed for valid inputs");
+        }
+
+        // 最初のペアの kana_input に対して lookup を実行する。
+        let target_kana = &records[0].0;
+        let results = reader.lookup(target_kana, 100)
+            .expect("lookup must succeed");
+
+        // 結果が 2 件以上の場合にのみ順序を検証する。
+        for i in 0..results.len().saturating_sub(1) {
+            prop_assert!(
+                results[i].frequency >= results[i + 1].frequency,
+                "lookup results must be frequency DESC: results[{}].frequency={} < results[{}].frequency={}",
+                i, results[i].frequency, i + 1, results[i + 1].frequency
+            );
+        }
+    }
+
+    /// Invariant 3: strategy が生成した全入力に対して record_choice が Ok(()) を返す。
+    ///
+    /// hiragana_string / kanji_string は validate_reading / validate_surface を
+    /// 通過する文字列のみを生成する。record_choice が Err を返した場合は
+    /// strategy の生成ロジックかバリデーション実装のどちらかに誤りがある。
+    #[test]
+    fn invariant_valid_inputs_always_succeed(
+        records in record_sequence()
+    ) {
+        let db = Database::open_in_memory().expect("open_in_memory");
+        let _guard = CapOverrideGuard::new(20);
+        let writer = db.learning_cache_writer();
+
+        for (kana, kanji) in &records {
+            let result = writer.record_choice(kana, kanji);
+            prop_assert!(
+                result.is_ok(),
+                "record_choice must return Ok for valid inputs: kana={kana:?}, kanji={kanji:?}, err={result:?}"
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2: `cargo test -p kotoha-storage --test learning_cache_proptest` を実行し、3 件全 PASS を確認する**
+
+```bash
+PROPTEST_CASES=64 cargo test -p kotoha-storage --test learning_cache_proptest 2>&1
+```
+
+期待する出力:
+```
+running 3 tests
+test invariant_lookup_result_is_frequency_desc ... ok
+test invariant_row_count_stays_within_cap ... ok
+test invariant_valid_inputs_always_succeed ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add crates/kotoha-storage/tests/learning_cache_proptest.rs \
+        crates/kotoha-storage/Cargo.toml \
+        Cargo.lock
+git commit -m "test(storage): add proptest for LearningCache 3 invariants (D2)
+
+Adds tests/learning_cache_proptest.rs with PROPTEST_CASES=64:
+- invariant_row_count_stays_within_cap (cap=20, CapOverrideGuard)
+- invariant_lookup_result_is_frequency_desc (frequency DESC monotone)
+- invariant_valid_inputs_always_succeed (strategy-level valid input guarantee)
+
+Strategies generate only validate_reading/validate_surface-passing inputs
+to ensure Invariant 3 holds without requiring result-level error tolerance.
+
+Refs: #105"
+```
+
+---
+
+### Task D3: 全 feature 構成 test 確認
+
+**Files:**
+- 変更なし(test 実行 + 結果記録のみ)
+
+P2-C 実装完了時点で 3 feature 構成の test 件数が baseline 予測(spec §6.6)と一致することを確認する。
+
+- [ ] **Step 1: `default` 構成で `cargo test --workspace` を実行する**
+
+```bash
+cargo test --workspace 2>&1 | tee /tmp/p2c-d-test-default.txt
+tail -5 /tmp/p2c-d-test-default.txt
+```
+
+期待する末尾 5 行(件数は 304 程度、exact 値は実装後に確定):
+```
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+
+```
+
+全 workspace crate の `test result: ok` を確認し、`FAILED` が 0 件であることを確認する。合計 PASS 数が 304 程度であることを確認する。
+
+- [ ] **Step 2: `dict` 構成で `cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict` を実行する**
+
+```bash
+cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict 2>&1 \
+    | tee /tmp/p2c-d-test-dict.txt
+tail -5 /tmp/p2c-d-test-dict.txt
+```
+
+期待する末尾 5 行(件数は 363 程度):
+```
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+
+```
+
+全 workspace crate の `test result: ok` を確認し、合計 PASS 数が 363 程度であることを確認する。
+
+- [ ] **Step 3: `dict-persist` 構成で `cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict-persist` を実行する**
+
+```bash
+cargo test --workspace --features kotoha-core/mock-backend,kotoha-core/dict-persist 2>&1 \
+    | tee /tmp/p2c-d-test-dict-persist.txt
+tail -5 /tmp/p2c-d-test-dict-persist.txt
+```
+
+期待する末尾 5 行(件数は 384 程度):
+```
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+...
+test result: ok. X passed; 0 failed; 0 ignored; 0 measured; 0 filtered out in Xs
+
+```
+
+全 workspace crate の `test result: ok` を確認し、合計 PASS 数が 384 程度であることを確認する。
+
+- [ ] **Step 4: 3 構成の実測 PASS 数と予測値の差分を記録する**
+
+実行結果から各構成の合計 PASS 数を集計し、以下の表を埋める。
+
+| 構成 | 予測 PASS 数 | 実測 PASS 数 | 差分 |
+|---|---|---|---|
+| `default` | 304 程度 | (実測値) | (差分) |
+| `dict` | 363 程度 | (実測値) | (差分) |
+| `dict-persist` | 384 程度 | (実測値) | (差分) |
+
+差分が予測値から ±5 件を超える場合、増加要因または減少要因(削除 / 統合した test がないか)を調査する。`FAILED` が 0 件であれば退行ゼロと判定する。
+
+---
+
+### Task D4: lefthook pre-push 全 PASS 確認
+
+**Files:**
+- 変更なし(lefthook 実行 + 結果記録のみ)
+
+P2-C 完了時の最終 gate として lefthook pre-push の全コマンドが PASS することを確認する。
+
+- [ ] **Step 1: lefthook pre-push の全コマンドを実行する**
+
+`lefthook.yml` が定義する pre-push コマンド群を順次実行する。`parallel: false` なので実行順序は `manifest-check` → `build` → `clippy` → `test` → `test-dict` → `test-dict-persist` である。
+
+```bash
+lefthook run pre-push 2>&1 | tee /tmp/p2c-d-lefthook-pre-push.txt
+tail -20 /tmp/p2c-d-lefthook-pre-push.txt
+```
+
+期待する末尾 20 行(各 step が PASS または `✔` で終わる):
+```
+  EXECUTE manifest-check
+  ...
+  ✔  manifest-check
+
+  EXECUTE build
+  ...
+  ✔  build
+
+  EXECUTE clippy
+  ...
+  ✔  clippy
+
+  EXECUTE test
+  ...
+  ✔  test
+
+  EXECUTE test-dict
+  ...
+  ✔  test-dict
+
+  EXECUTE test-dict-persist
+  ...
+  ✔  test-dict-persist
+
+SUMMARY: 6 tasks passed
+```
+
+いずれかの step が失敗した場合は、該当 step の出力を調査して修正してから再実行する。
+
+- [ ] **Step 2: lefthook 全 PASS を確認後に Phase P2-C-D 完了を宣言する**
+
+D4 は新規ファイルを生成しないため、commit は作成しない。D1〜D3 の commit が全て完了し、lefthook pre-push が PASS した時点で Phase P2-C-D は完了となる。
+
+実行結果の verbatim 出力(`/tmp/p2c-d-lefthook-pre-push.txt` の末尾 20 行)を WBS ログに転記する。
+
+---
+
+## Phase P2-C-E: review / WBS / PR
+
+Phase A〜D の実装が完了し、lefthook pre-push が全 PASS した後に Phase P2-C-E を開始する。Phase E は WBS 記録作成、静的解析クリア、PR 作成、Medium tier team-review、finding 修正、re-review、merge の 7 task で構成される。
+
+### Task E1: WBS 記録 `docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md` を作成する
+
+**Files:**
+- Create: `docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md`
+
+- [ ] **Step 1: WBS ファイルを Write ツールで作成する**
+
+  P2-B WBS(`docs/wbs/2026-04-25-feature-98-p2-b-user-dictionary.md`)の frontmatter + 章立てを踏襲する。固定値(spec / plan path、ISSUE 番号、branch 名)は具体値で記載し、実装後に確定する数値(test count 着地値、commit 数、変更 file 数、変更 lines)は「実装後に確定」と明記するプレースホルダを置く。
+
+  ```markdown
+  ---
+  title: P2-C LearningCache 本実装ログ
+  date: 2026-04-26
+  branch: feature/105-p2-c-learning-cache
+  issue: 105
+  pr: <PR# が確定したら追記>
+  follow-up-issue: <Medium / Low deferred Issue# が確定したら追記>
+  parent-spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
+  parent-plan: docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md
+  ---
+
+  # P2-C(LearningCache 本実装)実装ログ
+
+  ## サマリ
+
+  - `UserVocabReader` / `UserVocabWriter` ISP split(Phase A 完了、旧 `UserVocabStore` を 4 trait に分割)
+  - `LearningCacheReader` / `LearningCacheWriter` ISP split(Phase A 完了、旧 `LearningCacheStore` を 4 trait に分割)
+  - `SqliteLearningCacheStore` 本実装(Phase B 完了、UPSERT / auto eviction / LRU / lookup ordering の 23 件 L1 test + proptest 3 invariant)
+  - v002 migration 追加(Phase C 完了、`v002_learning_cache_index.sql` + migration test)
+  - proptest 拡張 + golden test 拡張(Phase D 完了、退行ゼロ確認)
+  - Medium tier team-review(security / architecture / testing / performance の 4 dimension、Critical + High を全消化)
+
+  ## metric
+
+  | 項目 | 値 |
+  |---|---|
+  | default features 合計 | 304 程度 PASS(実装後に確定) |
+  | `dict` features 合計 | 363 程度 PASS(実装後に確定) |
+  | `dict-persist` features 合計 | **384 程度 PASS(P2-C 新 baseline、実装後に確定)** |
+  | 工数(実) | 実装後に確定 |
+  | 変更 file 数 | 実装後に確定(PR diff から記載) |
+  | 変更 lines | 実装後に確定(PR diff から記載) |
+  | commit 数 | 実装後に確定(develop からの差分) |
+
+  ## Phase 別実装結果
+
+  | Phase | task 数 | 完了 | 主要 commit | 学び |
+  |---|---|---|---|---|
+  | Phase A | 8 | 実装後に確定 | A1 ISP split → A8 invariant | 実装後に記録 |
+  | Phase B | 11 | 実装後に確定 | B1 UPSERT → B11 proptest | 実装後に記録 |
+  | Phase C | 4 | 実装後に確定 | C1 migration → C4 migration test | 実装後に記録 |
+  | Phase D | 4 | 実装後に確定 | D1 proptest → D4 lefthook gate | 実装後に記録 |
+  | Phase E | 7 | (本 WBS で進行中) | E1 WBS / E4 PR / E6 review fix | — |
+
+  ## 学び / 判断ログ
+
+  - (本 plan 実行中に発見した知見、想定との差異、判断の根拠を記録)
+
+  ## 4-dim review 結果
+
+  | dimension | Critical | High | Medium | Low |
+  |---|---|---|---|---|
+  | security | 実装後に確定 | 実装後に確定 | 実装後に確定 | 実装後に確定 |
+  | architecture | 実装後に確定 | 実装後に確定 | 実装後に確定 | 実装後に確定 |
+  | testing | 実装後に確定 | 実装後に確定 | 実装後に確定 | 実装後に確定 |
+  | performance | 実装後に確定 | 実装後に確定 | 実装後に確定 | 実装後に確定 |
+  | **合計** | **0(全消化)** | **0(全消化)** | **新規 Issue に移管** | **新規 Issue に移管** |
+
+  ## deferred 項目(新規 Issue に移管)
+
+  以下の Medium / Low finding は PR merge 後に新規 follow-up Issue を起票して管理する。
+
+  - **connection pool(perf-M-1)**: `Mutex<Connection>` をコネクションプールに置き換える。Phase 3 IBus engine から高頻度で呼び出す前提で遅延を測定し、必要性が確認された場合に実施する
+  - **Mutex poison handling 改善(sec-L-2)**: `lock_conn` が panic する代わりに `StorageError::Sqlite` を返す recover 経路を追加する
+  - **LearningCache CLI 公開検討(Phase 3-A 以降)**: `kotoha-dict cache list` / `kotoha-dict cache flush` の subcommand を Phase 3 kick-off で判断する
+  - **cap 値の動的化 / config 化(Phase 5)**: `LEARNING_CACHE_MAX_ROWS` を設定ファイルから読み込む機構を Phase 5 personalization で追加する
+  - **review 由来の Medium / Low finding**: 実装後に確定
+
+  ## 参照
+
+  - spec: `docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md`
+  - plan: `docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md`
+  - P2-B WBS: `docs/wbs/2026-04-25-feature-98-p2-b-user-dictionary.md`
+  - ISSUE: https://github.com/std-koh-hinooka/kotoha-ime/issues/105
+  ```
+
+- [ ] **Step 2: WBS ファイルを commit する(develop merge 後に直接 push する)**
+
+  WBS 記録は対象 PR の merge 後に `develop` へ直接 push する例外扱いである(project CLAUDE.md「WBS 直接 push の例外」)。そのため、commit は feature branch 上で作成するが、push のタイミングは E7 merge 後とする。
+
+  ```bash
+  git add docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
+  git commit -m "docs(wbs): add P2-C WBS reflection log (#105)"
+  ```
+
+---
+
+### Task E2: 静的解析クリア確認(commit 直前の最終チェック)
+
+**Files:**
+- 変更なし(静的解析の確認のみ)
+
+- [ ] **Step 1: `cargo fmt --all` を実行して差分がないことを確認する**
+
+  ```bash
+  cargo fmt --all
+  git diff --exit-code
+  ```
+
+  `cargo fmt --all` は出力なしで終了する。`git diff --exit-code` が exit 0 を返さない場合は、差分ファイルを `git add` して追加 commit を作成してから先に進む。
+
+  Expected output:
+  ```
+  (no output — cargo fmt produces no stdout when all files are already formatted)
+  ```
+
+- [ ] **Step 2: `cargo clippy` で警告ゼロを確認する**
+
+  ```bash
+  cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tee /tmp/p2c-e-clippy.txt
+  tail -5 /tmp/p2c-e-clippy.txt
+  ```
+
+  Expected output(末尾 5 行):
+  ```
+      Checking kotoha-cli v0.1.0 (...)
+      Checking kotoha-dict v0.1.0 (...)
+      Finished `dev` profile [unoptimized + debuginfo] target(s) in X.XXs
+  warning: 0 warnings emitted
+  ```
+
+  警告が 1 件でも残っている場合は、警告箇所を修正してから Step 3 に進む。
+
+- [ ] **Step 3: `cargo audit` で 0 vulnerability を確認する**
+
+  ```bash
+  cargo audit 2>&1 | tee /tmp/p2c-e-audit.txt
+  tail -5 /tmp/p2c-e-audit.txt
+  ```
+
+  Expected output(末尾 5 行):
+  ```
+  Crate:     kotoha
+  Version:   0.1.0
+  Warning:   0 warnings
+  Vulnerabilities: 0
+  Successful audit, no vulnerabilities found
+  ```
+
+  vulnerability が 0 件でない場合は、該当 crate のバージョンを更新するか、audit.toml で ignore 登録して理由を PR body に記載する。
+
+---
+
+### Task E3: branch を origin に push する
+
+**Files:**
+- 変更なし(git 操作のみ)
+
+- [ ] **Step 1: feature branch を origin に push して upstream tracking branch を設定する**
+
+  ```bash
+  git push -u origin feature/105-p2-c-learning-cache
+  ```
+
+  Expected output:
+  ```
+  Enumerating objects: X, done.
+  Counting objects: 100% (X/X), done.
+  Delta compression using up to X threads
+  Compressing objects: 100% (X/X), done.
+  Writing objects: 100% (X/X), X KiB | X MiB/s, done.
+  Total X (delta X), reused 0 (delta 0), pack-reused 0
+  remote: Resolving deltas: 100% (X/X), done.
+  To github.com:std-koh-hinooka/kotoha-ime.git
+   * [new branch]      feature/105-p2-c-learning-cache -> feature/105-p2-c-learning-cache
+  Branch 'feature/105-p2-c-learning-cache' set up to track remote branch 'feature/105-p2-c-learning-cache' from 'origin'.
+  ```
+
+  lefthook pre-push フックが自動起動し、`fmt-check` / `clippy` / `test` / `test-dict` / `test-dict-persist` の 5 step が全 PASS することを確認する。いずれかの step が FAIL した場合は push がブロックされるため、該当箇所を修正してから再実行する。
+
+---
+
+### Task E4: `gh pr create` で PR を作成する
+
+**Files:**
+- 変更なし(gh CLI 操作のみ)
+
+- [ ] **Step 1: PR を `--base develop` 指定で作成する**
+
+  以下の bash コマンドを実行する。PR title は 70 文字以内の英語。PR body は HEREDOC で渡す。
+
+  ```bash
+  gh pr create \
+    --base develop \
+    --title "feat(p2-c): LearningCache full impl + ISP split (4-trait boundary)" \
+    --body "$(cat <<'EOF'
+  ## Summary
+
+  - Split `UserVocabStore` and `LearningCacheStore` monolithic traits into 4 ISP-aligned traits each: `UserVocabReader`, `UserVocabWriter`, `LearningCacheReader`, `LearningCacheWriter`
+  - Implement `SqliteLearningCacheStore` with full UPSERT, auto eviction (LRU), lookup ordering, and cap enforcement (replacing the Phase 2-B stub)
+  - Add `v002_learning_cache_index.sql` migration and auto-upgrade path from v001 DB
+  - Add 23 L1 unit tests + 3 proptest invariants for `LearningCacheStore`
+  - Remove deprecated `user_vocab_store` / `learning_cache_store` factory methods from `Database`
+
+  ## Scope
+
+  - Single-PR scope per CLAUDE.md Branch Scope Policy (1 ISSUE = 1 branch)
+  - Medium tier review per CLAUDE.md PR Review Matrix: `agent-teams:team-review` (security / architecture / testing / performance) + `owasp-security` + `secrets-check`
+
+  ## Test count baseline (post-merge target)
+
+  | feature set | expected PASS count |
+  |---|---|
+  | default | 304 approx. |
+  | dict | 363 approx. |
+  | dict-persist | 384 approx. |
+
+  ## Test plan
+
+  - [ ] `cargo test --workspace` passes with zero failures (default features)
+  - [ ] `cargo test --workspace --features dict` passes with zero failures
+  - [ ] `cargo test --workspace --features kotoha-cli/dict-persist` passes with zero failures
+  - [ ] `cargo clippy --workspace --all-targets -- -D warnings` emits zero warnings
+  - [ ] `cargo audit` reports 0 vulnerabilities
+  - [ ] lefthook pre-push gate (fmt / clippy / test / test-dict / test-dict-persist) all PASS
+  - [ ] `LearningCacheReader` / `LearningCacheWriter` / `UserVocabReader` / `UserVocabWriter` are established as public API
+  - [ ] Deprecated `UserVocabStore` and `LearningCacheStore` traits are removed
+  - [ ] v002 migration runs correctly on both fresh DB and v001 existing DB
+  - [ ] 23 L1 tests for `SqliteLearningCacheStore` all PASS
+  - [ ] 3 proptest invariants PASS at `PROPTEST_CASES=64`
+  - [ ] WBS log `docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md` is created
+  - [ ] Medium tier team-review Critical + High findings are all resolved (Medium / Low moved to follow-up Issue)
+
+  ## References
+
+  - Plan: `docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md`
+  - Spec: `docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md`
+  - WBS: `docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md`
+
+  Refs: #105
+  EOF
+  )"
+  ```
+
+- [ ] **Step 2: PR URL を確認して以降の task で使用する**
+
+  ```bash
+  gh pr view --json url,number | jq '{url, number}'
+  ```
+
+  出力された PR number を E6 / E7 の `gh pr view <number>` コマンドに使用する。
+
+---
+
+### Task E5: Medium tier team-review を実行する
+
+**Files:**
+- 変更なし(review 実行のみ)
+
+global CLAUDE.md「Sub-agent Self-Report is Untrusted」規定に従い、各 reviewer subagent には verbatim output を必須とする。
+
+global CLAUDE.md「System Resource Management」規定に従い、利用可能メモリが 8〜16GiB 帯の場合は 4 dimension を並列実行せず逐次実行する。実行前に `free -h` でメモリ状況を確認する。
+
+- [ ] **Step 1: メモリ使用状況を確認する**
+
+  ```bash
+  free -h
+  free -h | awk '/Swap/{split($3,a,"G"); split($2,b,"G"); if (length(a[1])>0 && length(b[1])>0) printf "Swap usage: %.1f%%\n", a[1]/b[1]*100}'
+  ```
+
+  利用可能メモリが 16GiB 超であれば 4 dimension 並列実行、8〜16GiB 帯であれば逐次実行、8GiB 未満であればユーザに中止を確認する。
+
+- [ ] **Step 2: `agent-teams:team-review` skill を Medium tier(4 dimension)で実行する**
+
+  main agent は以下の内容で `agent-teams:team-review` skill を呼び出す。
+
+  **skill 呼出引数:**
+
+  ```
+  skill: agent-teams:team-review
+  args: |
+    dimensions: security, architecture, testing, performance
+    scope: |
+      Branch: feature/105-p2-c-learning-cache
+      Issue: #105
+      Spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
+      Plan: docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md
+      P2-B WBS: docs/wbs/2026-04-25-feature-98-p2-b-user-dictionary.md
+      Primary changed crates: kotoha-storage (src/learning_cache/, src/user_vocab/, migrations/)
+      Test files: crates/kotoha-storage/tests/
+    reviewer_prompt_template: |
+      あなたは <dimension> dimension の reviewer である。
+      以下の scope を対象に review を実施し、finding を Critical / High / Medium / Low の 4 段階で分類する。
+      各 finding には以下の形式で記載する:
+        - severity: Critical | High | Medium | Low
+        - file: <file_path>:<line_number>
+        - recommendation: <修正方針を 1〜3 文で記述>
+        - verbatim_code: <該当コードの抜粋>
+      IMPORTANT: 報告の末尾に、最終確認コマンドの verbatim 出力の head 5 行と tail 5 行を必ず含めること。
+      "PASS" "ALL OK" などの要約のみの報告は不可。
+  ```
+
+- [ ] **Step 3: `owasp-security` skill を実行する**
+
+  ```
+  skill: owasp-security
+  args: |
+    scope: kotoha-storage crate の LearningCache 実装
+    files:
+      - crates/kotoha-storage/src/learning_cache/sqlite.rs
+      - crates/kotoha-storage/src/learning_cache/mod.rs
+      - crates/kotoha-storage/migrations/v002_learning_cache_index.sql
+    mode: review-only (no code modification)
+    IMPORTANT: 最終 verification コマンド出力の head/tail 5 行を verbatim で報告に含めること
+  ```
+
+- [ ] **Step 4: `secrets-check` skill を実行する**
+
+  ```
+  skill: secrets-check
+  args: |
+    scope: branch feature/105-p2-c-learning-cache の全変更ファイル
+    mode: review-only (no code modification)
+    IMPORTANT: スキャン結果の verbatim 出力(最終 5 行)を報告に含めること
+  ```
+
+- [ ] **Step 5: finding を Critical / High / Medium / Low に整理する**
+
+  4 dimension + owasp + secrets-check の finding を集約し、以下の表に整理する。
+
+  | finding-id | dimension | severity | file:line | summary |
+  |---|---|---|---|---|
+  | sec-C1 | security | Critical | (実行後に記入) | (実行後に記入) |
+  | arch-H1 | architecture | High | (実行後に記入) | (実行後に記入) |
+  | ... | ... | ... | ... | ... |
+
+  Critical / High finding の一覧を WBS ログの「4-dim review 結果」セクションに転記する。
+
+---
+
+### Task E6: Critical / High finding を全消化する
+
+**Files:**
+- finding の severity と対象 file に応じて異なる(実行後に確定)
+
+E5 で収集した Critical / High finding を 1 件ごとに独立 commit として修正する(P2-B PR #101 の 7 commit 慣習踏襲)。
+
+- [ ] **Step 1: finding を件数順に確認して修正順序を決定する**
+
+  Critical finding を先に処理し、次に High finding を処理する。1 件の finding が複数ファイルに影響する場合は同一 commit にまとめる。
+
+- [ ] **Step 2: 各 finding を修正して commit を作成する**
+
+  commit message の format は `fix(<dim>-<finding-id>): <summary>` とする。以下に各 dimension の例を示す。
+
+  ```bash
+  # security dimension の Critical finding の例
+  git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+  git commit -m "fix(sec-c1): sanitize SQL parameter binding in LearningCacheStore UPSERT"
+
+  # architecture dimension の High finding の例
+  git add crates/kotoha-storage/src/learning_cache/mod.rs
+  git commit -m "fix(arch-h1): extract CapEnforcement into separate module per SRP"
+
+  # testing dimension の High finding の例
+  git add crates/kotoha-storage/tests/learning_cache_tests.rs
+  git commit -m "fix(test-h1): add boundary-value tests for LEARNING_CACHE_MAX_ROWS cap"
+
+  # performance dimension の High finding の例
+  git add crates/kotoha-storage/src/learning_cache/sqlite.rs
+  git commit -m "fix(perf-h1): replace sequential LRU scan with indexed ORDER BY for eviction"
+  ```
+
+- [ ] **Step 3: 各 finding 修正後に lefthook pre-push を手動実行して退行がないことを確認する**
+
+  ```bash
+  # lefthook の pre-push hook を手動実行する(全 5 step)
+  lefthook run pre-push 2>&1 | tee /tmp/p2c-e6-lefthook.txt
+  tail -10 /tmp/p2c-e6-lefthook.txt
+  ```
+
+  Expected output(末尾部分):
+  ```
+  SUMMARY: 6 tasks passed
+  ```
+
+  いずれかの task が FAIL した場合は、退行を修正してから次の finding に進む。
+
+- [ ] **Step 4: 修正済み commit を origin に push して PR を最新化する**
+
+  ```bash
+  git push origin feature/105-p2-c-learning-cache
+  gh pr view <PR_NUMBER>
+  ```
+
+  GitHub 上の PR に新 commit が反映されていることを確認する。
+
+---
+
+### Task E7: re-review + merge までのチェックリスト確認 + squash merge
+
+**Files:**
+- 変更なし(review 実行 + git 操作のみ)
+
+- [ ] **Step 1: E5 の 4-dim team-review を再実行して Critical + High が 0 件になったことを確認する**
+
+  E6 で修正した finding に対して team-review を再実行する。再実行時は E5 Step 2 と同一の引数を使用する。Critical + High finding が 0 件になるまで E6 → E7 Step 1 のサイクルを繰り返す。
+
+  Critical + High が 0 件になった時点で Step 2 に進む。Medium / Low finding は新規 follow-up Issue に移管する(spec §7.3 deferred Issue 方針準拠)。
+
+- [ ] **Step 2: merge ready チェックリストを全項目確認する**
+
+  spec §8 Acceptance Criteria の全 13 項目を確認する。
+
+  - [ ] `cargo test --workspace` が `default` / `dict` / `dict-persist` の 3 構成すべてで PASS し、退行ゼロ(全 355+ test PASS を維持)
+  - [ ] `cargo clippy --workspace --all-targets -- -D warnings` で警告ゼロ
+  - [ ] `cargo audit` で 0 vulnerability を維持
+  - [ ] lefthook pre-push の 3-feature gate(fmt / clippy / test)が全 PASS
+  - [ ] P2-C 着地後の test count baseline: `default` 304 程度 / `dict` 363 程度 / `dict-persist` 384 程度
+  - [ ] `LearningCacheReader` / `LearningCacheWriter` / `UserVocabReader` / `UserVocabWriter` の 4 trait が `kotoha-storage` の public API として確立されている
+  - [ ] 旧 `UserVocabStore` trait および旧 `LearningCacheStore` trait が削除されている
+  - [ ] `Database` factory が `user_vocab_reader` / `user_vocab_writer` / `learning_cache_reader` / `learning_cache_writer` の 4 method を持ち、旧 `user_vocab_store` / `learning_cache_store` の 2 method が削除されている
+  - [ ] v002 migration(`v002_learning_cache_index.sql`)が新規 DB 初期化と既存 v001 DB の auto-upgrade の双方で正常に動作する
+  - [ ] `SqliteLearningCacheStore` が UPSERT / auto eviction / LRU 削除 / lookup ordering の本実装を持ち、stub でないことを 23 件の L1 test が証明する
+  - [ ] proptest 3 invariant が `PROPTEST_CASES=64` で全 PASS
+  - [ ] WBS 記録(`docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md`)が作成されている
+  - [ ] Medium tier team-review(security / performance / architecture / testing の 4 dimension)で Critical / High finding が全消化されている(Medium / Low finding は新規 follow-up Issue に移管)
+
+  上記チェックリストの全項目が確認できた時点で Step 3 に進む。
+
+- [ ] **Step 3: squash merge を実行する**
+
+  P2-B PR #101 の慣習(squash merge)を踏襲する。
+
+  ```bash
+  gh pr merge <PR_NUMBER> --squash --delete-branch
+  ```
+
+  Expected output:
+  ```
+  ✓ Squashed and merged pull request #<PR_NUMBER> (feat(p2-c): LearningCache full impl + ISP split (4-trait boundary))
+  ✓ Deleted branch feature/105-p2-c-learning-cache
+  ```
+
+- [ ] **Step 4: merge 後に WBS 記録を `develop` へ直接 push する**
+
+  WBS 記録(`docs/wbs/*.md`)は対象 PR の merge 後に `develop` へ直接 push する例外扱いである(project CLAUDE.md「WBS 直接 push の例外」)。
+
+  ```bash
+  git checkout develop
+  git pull origin develop
+  # WBS ファイルが feature branch の squash merge に含まれていない場合は以下を実行する
+  # (squash merge で WBS commit が含まれた場合は git add / commit は不要)
+  git add docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
+  git commit -m "docs(wbs): add P2-C WBS reflection log (#105)"
+  git push origin develop
+  ```
+
+  push 後に `git log origin/develop --oneline | head -5` で WBS commit が develop に存在することを確認する。
+
+- [ ] **Step 5: Medium / Low finding の follow-up Issue を起票する**
+
+  E5 Step 5 でまとめた Medium / Low finding のうち、spec §7.3 deferred Issue 一覧に記載されていない finding を新規 GitHub Issue として起票する。
+
+  ```bash
+  gh issue create \
+    --title "P2-C follow-up: Medium/Low findings from team-review" \
+    --body "$(cat <<'EOF'
+  ## Context
+
+  These findings were identified during the Medium-tier team-review of PR #<PR_NUMBER> (P2-C LearningCache implementation).
+  Critical and High findings were resolved before merge. Medium and Low findings are deferred per spec §7.3.
+
+  ## Findings
+
+  (E5 Step 5 の Medium / Low finding 一覧をここに転記する)
+
+  ## References
+
+  - Spec §7.3: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
+  - WBS: docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
+  EOF
+  )"
+  ```
+
+---
+
+## Self-review 履歴
+
+本 plan は writing-plans skill に基づき以下の手順で作成した。
+
+| Phase | 範囲 | 着地行数 | 担当 |
+|---|---|---|---|
+| header + Phase A | 8 task(UserVocab ISP split) | 1075 行(累計) | docs-architect subagent #1 |
+| Phase B | 11 task(LearningCache 本実装) | 2224 行(累計) | docs-architect subagent #2 |
+| Phase C + D | 7 task(migration + test 整備) | 2998 行(累計) | docs-architect subagent #3 |
+| Phase E | 7 task(review / WBS / PR) | 3790 行(累計) | docs-architect subagent #4 |
+
+## 受容基準(spec §8 から再掲)
+
+- [ ] `cargo test --workspace` が `default` / `dict` / `dict-persist` の 3 構成すべてで PASS し、退行ゼロ(全 355+ test PASS を維持)
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` で警告ゼロ
+- [ ] `cargo audit` で 0 vulnerability を維持
+- [ ] lefthook pre-push の 3-feature gate(fmt / clippy / test)が全 PASS
+- [ ] P2-C 着地後の test count baseline: `default` 304 程度 / `dict` 363 程度 / `dict-persist` 384 程度
+- [ ] `LearningCacheReader` / `LearningCacheWriter` / `UserVocabReader` / `UserVocabWriter` の 4 trait が `kotoha-storage` の public API として確立されている
+- [ ] 旧 `UserVocabStore` trait および旧 `LearningCacheStore` trait が削除されている
+- [ ] `Database` factory が `user_vocab_reader` / `user_vocab_writer` / `learning_cache_reader` / `learning_cache_writer` の 4 method を持ち、旧 `user_vocab_store` / `learning_cache_store` の 2 method が削除されている
+- [ ] v002 migration(`v002_learning_cache_index.sql`)が新規 DB 初期化と既存 v001 DB の auto-upgrade の双方で正常に動作する
+- [ ] `SqliteLearningCacheStore` が UPSERT / auto eviction / LRU 削除 / lookup ordering の本実装を持ち、stub でないことを 23 件の L1 test が証明する
+- [ ] proptest 3 invariant が `PROPTEST_CASES=64` で全 PASS
+- [ ] WBS 記録(`docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md`)が作成されている
+- [ ] Medium tier team-review(security / performance / architecture / testing の 4 dimension)で Critical / High finding が全消化されている(Medium / Low finding は新規 follow-up Issue に移管)
+
+---
+
+end of plan(33 task / 5 phase)

--- a/docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
+++ b/docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
@@ -1,0 +1,1020 @@
+---
+title: Phase 2-C — LearningCache 本実装 + arch-M-2 ISP split 設計
+phase: 2
+sub-phase: C
+status: draft
+related-adr:
+  - 0014  # phase-2 dictionary layer architecture
+  - 0015  # kotoha-storage SQLite adoption
+related-spec:
+  - 2026-04-25-kotoha-phase-2-design.md
+  - 2026-04-25-p2-b-user-dictionary-design.md
+created-at: 2026-04-26
+---
+
+# Phase 2-C — LearningCache 本実装 + arch-M-2 ISP split 設計書
+
+本設計書は Phase 2「Dictionary and learning」の 3 番目の milestone P2-C を詳細化する子 spec である。Phase 2 spec(parent-spec)§3.2 Learning cache および §5.2 persistence を前提とし、P2-B で skeleton として配置した `LearningCacheStore` の 3 method を本実装する。同時に arch-M-2(Interface Segregation Principle: Reader/Writer 分離)を消化し、`UserVocabStore` / `LearningCacheStore` の両 trait を Reader/Writer に分割する。Phase 2 spec / ADR 0014 と本設計書の記述が矛盾する箇所は、本設計書が新しい(P2-C kick-off で確定した最新方針)とする。
+
+## 目次
+
+- [1. 概要 / 目的 / 非目的](#1-概要--目的--非目的)
+- [2. アーキテクチャ全体像](#2-アーキテクチャ全体像)
+- [3. ISP split: trait 設計](#3-isp-split-trait-設計)
+- [4. SQL / migration / index 設計](#4-sql--migration--index-設計)
+- [5. エラー処理と edge case](#5-エラー処理と-edge-case)
+- [6. テスト戦略](#6-テスト戦略)
+- [7. 実装順序と branch / PR 戦略](#7-実装順序と-branch--pr-戦略)
+- [8. 受容基準](#8-受容基準acceptance-criteria)
+- [9. 参考 / 関連文書](#9-参考--関連文書)
+
+---
+
+## 1. 概要 / 目的 / 非目的
+
+### 1.1 目的
+
+P2-C は以下 3 点を達成する milestone である。
+
+1. P2-B で skeleton として配置した `LearningCacheStore` trait の 3 method(`lookup` / `record_choice` / `evict_lru`)を `SqliteLearningCacheStore` に本実装する。P2-B 着地時点で `learning_cache` table schema(v001 migration)は既に存在しており、本 Phase はビジネスロジックとインデックス追加のみを担う。
+2. arch-M-2 として `UserVocabStore` / `LearningCacheStore` の両 trait を SOLID ISP(Interface Segregation Principle)に従い Reader/Writer の 4 trait に分割する。
+3. v002 migration を追加し、`learning_cache` table に `idx_learning_cache_last_used` index を付与する。
+
+### 1.2 P2-B 着地状態の確認
+
+P2-B 完了時点において以下のコンポーネントが確立済である。
+
+- `LearningCacheStore` trait(`lookup` / `record_choice` / `evict_lru` の 3 method)は `crates/kotoha-storage/src/learning_cache/mod.rs` に宣言済
+- `SqliteLearningCacheStore` は `crates/kotoha-storage/src/learning_cache/sqlite.rs` に stub 実装済(すべての method が no-op を返す)
+- `learning_cache` table は v001 migration(`migrations/v001_initial.sql`)で schema 作成済
+- `Database::learning_cache_store()` factory は `crates/kotoha-storage/src/database.rs` に存在し、stub instance を返す
+- test count baseline は `dict-persist` feature で 355 PASS
+
+### 1.3 本 Phase の射程
+
+P2-C は以下を実装対象とする。
+
+- `kotoha-storage` 内 `LearningCacheStore` の本実装(UPSERT / auto eviction / lookup ordering)
+- `UserVocabReader` / `UserVocabWriter` / `LearningCacheReader` / `LearningCacheWriter` の 4 trait 新設と旧 `UserVocabStore` / `LearningCacheStore` trait の削除
+- `Database` factory の 4 method 化(`user_vocab_reader` / `user_vocab_writer` / `learning_cache_reader` / `learning_cache_writer`)
+- v002 migration(`idx_learning_cache_last_used`)
+- L1 / L2 / proptest の全 test 整備
+
+### 1.4 非目的(Out of scope)
+
+以下は本 Phase の対象外である。
+
+- **Hybrid backend / Ranker 統合(P2-D)**: `BackendConfig::Hybrid { llm, dict, learning }` および LLM 候補 / Dict 候補 / LearningCache hit を merge / dedupe / rerank する Ranker 実装は P2-D で行う
+- **IBus engine 接続(Phase 3-A)**: `kotoha-dict` CLI から IBus engine への LearningCache 公開は Phase 3 で判断する。P2-C の LearningCache は CLI に露出させない
+- **connection pool(perf-M-1)**: `Mutex<Connection>` を Pool に置き換える最適化は別 Issue で扱う
+- **prefix lookup**: `kana_input` の prefix match は Phase 3 で必要性が顕在化してから追加する
+- **v002 migration の down 整備**: forward-only 方針(P2-B §3.6 決定)を継続する
+
+---
+
+## 2. アーキテクチャ全体像
+
+### 2.1 データフロー図(ASCII)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  呼び出し元                                                   │
+│  ┌────────────┐  ┌───────────────────────┐  ┌────────────┐  │
+│  │ kotoha-cli  │  │ Phase 3 IBus engine  │  │ P2-D Ranker│  │
+│  │ (dict_cli) │  │ (kotoha-ibus, 未着手) │  │ (P2-D 未着手)│  │
+│  └─────┬──────┘  └──────────┬────────────┘  └─────┬──────┘  │
+└────────┼────────────────────┼────────────────────┼──────────┘
+         │                   │                    │
+         ▼                   ▼                    ▼
+┌──────────────────────────────────────────────────────────────┐
+│  kotoha-storage: Database factory 4 method                   │
+│                                                              │
+│  db.user_vocab_reader()   ──►  Box<dyn UserVocabReader>      │
+│  db.user_vocab_writer()   ──►  Box<dyn UserVocabWriter>      │
+│  db.learning_cache_reader()──► Box<dyn LearningCacheReader>  │
+│  db.learning_cache_writer()──► Box<dyn LearningCacheWriter>  │
+│                              │                               │
+│  (全 factory は内部で Arc<SqliteXXXStore> を共有する)         │
+└──────────────────────────────┬───────────────────────────────┘
+                               │
+                               ▼
+┌──────────────────────────────────────────────────────────────┐
+│  SQLite kotoha.db                                            │
+│  ┌──────────────────────┐  ┌──────────────────────────────┐  │
+│  │ user_vocab table     │  │ learning_cache table         │  │
+│  │  idx_user_vocab_reading│ │  idx_learning_cache_kana    │  │
+│  │  (v001)              │  │  idx_learning_cache_last_used│  │
+│  │                      │  │  (v002 で追加)               │  │
+│  └──────────────────────┘  └──────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 P2-C 着地後の crate 構造
+
+```
+crates/kotoha-storage/
+├── migrations/
+│   ├── v001_initial.sql                    (既存、変更なし)
+│   └── v002_learning_cache_index.sql       (新規: idx_learning_cache_last_used 追加)
+├── src/
+│   ├── lib.rs                              (pub use 再 export、ISP 4 trait を公開)
+│   ├── database.rs                         (factory 4 method 化、旧 2 method 削除)
+│   ├── migrations.rs                       (LATEST_VERSION = 2 に更新、v002 登録)
+│   ├── error.rs                            (変更なし)
+│   ├── path.rs                             (変更なし)
+│   ├── validation.rs                       (変更なし)
+│   ├── learning_cache/
+│   │   ├── mod.rs                          (LearningCacheReader + LearningCacheWriter trait
+│   │   │                                    + LearningCacheRecord 型、旧 LearningCacheStore
+│   │   │                                    trait 削除)
+│   │   └── sqlite.rs                       (本実装: UPSERT + auto eviction + cap const
+│   │                                        + cap override RAII guard + 23 単体 test)
+│   └── user_vocab/
+│       ├── store.rs                         (UserVocabReader + UserVocabWriter に分割、
+│       │                                    旧 UserVocabStore trait 削除)
+│       ├── sqlite.rs                        (UserVocabReader + UserVocabWriter 双方を
+│       │                                    impl、既存 test を移行)
+│       └── mock.rs                          (UserVocabReader + UserVocabWriter 双方を
+│                                            impl、既存 test を移行)
+├── tests/
+│   ├── learning_cache_store.rs             (新規: L2 integration test 3 件)
+│   ├── learning_cache_proptest.rs          (新規: proptest 3 invariant)
+│   └── dict_user_vocab.rs                  (既存修正: factory split 反映)
+```
+
+`kotoha-cli/src/dict_cli.rs` は factory API の変更に追従するよう書換える。
+
+### 2.3 設計境界
+
+本 Phase は「1 Phase 1 ISSUE 1 PR」原則(global CLAUDE.md Branch Scope Policy: ≤20 file / ≤1000 line)に従う。ISP split は LearningCache 本実装の前提条件であるため、単一 PR に統合する。Branch Scope Policy 上限超過が見込まれる場合は §7.2 のフォールバック戦略を適用する。
+
+---
+
+## 3. ISP split: trait 設計
+
+### 3.1 LearningCacheReader / LearningCacheWriter(新設)
+
+P2-B の `LearningCacheStore` trait を ISP に従い 2 trait に分割する。旧 `LearningCacheStore` trait は本 Phase 完了時点で削除する。
+
+```rust
+//! `crates/kotoha-storage/src/learning_cache/mod.rs`
+
+pub mod sqlite;
+
+pub use sqlite::SqliteLearningCacheStore;
+
+use crate::error::StorageError;
+
+/// Learning cache の read 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+/// - `limit` は 0 より大きい値を推奨する(0 を渡した場合は空 `Vec` を返す)
+///
+/// # Postconditions
+///
+/// - `lookup` の戻り値は `frequency DESC, last_used_at DESC` 順に `limit` 件以下を含む
+/// - 該当 entry が存在しない場合は `Ok(Vec::new())` を返し、`Err` は返さない
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: `kana_input` が validation 違反の場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait LearningCacheReader: Send + Sync {
+    /// `kana_input` に対応する変換候補を `frequency DESC, last_used_at DESC` 順で返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+    /// - `limit` は呼び出し元が必要な件数の上限を示す
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の長さは `limit` 以下
+    /// - 戻り値の `frequency` は先頭 ≥ 末尾(単調非増加、同値は `last_used_at DESC` で整列)
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `kana_input` が hiragana 以外の文字を含む場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use kotoha_storage::learning_cache::LearningCacheReader;
+    /// # fn doc(reader: &dyn LearningCacheReader) -> Result<(), Box<dyn std::error::Error>> {
+    /// let results = reader.lookup("ちょうかん", 5)?;
+    /// // results[0].frequency >= results[1].frequency (先頭が最多)
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn lookup(
+        &self,
+        kana_input: &str,
+        limit: usize,
+    ) -> Result<Vec<LearningCacheRecord>, StorageError>;
+}
+
+/// Learning cache の write 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+/// - `chosen_kanji` は non-empty / ≤256 bytes / no control char / no bidi / no disallowed PUA
+///
+/// # Postconditions
+///
+/// - `record_choice` 成功後は該当 `(kana_input, chosen_kanji)` の `frequency` が 1 以上増加し、
+///   `last_used_at` が現在時刻(UNIX epoch seconds)以上の値に更新される
+/// - `record_choice` 成功後にキャッシュ行数が cap を超えた場合、`last_used_at` が最も古い entry
+///   から順に削除され、行数が cap に収まる状態を保つ
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: validation 違反の場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait LearningCacheWriter: Send + Sync {
+    /// ユーザの変換選択を `learning_cache` table に記録する。
+    ///
+    /// `(kana_input, chosen_kanji)` が既存の場合は `frequency += 1` かつ
+    /// `last_used_at` を現在時刻に更新する。新規の場合は `frequency = 1` で insert する。
+    /// insert / update 後に行数が cap を超えた場合は `last_used_at` が最も古い entry を
+    /// 自動的に削除し、行数を cap 以内に収める。
+    ///
+    /// # Preconditions
+    ///
+    /// - `kana_input` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+    /// - `chosen_kanji` は validate_surface の制約を満たす(non-empty / ≤256 bytes /
+    ///   no control char / no bidi / no disallowed PUA)
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値 `Ok(())` の時点でトランザクションがコミットされている
+    /// - 行数は `effective_max_rows()` 以下を維持する
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `kana_input` / `chosen_kanji` が validation 違反
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害(disk full / SQLITE_BUSY など)
+    fn record_choice(&self, kana_input: &str, chosen_kanji: &str) -> Result<(), StorageError>;
+
+    /// `learning_cache` table から LRU(最終使用が最も古い)entry を削除して行数を `max_entries` 以内に収める。
+    ///
+    /// 呼び出し元が明示的に eviction を要求する場合に使用する。
+    /// 通常の record_choice では内部で `effective_max_rows()` を cap として自動 eviction が動作するため、
+    /// 本 method を明示呼び出しする必要は少ない。本 method は test / 手動 GC /
+    /// Phase 5 personalization での動的 cap 変更を想定して `max_entries` 引数を維持する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `max_entries` は 1 以上を推奨する(0 を渡した場合は全行削除が発生する)
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は削除した行数を示す
+    /// - 行数が `max_entries` 以下の場合は削除を行わず `Ok(0)` を返す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn evict_lru(&self, max_entries: usize) -> Result<usize, StorageError>;
+}
+
+/// Learning cache の 1 行を表す struct。
+///
+/// # Invariants
+///
+/// - `id` は DB 内の `INTEGER PRIMARY KEY AUTOINCREMENT` 値(DB から取得した場合のみ有効)
+/// - `frequency` は 1 以上(insert 時点で 1、以降 `record_choice` 毎に +1 される)
+/// - `last_used_at` は UNIX epoch seconds 形式の非負整数
+#[derive(Debug, Clone, PartialEq)]
+pub struct LearningCacheRecord {
+    /// `learning_cache.id`(DB 自動採番)。
+    pub id: i64,
+    /// 変換前のひらがな入力。
+    pub kana_input: String,
+    /// ユーザが選択した変換後文字列。
+    pub chosen_kanji: String,
+    /// `(kana_input, chosen_kanji)` の組合せが選ばれた累積回数。
+    pub frequency: u32,
+    /// 最後に選択された時刻(UNIX epoch seconds)。
+    pub last_used_at: i64,
+}
+```
+
+### 3.2 UserVocabReader / UserVocabWriter(arch-M-2 split)
+
+旧 `UserVocabStore` trait を ISP に従い Reader / Writer の 2 trait に分割する。旧 `UserVocabStore` trait は本 Phase 完了時点で削除する。`kotoha-cli/src/dict_cli.rs` が唯一の consumer であり、書換範囲は同 1 ファイルに収まる。
+
+```rust
+//! `crates/kotoha-storage/src/user_vocab/store.rs`
+
+use crate::error::StorageError;
+
+/// User vocabulary の read 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `reading` はひらがな canonical(`U+3040..=U+309F + U+30FC + U+30FB`)
+///
+/// # Postconditions
+///
+/// - `find_by_reading` は `score DESC` 順で最大 `limit` 件返す
+/// - `find_by_prefix` は `score DESC` 順で最大 `limit` 件返す
+/// - `find_by_id` は不在の場合 `Ok(None)` を返す(エラーではない)
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: `reading` が validation 違反の場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait UserVocabReader: Send + Sync {
+    /// `reading` が完全一致する entry を `score DESC` 順で返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `reading` はひらがな canonical
+    /// - `limit` は呼び出し元が必要な件数の上限を示す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `reading` が hiragana 以外を含む場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn find_by_reading(
+        &self,
+        reading: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError>;
+
+    /// 主キー `id` で entry 1 件を引く。
+    ///
+    /// # Postconditions
+    ///
+    /// - 不在の場合は `Ok(None)` を返す
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn find_by_id(&self, id: i64) -> Result<Option<UserVocabRecord>, StorageError>;
+
+    /// `reading` が `reading_prefix` で前方一致する entry を `score DESC` 順で返す。
+    ///
+    /// SQL `reading LIKE 'PREFIX%'` を使用する。
+    ///
+    /// # Preconditions
+    ///
+    /// - `reading_prefix` はひらがな canonical
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: `reading_prefix` が validation 違反の場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn find_by_prefix(
+        &self,
+        reading_prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<UserVocabRecord>, StorageError>;
+
+    /// 全 entry を `id ASC` 順でページネーション付きで返す。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn list_all(&self, limit: usize, offset: usize) -> Result<Vec<UserVocabRecord>, StorageError>;
+}
+
+/// User vocabulary の write 操作を提供する抽象境界。
+///
+/// # Preconditions
+///
+/// - `record.surface` / `record.reading` / `record.pos` / `record.score` は各 validation を通過
+///
+/// # Postconditions
+///
+/// - `insert` 成功時は採番された `id` を返す
+/// - UNIQUE(surface, reading) 違反は [`StorageError::DuplicateEntry`]
+/// - `delete_by_id` / `delete_by_surface_reading` の対象不在は [`StorageError::NotFound`]
+///
+/// # Errors
+///
+/// - [`StorageError::InvalidField`]: validation 違反の場合
+/// - [`StorageError::DuplicateEntry`]: UNIQUE 制約違反の場合
+/// - [`StorageError::NotFound`]: 削除対象が存在しない場合
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+pub trait UserVocabWriter: Send + Sync {
+    /// `record` を `user_vocab` table に insert し、採番された `id` を返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - `record.surface` / `record.reading` / `record.pos` は各 validate_* を通過
+    /// - `record.score` は finite + non-negative
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は `AUTOINCREMENT` で採番された `id`
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::InvalidField`]: field validation 違反の場合
+    /// - [`StorageError::DuplicateEntry`]: UNIQUE(surface, reading) 違反の場合
+    /// - [`StorageError::QuotaExceeded`]: 行数が `USER_VOCAB_MAX_ROWS` に到達している場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn insert(&self, record: UserVocabRecord) -> Result<i64, StorageError>;
+
+    /// 主キー `id` で entry を 1 件削除する。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`]: `id` が存在しない場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn delete_by_id(&self, id: i64) -> Result<(), StorageError>;
+
+    /// `(surface, reading)` で entry を 1 件削除する。
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`]: 対象 entry が存在しない場合
+    /// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+    fn delete_by_surface_reading(&self, surface: &str, reading: &str) -> Result<(), StorageError>;
+}
+
+/// User vocabulary の row。
+///
+/// # Invariants
+///
+/// - `id` は insert 前は `None`、DB から取得した場合は `Some`
+/// - `score` は finite + non-negative(`validate_score` 通過後に保証)
+/// - `created_at` / `updated_at` は UNIX epoch seconds
+#[derive(Debug, Clone, PartialEq)]
+pub struct UserVocabRecord {
+    pub id: Option<i64>,
+    pub surface: String,
+    pub reading: String,
+    pub pos: String,
+    pub score: f32,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+```
+
+`SqliteUserVocabStore` は `UserVocabReader` と `UserVocabWriter` の両方を impl する。`MockUserVocabStore` も同様に両方を impl する。
+
+### 3.3 Database factory 4 method 化
+
+```rust
+//! `crates/kotoha-storage/src/database.rs`(抜粋)
+
+impl Database {
+    /// `Arc<Database>` を `Box<dyn UserVocabReader>` として公開する。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持し、
+    ///   同一 `Database` から生成された他の factory の戻り値と同一 SQLite connection を共有する
+    pub fn user_vocab_reader(self: &Arc<Self>) -> Box<dyn crate::user_vocab::store::UserVocabReader> {
+        Box::new(crate::user_vocab::sqlite::SqliteUserVocabStore::new(
+            Arc::clone(self),
+        ))
+    }
+
+    /// `Arc<Database>` を `Box<dyn UserVocabWriter>` として公開する。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteUserVocabStore>` を保持する
+    pub fn user_vocab_writer(self: &Arc<Self>) -> Box<dyn crate::user_vocab::store::UserVocabWriter> {
+        Box::new(crate::user_vocab::sqlite::SqliteUserVocabStore::new(
+            Arc::clone(self),
+        ))
+    }
+
+    /// `Arc<Database>` を `Box<dyn LearningCacheReader>` として公開する。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    pub fn learning_cache_reader(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::learning_cache::LearningCacheReader> {
+        Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+            Arc::clone(self),
+        ))
+    }
+
+    /// `Arc<Database>` を `Box<dyn LearningCacheWriter>` として公開する。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の trait object は内部で `Arc<SqliteLearningCacheStore>` を保持する
+    pub fn learning_cache_writer(
+        self: &Arc<Self>,
+    ) -> Box<dyn crate::learning_cache::LearningCacheWriter> {
+        Box::new(crate::learning_cache::SqliteLearningCacheStore::new(
+            Arc::clone(self),
+        ))
+    }
+}
+```
+
+旧 `user_vocab_store()` と `learning_cache_store()` の 2 method は本 Phase 完了時点で削除する。各 factory は内部で `Arc<SqliteXXXStore>` を新規生成して `Box<dyn TraitX>` で wrap して返す。同一 `Arc<Database>` から生成された複数の factory 戻り値は、同一の `Mutex<Connection>` を介して SQLite connection を共有する。
+
+---
+
+## 4. SQL / migration / index 設計
+
+### 4.1 v002 migration
+
+```sql
+-- crates/kotoha-storage/migrations/v002_learning_cache_index.sql
+-- spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md §4.1
+
+CREATE INDEX idx_learning_cache_last_used ON learning_cache(last_used_at);
+```
+
+v002 migration を追加することにより、`migrations.rs` の `LATEST_VERSION` を `2` に更新し、`MIGRATIONS` 定数配列に `(2, include_str!("../migrations/v002_learning_cache_index.sql"))` を追加する。
+
+本 migration は forward-only(P2-B §3.6 決定)とする。既存 v001 DB を持つ環境では `Database::open()` 実行時に `PRAGMA user_version` が `1` であることを検出し、v002 を自動 apply する。新規 DB 初期化では v001 と v002 を順に apply する。
+
+追加する index の目的は、`evict_lru` の LRU 削除(`ORDER BY last_used_at ASC`) および `lookup` の `ORDER BY frequency DESC, last_used_at DESC` における `last_used_at` 列のソートを index seek で高速化することである。
+
+### 4.2 record_choice の実装
+
+`record_choice` は以下の手順で動作する。
+
+1. `validate_reading(kana_input)` を実行し、ひらがな以外が含まれる場合は `StorageError::InvalidField` を返す。
+2. `validate_surface(chosen_kanji)` を実行し、validation 違反の場合は `StorageError::InvalidField` を返す。
+3. `now = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64).unwrap_or(0)` で現在時刻を取得する。
+4. `self.db.lock_conn()` で `Mutex<Connection>` を取得する。
+5. UPSERT SQL を `prepare_cached` で実行する。
+6. 総行数が `effective_max_rows()` を超えた場合、共通 helper `evict_to_cap` を呼び出して超過分を削除する。
+
+```rust
+// record_choice の UPSERT SQL(SQLite 3.24+ ON CONFLICT UPSERT 構文)
+const UPSERT_SQL: &str =
+    "INSERT INTO learning_cache (kana_input, chosen_kanji, frequency, last_used_at)
+     VALUES (?1, ?2, 1, ?3)
+     ON CONFLICT(kana_input, chosen_kanji)
+     DO UPDATE SET
+         frequency     = frequency + 1,
+         last_used_at  = excluded.last_used_at";
+```
+
+`prepare_cached` を使用することで Phase 3 IBus engine の打鍵毎呼び出しでも SQL コンパイルを 1 度きりにする(perf-H1: P2-B `SqliteUserVocabStore` と同方針)。
+
+### 4.3 lookup の実装
+
+```rust
+// lookup SQL
+const LOOKUP_SQL: &str =
+    "SELECT id, kana_input, chosen_kanji, frequency, last_used_at
+     FROM learning_cache
+     WHERE kana_input = ?1
+     ORDER BY frequency DESC, last_used_at DESC
+     LIMIT ?2";
+```
+
+`idx_learning_cache_kana`(v001 で作成済)経由で index seek を行い、`kana_input` 完全一致の行セットを取得する。取得行セットを `frequency DESC, last_used_at DESC` でソートして `limit` 件を返す。該当 entry が存在しない場合は `Ok(Vec::new())` を返す。
+
+### 4.4 evict_lru の実装(明示呼び出し用)
+
+```rust
+// evict_lru の総行数チェック SQL
+const COUNT_SQL: &str = "SELECT count(*) FROM learning_cache";
+
+// evict_to_cap が使用する LRU 削除 SQL
+const EVICT_SQL: &str =
+    "DELETE FROM learning_cache
+     WHERE id IN (
+         SELECT id FROM learning_cache
+         ORDER BY last_used_at ASC, id ASC
+         LIMIT ?1
+     )";
+```
+
+`evict_lru` は以下の手順で動作する。
+
+1. `self.db.lock_conn()` で `Mutex<Connection>` を取得する。
+2. 共通 helper `evict_to_cap(&conn, max_entries)` を呼び出す。`evict_to_cap` は内部で `COUNT_SQL` を実行し、総行数が `max_entries` 以下なら `Ok(0)` を early return する。
+3. 総行数が `max_entries` を超えている場合、超過分(`total - max_entries` 件)を `EVICT_SQL` で削除する。
+4. 削除した行数を `Ok(n)` で返す。
+
+```rust
+// evict_lru の実装例
+impl LearningCacheWriter for SqliteLearningCacheStore {
+    fn evict_lru(&self, max_entries: usize) -> Result<usize, StorageError> {
+        let conn = self.db.lock_conn();
+        evict_to_cap(&conn, max_entries)
+    }
+}
+```
+
+`record_choice` が内部で呼び出す `evict_to_cap` は `cap = effective_max_rows()` を渡す。`evict_lru` は呼び出し元が指定した `max_entries` を `cap` として `evict_to_cap` に渡す。両者は同一 helper を共有するが、cap の出所が異なる。
+
+### 4.5 共通 eviction helper `evict_to_cap`
+
+`record_choice` と `evict_lru` の両方から呼び出す共通 helper を抽出する。
+
+```rust
+/// `learning_cache` の行数が `cap` を超えている場合、LRU から `count - cap` 行削除する。
+///
+/// # Preconditions
+///
+/// - `conn` は `lock_conn()` で取得済の `MutexGuard<Connection>`
+/// - `cap` は呼び出し元が指定する行数上限値。`record_choice` からは `effective_max_rows()` を渡し、
+///   `evict_lru` からは呼び出し元が引数として指定した `max_entries` を渡す
+///
+/// # Postconditions
+///
+/// - 戻り値は削除した行数
+/// - 行数 ≤ cap が保証される
+///
+/// # Errors
+///
+/// - [`StorageError::Sqlite`]: SQLite backend 障害の場合
+fn evict_to_cap(conn: &rusqlite::Connection, cap: usize) -> Result<usize, StorageError> {
+    let total: i64 = conn.query_row(COUNT_SQL, [], |r| r.get(0))?;
+    let total = total as usize;
+    if total <= cap {
+        return Ok(0);
+    }
+    let excess = total - cap;
+    let mut stmt = conn.prepare_cached(EVICT_SQL)?;
+    let deleted = stmt.execute(rusqlite::params![excess as i64])?;
+    Ok(deleted)
+}
+```
+
+### 4.6 cap const と test override pattern
+
+`LEARNING_CACHE_MAX_ROWS` は production の行数上限を定義する。P2-B の `USER_VOCAB_MAX_ROWS` / `QuotaOverrideGuard` パターンを完全に踏襲する。
+
+```rust
+//! `crates/kotoha-storage/src/learning_cache/sqlite.rs`(cap override 部分)
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Learning cache の行数上限(production 値)。
+pub const LEARNING_CACHE_MAX_ROWS: usize = 10_000;
+
+/// テスト時の行数上限上書き(0 = unset、`LEARNING_CACHE_MAX_ROWS` を使用)。
+///
+/// `cargo test` ビルドでのみ意味を持ち、production binary には含まれない。
+/// 10,000 行を実際に挿入するテストは時間 / メモリの観点で非現実的なため、
+/// 単体テストはこの override を介して小さな上限値で eviction 動作を検証する。
+#[cfg(test)]
+pub(crate) static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
+
+/// override の直列化用 Mutex(複数 test が同時 override しないよう直列化)。
+#[cfg(test)]
+pub(crate) static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// 行数上限の effective value を返す(`#[cfg(test)]` 時のみ override を考慮)。
+#[inline]
+pub(crate) fn effective_max_rows() -> usize {
+    #[cfg(test)]
+    {
+        let v = LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.load(Ordering::SeqCst);
+        if v != 0 {
+            return v;
+        }
+    }
+    LEARNING_CACHE_MAX_ROWS
+}
+
+/// テスト中だけ `LEARNING_CACHE_MAX_ROWS` を `cap` に上書きする RAII guard。
+///
+/// drop 時に自動で 0(無効)に戻すので、test 同士の干渉を防ぐ。
+/// override は process 全体の static なため、複数 test が同時に
+/// override を活性化すると競合する。よって `CAP_OVERRIDE_LOCK` を
+/// 取得して直列化する。
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(test)]
+/// # fn example() {
+/// let _guard = CapOverrideGuard::new(5);
+/// // このブロック内では cap = 5 で動作する
+/// // _guard が drop されると cap = LEARNING_CACHE_MAX_ROWS に戻る
+/// # }
+/// ```
+#[cfg(test)]
+pub(crate) struct CapOverrideGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl CapOverrideGuard {
+    pub(crate) fn new(cap: usize) -> Self {
+        // poison していても続行(直前 test の panic でも次 test を回したい)。
+        let lock = CAP_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(cap, Ordering::SeqCst);
+        Self { _lock: lock }
+    }
+}
+
+#[cfg(test)]
+impl Drop for CapOverrideGuard {
+    fn drop(&mut self) {
+        LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(0, Ordering::SeqCst);
+    }
+}
+```
+
+---
+
+## 5. エラー処理と edge case
+
+### 5.1 StorageError 既存 variant 流用
+
+P2-C は `StorageError` に新規 variant を追加しない。追加しない理由を以下に示す。
+
+- LearningCache は cap 超過を eviction で自動吸収するため、`QuotaExceeded` を呼び出し元に返す必要がない(`UserVocabStore` の `insert` が `QuotaExceeded` を返すのと対称的に設計する必要はない)
+- validation 失敗は既存 `InvalidField` variant で網羅できる
+- SQLite backend 障害は既存 `Sqlite` variant で網羅できる
+
+ケース別の variant 対応表を以下に示す。
+
+| ケース | 使用する StorageError variant |
+|---|---|
+| `kana_input` が hiragana 以外を含む | `InvalidField { name: "kana_input", .. }` |
+| `chosen_kanji` が空 / 256 bytes 超 / control char / bidi / disallowed PUA | `InvalidField { name: "chosen_kanji", .. }` |
+| SQLite backend 障害(disk full / SQLITE_BUSY / SQLITE_LOCKED) | `Sqlite(rusqlite::Error)` |
+| `Mutex<Connection>` の lock_conn での poison | lock_conn 内で `expect` により panic(既存実装と同方針、本 Phase で変更なし。recover 経路の追加は §7.3 の sec-L-2 Issue で後続対応) |
+
+### 5.2 edge case 一覧
+
+以下の 10 件の edge case について、入力 / 期待動作 / 設計判断を定義する。
+
+**E1: 同エントリを連続して record_choice した場合**
+
+- 入力: `record_choice("あい", "愛")` を N 回呼び出す
+- 期待動作: `(kana_input="あい", chosen_kanji="愛")` の `frequency` が N に増加し、`last_used_at` が最後の呼び出し時刻に更新される
+- 設計判断: UPSERT の `ON CONFLICT DO UPDATE SET frequency = frequency + 1` が正確に 1 ずつ増分する
+
+**E2: 同一 kana_input に異なる chosen_kanji を record_choice した場合**
+
+- 入力: `record_choice("あい", "愛")` と `record_choice("あい", "哀")` を別々に呼び出す
+- 期待動作: `UNIQUE(kana_input, chosen_kanji)` の制約により 2 件の別 entry として保持される
+- 設計判断: `(kana_input, chosen_kanji)` の複合 UNIQUE が entry の識別単位である
+
+**E3: cap 直上 / 直下 / burst insert した場合**
+
+- 入力(直下): 行数が `cap - 1` の状態で `record_choice` を 1 件実行する
+- 期待動作: 行数が `cap` になり eviction は発生しない
+- 入力(直上): 行数が `cap` の状態で新規 `record_choice` を実行する
+- 期待動作: 新規 entry が insert された後、`last_used_at` が最小の entry 1 件が削除され行数が `cap` に戻る
+- 入力(burst): 行数 0 の状態から `cap + 10` 件を連続して insert する
+- 期待動作: 最終行数は `cap` 以下であり、`cap + 10` にはならない
+
+**E4: last_used_at が tie した場合の tie-break**
+
+- 入力: 2 件の entry が同一の `last_used_at` を持ち、eviction が 1 件のみ必要な場合
+- 期待動作: `id ASC` で小さい entry(先に insert された entry)が削除される
+- 設計判断: `EVICT_SQL` の `ORDER BY last_used_at ASC, id ASC` が tie-break を担保する
+
+**E5: record_choice で更新した entry が eviction 対象から外れる場合**
+
+- 入力: 行数 cap の状態で、既存の最古エントリに対して `record_choice` を実行する
+- 期待動作: 対象 entry の `last_used_at` が現在時刻に更新されるため LRU 最古でなくなり、eviction 対象から外れる。代わりに次に古い entry が削除される
+- 設計判断: UPSERT で `last_used_at = excluded.last_used_at` を更新することで LRU 保護が自動的に機能する
+
+**E6: lookup で該当 entry が存在しない場合**
+
+- 入力: `lookup("ほげほげ", 10)` を呼び出す(該当 kana_input が存在しない)
+- 期待動作: `Ok(Vec::new())` を返す。`Err` を返すことは仕様違反である
+- 設計判断: 変換候補の不在は正常状態であり、エラーとして扱わない
+
+**E7: lookup の ordering と limit**
+
+- 入力: `(kana_input="あ", chosen_kanji="亜")` frequency=5、`(kana_input="あ", chosen_kanji="阿")` frequency=3 が存在する状態で `lookup("あ", 1)` を呼び出す
+- 期待動作: frequency が高い `chosen_kanji="亜"` の entry のみが返される
+- 設計判断: `ORDER BY frequency DESC, last_used_at DESC LIMIT ?2` が ordering と件数制限を担保する
+
+**E8: validation reject の場合**
+
+- 入力(非ひらがな kana_input): `record_choice("abc", "亜")` を呼び出す
+- 期待動作: `Err(StorageError::InvalidField { name: "kana_input", .. })`
+- 入力(空 chosen_kanji): `record_choice("あ", "")` を呼び出す
+- 期待動作: `Err(StorageError::InvalidField { name: "chosen_kanji", .. })`
+- 入力(PUA in chosen_kanji、allowlist 外): `record_choice("あ", "\u{E001}")` を呼び出す
+- 期待動作: `Err(StorageError::InvalidField { name: "chosen_kanji", reason: "PUA char" })`
+- 入力(256 bytes 超 kana_input): `"あ".repeat(86)` (= 258 bytes) を kana_input として渡す
+- 期待動作: `Err(StorageError::InvalidField { name: "kana_input", reason: "byte size > 256" })`
+
+**E9: 並行 record_choice の直列化**
+
+- 入力: 複数スレッドが同時に `record_choice` を呼び出す
+- 期待動作: `Mutex<Connection>` による直列化により deadlock / data race が発生せず、全 insert が完了する
+- 設計判断: `lock_conn()` が `Mutex::lock().expect(...)` で排他取得するため、並行呼び出しは直列化される
+
+**E10: system clock の backward jump**
+
+- 入力: 2 回連続の `record_choice` 呼び出しの間に system clock が過去に戻る
+- 期待動作: `last_used_at` が後の呼び出しで小さくなる可能性がある。LRU ordering の厳密性は保証されないが、eviction 動作は継続する。crash や `Err` は返さない
+- 設計判断: NTP 補正や VM suspend/resume による backward jump は稀であり、self-recovering とみなす。明示的な単調増加保証は導入しない(実装コストに対して効果が薄い)
+
+---
+
+## 6. テスト戦略
+
+### 6.1 Test layer 構成
+
+P2-B の慣習(L1 単体 / L2 integration / L4 e2e)を踏襲する。L3 golden test は本 Phase の実装に対して適用しない。
+
+| Layer | 配置 | 焦点 |
+|---|---|---|
+| L1 単体 | `crates/kotoha-storage/src/learning_cache/sqlite.rs` の `#[cfg(test)] mod tests` | SQL semantics / UPSERT / eviction / validation / cap override |
+| L1 単体(ISP split 退行確認) | `crates/kotoha-storage/src/user_vocab/{sqlite,mock}.rs` の既存 test | trait split 後の退行ゼロを確認 |
+| L2 integration | `crates/kotoha-storage/tests/learning_cache_store.rs`(新規) | factory 経由の wiring / 並行性 / 永続性 |
+| L2 integration | `crates/kotoha-storage/tests/dict_user_vocab.rs`(既存修正) | factory split 後の API 変更に追従 |
+| L2 proptest | `crates/kotoha-storage/tests/learning_cache_proptest.rs`(新規) | 3 invariant の property-based 検証 |
+| L4 e2e | `crates/kotoha-cli/tests/dict_cli.rs`(既存修正) | CLI から ISP split 経由の動作確認 |
+
+### 6.2 単体 test 一覧(23 件)
+
+以下の 23 件の単体 test を `crates/kotoha-storage/src/learning_cache/sqlite.rs` の `#[cfg(test)] mod tests` に実装する。
+
+| test 関数名 | 検証内容 |
+|---|---|
+| `record_choice_inserts_new_entry` | 新規 entry が learning_cache table に 1 行挿入される |
+| `record_choice_increments_frequency_on_duplicate` | 同一 entry を 2 回 record すると frequency が 2 になる |
+| `record_choice_creates_separate_entries_for_different_kanji` | 同一 kana_input / 異なる chosen_kanji が別 entry として保持される |
+| `record_choice_updates_last_used_at_on_duplicate` | duplicate record 時に last_used_at が更新される |
+| `record_choice_does_not_evict_below_cap` | 行数が cap 未満の間は eviction が発生しない |
+| `record_choice_evicts_oldest_when_over_cap` | cap + 1 件目の insert 後に最古 entry が削除される |
+| `record_choice_maintains_cap_on_burst_insert` | burst insert 後の行数が cap 以下を維持する |
+| `record_choice_protects_recently_updated_entry_from_eviction` | record_choice で更新した entry は eviction 対象から外れる |
+| `record_choice_rejects_non_hiragana_kana_input` | ASCII の kana_input は InvalidField を返す |
+| `record_choice_rejects_empty_chosen_kanji` | 空文字列の chosen_kanji は InvalidField を返す |
+| `record_choice_rejects_pua_in_chosen_kanji` | allowlist 外 PUA を含む chosen_kanji は InvalidField を返す |
+| `record_choice_rejects_oversize_kana_input` | 257 bytes 超の kana_input は InvalidField を返す |
+| `lookup_returns_empty_for_unknown_kana_input` | 存在しない kana_input に対して空 Vec を返す |
+| `lookup_returns_single_match` | 1 件の entry を持つ kana_input に対して 1 件を返す |
+| `lookup_orders_by_frequency_desc_then_last_used_at_desc` | 複数 entry が frequency DESC, last_used_at DESC 順に並ぶ |
+| `lookup_respects_limit` | limit=1 を渡すと 1 件のみ返す |
+| `lookup_rejects_non_hiragana` | ASCII の kana_input に対して InvalidField を返す |
+| `evict_lru_returns_zero_when_under_cap` | `evict_lru(cap)` を呼び出したとき行数が `cap` 以下の場合は `Ok(0)` を返す |
+| `evict_lru_deletes_excess_rows` | `evict_lru(cap)` を呼び出したとき行数が `cap` を超えている場合は超過分を削除して行数を `cap` に収める |
+| `evict_lru_tiebreaks_by_id_when_last_used_at_equal` | `evict_lru(cap)` を呼び出したとき `last_used_at` が同値の entry が複数ある場合は `id ASC` で削除順を決定する |
+| `cap_override_guard_restores_default_on_drop` | CapOverrideGuard を drop すると effective_max_rows が LEARNING_CACHE_MAX_ROWS に戻る |
+| `effective_max_rows_returns_override_in_test` | override 設定中は effective_max_rows が override 値を返す |
+| `effective_max_rows_returns_default_when_override_zero` | override が 0 の場合は effective_max_rows が LEARNING_CACHE_MAX_ROWS を返す |
+
+### 6.3 L2 integration test(新規 / 修正)
+
+**新規: `crates/kotoha-storage/tests/learning_cache_store.rs`**
+
+| test 関数名 | 検証内容 |
+|---|---|
+| `factory_returns_reader_and_writer_sharing_same_data` | `learning_cache_reader` と `learning_cache_writer` が同一 DB を共有し、writer で記録した entry を reader が参照できる |
+| `concurrent_record_choice_is_serialized` | 8 スレッドが同時に record_choice を呼び出しても deadlock が発生せず全件が記録される |
+| `eviction_persists_across_factory_reopens` | file-backed DB で eviction 後に Database を再 open しても行数が cap 以下を維持する |
+
+**既存修正: `crates/kotoha-storage/tests/dict_user_vocab.rs`**
+
+`user_vocab_store()` factory 呼び出しを `user_vocab_reader()` / `user_vocab_writer()` に置換する。PASS 数は修正前後で同数を維持する。
+
+### 6.4 L4 e2e test(既存修正)
+
+`crates/kotoha-cli/tests/dict_cli.rs` の factory 呼び出し部分を ISP split 後の API に追従して書き換える。P2-C では LearningCache を CLI に公開しないため、新規 subcommand の追加は行わない。
+
+### 6.5 proptest
+
+`crates/kotoha-storage/tests/learning_cache_proptest.rs` に以下の 3 invariant を検証する proptest を実装する。
+
+**Invariant 1: 任意の record sequence 後も行数が cap 以下**
+
+```
+input strategy:
+  hiragana 1〜32 char (kana_input) ×
+  kanji 1〜10 char (chosen_kanji) ×
+  0〜200 件の record sequence
+invariant:
+  record sequence 完了後の total row count ≤ cap
+  cap は CapOverrideGuard で 20 に設定し、record_choice が内部で参照する effective_max_rows() = 20 を使用する
+  本 invariant は record_choice 経由の自動 eviction を対象とする。
+  evict_lru(max_entries) の直接呼び出しは本 invariant の対象外であり、L1 単体 test で個別に検証する。
+```
+
+**Invariant 2: lookup 結果は frequency DESC で単調非増加**
+
+```
+input strategy:
+  上記と同一の record sequence を実行後、kana_input を 1 件取り出して lookup を呼び出す
+invariant:
+  lookup 結果 results[i].frequency >= results[i+1].frequency (全 i に対して成立)
+```
+
+**Invariant 3: insert 対象全 entry が validate_surface を通過**
+
+```
+input strategy:
+  validate_surface が Ok を返す文字列のみを生成する strategy
+invariant:
+  record_choice が Ok(()) を返す ⟺ validate_surface(chosen_kanji).is_ok() かつ validate_reading(kana_input).is_ok()
+```
+
+proptest の実行設定は `PROPTEST_CASES=64`(P2-B 同水準)とする。
+
+### 6.6 test count baseline 予測
+
+以下の表は P2-C 着地後の test count baseline 予測を示す。実値は実装後に確定する。
+
+| 構成 | P2-B 着地(実測) | P2-C 着地予測 |
+|---|---|---|
+| `default` | 281 | 304 程度 |
+| `dict` | 340 | 363 程度 |
+| `dict-persist` | 355 | 384 程度 |
+
+予測根拠: L1 単体 23 件 + L2 integration 3 件 + proptest 3 件 = 29 件の新規 test が追加される。既存 test の修正によるカウント変動は発生しない(削除 / 統合なし)。退行ゼロ(P2-B 着地時の全 355+ test PASS 維持)を必須条件とする。
+
+---
+
+## 7. 実装順序と branch / PR 戦略
+
+### 7.1 実装 phase A〜E
+
+実装を以下の 5 phase に分割して順次実行する。
+
+| Phase | 内容 | 主要影響ファイル | 推定工数 |
+|---|---|---|---|
+| P2-C-A | UserVocab ISP split 先行(機械換装: 旧 `UserVocabStore` を Reader/Writer に分割、全 consumer を書換) | `user_vocab/store.rs` + `user_vocab/sqlite.rs` + `user_vocab/mock.rs` + `database.rs` + `dict_cli.rs` + `tests/dict_user_vocab.rs` | 1 day |
+| P2-C-B | LearningCache 本実装(UPSERT / eviction / lookup / validate) | `learning_cache/mod.rs` + `learning_cache/sqlite.rs` | 1 day |
+| P2-C-C | v002 migration + idx_learning_cache_last_used + factory LearningCache split | `migrations/v002_learning_cache_index.sql` + `migrations.rs` + `database.rs` | 半日 |
+| P2-C-D | test 整備(L1 23 件 / L2 integration 3 件 / proptest 3 invariant / L4 修正) | `tests/` 配下 + `src/learning_cache/sqlite.rs` 内 `#[cfg(test)]` | 1 day |
+| P2-C-E | team-review feedback 対応 + WBS 記録 + PR 作成 | review feedback 次第 | 半日〜1 day |
+
+合計推定工数は 3.5〜4 day である。Branch Scope Policy の 20 file / 1000 line 上限に収まる想定であるが、P2-C-A(ISP split)で 1 PR の変更ファイル数が 20 を超えることが見込まれる場合は §7.2 のフォールバックを適用する。
+
+### 7.2 branch / PR 戦略
+
+- branch 名: `feature/<issue#>-p2-c-learning-cache`(ISSUE 番号は本 spec 承認後に起票)
+- PR: 単一 PR を基本とする(ISP split は LearningCache 本実装の前提条件であるため分離すると中間状態でビルドが壊れる)
+- review: Medium tier を適用する(team-review 4 dimension: security / performance / architecture / testing + owasp-security + secrets-check + simplify)
+- フォールバック: Branch Scope Policy 上限超過時は「P2-C-A ISP split のみ先行 PR」→「P2-C-B 以降 LearningCache 本実装 PR」の 2 PR 分割を適用する。分割時は先行 PR に `LearningCacheStore` stub が残ること(互換ビルド可能)を確認してから merge する
+
+### 7.3 後段 Issue 起票候補(本 Phase 着地後)
+
+P2-C 着地後に以下の Issue を新規起票する。
+
+- **connection pool(perf-M-1)**: `Mutex<Connection>` をコネクションプールに置き換える。Phase 3 IBus engine から高頻度で呼び出す前提で遅延を測定し、必要性が確認された場合に実施する
+- **Mutex poison handling 改善(sec-L-2)**: `lock_conn` が panic する代わりに `StorageError::Sqlite` を返す recover 経路を追加する。Phase 3 前提として実施する
+- **LearningCache CLI 公開検討(Phase 3-A以降)**: `kotoha-dict cache list` / `kotoha-dict cache flush` の subcommand を追加するかを Phase 3 kick-off で判断する
+- **cap 値の動的化 / config 化(Phase 5)**: `LEARNING_CACHE_MAX_ROWS` を設定ファイルから読み込む機構を Phase 5 personalization で追加する
+- **v002 migration の down 整備(YAGNI 解除時)**: forward-only から bidirectional migration に切り替える必要が生じた場合に別 ADR で方針確定後に実施する
+
+### 7.4 Phase 状態への影響
+
+P2-C 着地後の Phase 2 進捗マトリクスを以下に示す。
+
+| milestone | 状態 |
+|---|---|
+| P2-A | 完了 |
+| P2-A hardening | 完了 |
+| P2-B | 完了 |
+| P2-C | **完了 ← 本 Phase** |
+| P2-D | 未着手(Hybrid backend / Ranker) |
+
+P2-D(Hybrid backend / Ranker 統合)の着手前に LearningCache の本実装 + Reader/Writer ISP boundary が確立した状態を作ることが本 Phase の最大成果である。P2-D は本 Phase が確立した `LearningCacheReader` / `LearningCacheWriter` の 4 trait を組み合わせて Ranker を構成する。
+
+---
+
+## 8. 受容基準(Acceptance Criteria)
+
+以下の全項目を満たした状態を P2-C 完了とする。
+
+- [ ] `cargo test --workspace` が `default` / `dict` / `dict-persist` の 3 構成すべてで PASS し、退行ゼロ(全 355+ test PASS を維持)
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` で警告ゼロ
+- [ ] `cargo audit` で 0 vulnerability を維持
+- [ ] lefthook pre-push の 3-feature gate(fmt / clippy / test)が全 PASS
+- [ ] P2-C 着地後の test count baseline: `default` 304 程度 / `dict` 363 程度 / `dict-persist` 384 程度
+- [ ] `LearningCacheReader` / `LearningCacheWriter` / `UserVocabReader` / `UserVocabWriter` の 4 trait が `kotoha-storage` の public API として確立されている
+- [ ] 旧 `UserVocabStore` trait および旧 `LearningCacheStore` trait が削除されている
+- [ ] `Database` factory が `user_vocab_reader` / `user_vocab_writer` / `learning_cache_reader` / `learning_cache_writer` の 4 method を持ち、旧 `user_vocab_store` / `learning_cache_store` の 2 method が削除されている
+- [ ] v002 migration(`v002_learning_cache_index.sql`)が新規 DB 初期化と既存 v001 DB の auto-upgrade の双方で正常に動作する
+- [ ] `SqliteLearningCacheStore` が UPSERT / auto eviction / LRU 削除 / lookup ordering の本実装を持ち、stub でないことを 23 件の L1 test が証明する
+- [ ] proptest 3 invariant が `PROPTEST_CASES=64` で全 PASS
+- [ ] WBS 記録(`docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md`)が作成されている
+- [ ] Medium tier team-review(security / performance / architecture / testing の 4 dimension)で Critical / High finding が全消化されている(Medium / Low finding は新規 follow-up Issue に移管)
+
+---
+
+## 9. 参考 / 関連文書
+
+本設計書は以下の文書を参照した。矛盾がある場合は本設計書が優先する。
+
+- `docs/adr/0014-phase-2-dictionary-layer-architecture.md` — Phase 2 dictionary layer の全体 ADR
+- `docs/adr/0015-kotoha-storage-sqlite-adoption.md` — kotoha-storage SQLite 採用根拠
+- `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` §3.2 / §5.2 / §6.3 — Phase 2 全体 spec の LearningCache 関連節
+- `docs/superpowers/specs/2026-04-25-p2-b-user-dictionary-design.md` §5.2 / §6.3 — P2-B の schema 設計と trait 定義
+- `docs/wbs/2026-04-25-feature-98-p2-b-user-dictionary.md` — P2-B 実装ログ(cap override / proptest / validation パターンの根拠)
+- session handoff memory `project_session_handoff_2026-04-25.md` — P2-C 着手前の状態確認
+- `crates/kotoha-storage/migrations/v001_initial.sql` — `learning_cache` table schema(本設計書が前提とする schema)
+- `crates/kotoha-storage/src/learning_cache/mod.rs` — P2-B 着地時の `LearningCacheStore` trait skeleton
+- `crates/kotoha-storage/src/learning_cache/sqlite.rs` — P2-B 着地時の stub 実装(本 Phase で本実装に置換)
+- `crates/kotoha-storage/src/user_vocab/sqlite.rs` — `QuotaOverrideGuard` パターンの原典(`CapOverrideGuard` がこれを踏襲する)
+- `crates/kotoha-storage/src/validation.rs` — `validate_reading` / `validate_surface` の実装(本 Phase で再利用)
+- `crates/kotoha-storage/src/error.rs` — `StorageError` variant 定義(本 Phase で追加なし)

--- a/docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
+++ b/docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
@@ -931,6 +931,8 @@ proptest の実行設定は `PROPTEST_CASES=64`(P2-B 同水準)とする。
 
 予測根拠: L1 単体 23 件 + L2 integration 3 件 + proptest 3 件 = 29 件の新規 test が追加される。既存 test の修正によるカウント変動は発生しない(削除 / 統合なし)。退行ゼロ(P2-B 着地時の全 355+ test PASS 維持)を必須条件とする。
 
+> **2026-04-26 実測 note(P2-C 着地後)**: 実装着地時の test count baseline は default 320 / dict 379 / dict-persist 394 となった。本予測値との差分(+16 / +16 / +10)は、Phase B-followup commit `726b07d` で plan §6.2 23 件のうち初回 dispatch で漏れた 7 件 reject path test を追加実装したこと、および Phase C で v002 migration runner test を当初想定の 2 件から 3 件に拡張したことに起因する。退行ゼロ + 全 PASS は維持されており、実装は予測上回りで着地した。
+
 ---
 
 ## 7. 実装順序と branch / PR 戦略

--- a/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
+++ b/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
@@ -1,0 +1,131 @@
+---
+title: P2-C LearningCache 本実装ログ
+date: 2026-04-26
+branch: feature/105-p2-c-learning-cache
+issue: 105
+pr: <PR# が確定したら追記>
+follow-up-issue: <Medium / Low deferred Issue# が確定したら追記>
+parent-spec: docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md
+parent-plan: docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md
+---
+
+# P2-C(LearningCache 本実装)実装ログ
+
+## サマリ
+
+- `UserVocabReader` / `UserVocabWriter` の ISP split 完了(Phase A、旧 `UserVocabStore` の 2 trait 分割)
+- `LearningCacheReader` / `LearningCacheWriter` の ISP split 完了(Phase A、旧 `LearningCacheStore` の 2 trait 分割)
+- `SqliteLearningCacheStore` 本実装完了(Phase B、`lookup` / `record_choice` UPSERT / `evict_lru` / 自動 LRU 退避 / cap 制御)
+- v002 migration 追加完了(Phase C、`v002_learning_cache_index.sql` で `idx_learning_cache_last_used` を index 化)
+- L2 integration test + proptest 3 invariant 追加完了(Phase D、退行ゼロ確認)
+- production binary cleanliness 回復完了(Phase D fix、`CapOverrideGuard` 系を `test-helpers` feature flag で gate)
+
+## metric
+
+実機検証ベース(`cargo test --workspace [...] --features kotoha-storage/test-helpers` 出力)で記録する。
+
+| 項目 | 値 |
+|---|---|
+| `default` features 合計 | **320 PASS**(P2-B baseline 281 から +39) |
+| `dict` features 合計 | **368 PASS**(P2-B baseline 340 から +28) |
+| `dict-persist` features 合計(P2-C 新 baseline) | **411 PASS**(P2-B baseline 355 から +56) |
+| 工数(実) | 1 セッション(plan 執筆 + 実装 + Phase D fix を subagent dispatch で消化) |
+| 変更 file 数 | 20(WBS 含めると 21) |
+| 変更 lines | +1756 / -166(WBS 除く、`git diff 130a214..HEAD --stat` 出力) |
+| commit 数 | 26(`git log --oneline 130a214..HEAD` 集計、Phase A 7 + B 12 + C 3 + D 2 + Phase D fix 1) |
+| production binary 検査 | `nm -C` で test-only symbol 0 件(`CapOverrideGuard` / `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` / `CAP_OVERRIDE_LOCK` / `effective_max_rows` を全件 grep で確認) |
+| clippy 警告 | 0(`--features kotoha-storage/test-helpers -- -D warnings`) |
+| `cargo audit` | 0 vulnerability |
+| lefthook pre-push 6 step | 全 PASS(manifest-check / build / clippy / test / test-dict / test-dict-persist) |
+
+## Phase 別実装結果
+
+| Phase | task 数 | 完了 | 主要 commit | 学び |
+|---|---|---|---|---|
+| Phase A(ISP split) | 7 | 7/7 ✅ | `afaaf5d` UserVocab split → `1d3301d` LearningCache split → `400d0a3` 退行ゼロ verify | Plan A4 が learning_cache_* factory も含んでいたが main agent 判断で user_vocab_* のみに scope 絞り、Phase B B11 で learning_cache_* factory 化 |
+| Phase B(LearningCache 本実装) | 12 | 12/12 ✅ | `76534cb` lookup TDD red → `c23d6e3` lookup green → `73e3cd3` UPSERT → `fd124b7` evict_to_cap → `3c8391d` evict_lru → `c48ce02` factory + B11 → `eef7cc9` race fix → `726b07d` test 補完 | Plan B1 と B11 を機能上 swap(B1 で B11 先取り、B11 で factory test 追加に再定義)、`CapOverrideGuard::lock_only()` 追加で race condition 解消、初回実装で 7 件不足した test を `726b07d` followup commit で吸収 |
+| Phase C(v002 migration) | 3 | 3/3 ✅ | `694b575` migration file → `d7aa564` MIGRATIONS 配列登録 → `90132af` runner test | v002 を MIGRATIONS array に push する順序が LATEST_VERSION 更新と分離されていたため commit 単位で疎通確認できる構成にした |
+| Phase D(test 拡張) | 2 + 1 fix | 3/3 ✅ | `ec9752d` L2 integration → `896c663` proptest 3 invariant → `42f5cd2` test-helpers feature flag | Phase D 当初は integration test crate からアクセスするため `CapOverrideGuard` 系を `pub` 昇格していたが spec deviation だったため `42f5cd2` で `test-helpers` feature flag に変更し production binary cleanliness を回復 |
+| Phase E(本 WBS で進行中) | 7 | E1〜E4 を本セッションで実施、E5〜E7 は main agent が引き継ぐ | E1 WBS / E2 静的解析 / E3 push / E4 PR | — |
+
+## 学び / 判断ログ
+
+### 1. Phase A の plan scope と main agent 判断の差異
+
+- Plan の Task A4 は `learning_cache_reader` / `learning_cache_writer` factory も含んでいたが、main agent 判断で **`user_vocab_*` factory のみに scope を絞った**。
+- 理由: A4 で 4 factory を一括 swap すると Phase A 完了時点で `learning_cache_*` の test fixture が用意できず、build break が長期化するため。
+- 結果: Phase B B11(`c48ce02`)で `learning_cache_*` factory 化 + factory test 追加に再定義し、機能上 plan 通り着地した。
+
+### 2. plan 未記載の 3 file 修正必須(Phase A)
+
+- `kotoha-core/src/dict/backend.rs`、`kotoha-core/tests/dict_backend_user_vocab.rs`、`kotoha-storage/src/user_vocab/mod.rs` の 3 file は plan に列挙されていなかったが、Phase A の ISP split 完了には修正必須だった。
+- 教訓: trait 分割系 plan は `grep -r "<old_trait_name>"` を plan 執筆段階で実行し、直接参照のみならず `use` import / re-export / pub use chain も列挙する。
+
+### 3. Phase B B1 と B11 の swap
+
+- Plan は B1 = `learning_cache_reader/writer` factory 追加、B11 = proptest 追加 だったが、B1 で factory を先行追加すると B2〜B10 の test fixture が `Database::learning_cache_reader()` 経由で取れない問題があった。
+- 修正: B1 で B11 (proptest) を先取り、B11 を factory finalize + factory test に再定義。
+- commit hash: B11 finalize = `c48ce02`、B11 proptest = `896c663`(Phase D に再配置)。
+
+### 4. race condition 修正(`CapOverrideGuard::lock_only()`)
+
+- `record_choice` test を `cargo test` で並列実行すると `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` の thread_local 設定が干渉する race condition が発生した(`eef7cc9`)。
+- 修正: `CapOverrideGuard::lock_only()` を追加して mutex のみ取得し override 値は変更しない pattern を確立。production code は不変のまま test 側のみで対応。
+
+### 5. plan §6.2 23 件単体 test の欠落
+
+- Plan §6.2 で「23 件 L1 unit test」を要件としたが、初回実装(`bb5a65a`〜`f056265`)で 16 件しか書けず 7 件不足。
+- 修正: `726b07d` followup commit で record_choice / lookup / cap-guard validation の漏れ 7 件を追加。
+- 教訓: plan に列挙された test 件数は subagent prompt に明示し、subagent 報告で「N 件中 M 件 PASS」を numerical に検証する。
+
+### 6. Phase D fix(`42f5cd2`)— `pub` 昇格の spec deviation 回復
+
+- Phase D 当初実装で integration test crate(`tests/learning_cache_store.rs`)からアクセスするため `CapOverrideGuard` / `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` / `CAP_OVERRIDE_LOCK` / `effective_max_rows` を `pub` 昇格していた。
+- 問題: production binary に test-only symbol が漏出し spec の binary cleanliness 要件に違反。
+- 修正: `kotoha-storage/Cargo.toml` に `test-helpers` feature flag を追加し、当該 4 symbol を `#[cfg(any(test, feature = "test-helpers"))]` で gate。lefthook の test step を `--features kotoha-storage/test-helpers` 込みに更新(2026-04-26 PR で同時適用)。
+- 検証: `nm -C` で release binary 内に当該 symbol が 0 件であることを確認。
+
+### 7. ISP split による 4 trait 確立
+
+- Phase A〜B の完了時点で `UserVocabReader` / `UserVocabWriter` / `LearningCacheReader` / `LearningCacheWriter` の 4 trait が `kotoha-storage` の public API として確立された。
+- 旧 `UserVocabStore` / `LearningCacheStore` は完全削除済み(`afaaf5d` / `1d3301d` で削除確認)。
+- factory も `Database::user_vocab_reader()` / `user_vocab_writer()` / `learning_cache_reader()` / `learning_cache_writer()` の 4 method 体系に移行(`1c1da24` / `c48ce02`)。
+
+### 8. v002 migration の auto-upgrade path
+
+- Phase C で `v002_learning_cache_index.sql` を追加し `idx_learning_cache_last_used ON learning_cache(last_used_at)` を導入。
+- `evict_lru` の `ORDER BY last_used_at ASC LIMIT N` を index で走査可能にし、cap eviction の計算量を O(N) から O(log N + cap) に改善。
+- runner test(`90132af`)で fresh DB / v001 から v002 への自動 upgrade の双方を検証済み。
+
+## 4-dim review 結果
+
+本 Phase E 前半(E1〜E4)時点では未実施。**Phase E 後半(E5)で `agent-teams:team-review` skill を 4 dimension(security / architecture / testing / performance)で実行予定**。
+
+| dimension | Critical | High | Medium | Low |
+|---|---|---|---|---|
+| security | pending | pending | pending | pending |
+| architecture | pending | pending | pending | pending |
+| testing | pending | pending | pending | pending |
+| performance | pending | pending | pending | pending |
+| **合計** | (E5 で確定)| (E5 で確定)| (新規 Issue に移管)| (新規 Issue に移管)|
+
+E6 で Critical / High finding を全消化、Medium / Low は新規 follow-up Issue に移管予定(spec §7.3 deferred Issue 方針準拠)。
+
+## deferred 項目(新規 Issue に移管予定)
+
+以下の Medium / Low finding は PR merge 後に新規 follow-up Issue を起票して管理する候補である。E5 review 結果に応じて確定する。
+
+- **connection pool(perf-M-1)**: `Mutex<Connection>` をコネクションプールに置き換える。Phase 3 IBus engine から高頻度で呼び出す前提で遅延を測定し、必要性が確認された場合に実施する
+- **Mutex poison handling 改善(sec-L-2)**: `lock_conn` が panic する代わりに `StorageError::Sqlite` を返す recover 経路を追加する
+- **LearningCache CLI 公開検討(Phase 3-A 以降)**: `kotoha-dict cache list` / `kotoha-dict cache flush` の subcommand を Phase 3 kick-off で判断する
+- **cap 値の動的化 / config 化(Phase 5)**: `LEARNING_CACHE_MAX_ROWS` を設定ファイルから読み込む機構を Phase 5 personalization で追加する
+- **review 由来の Medium / Low finding**: E5 実行後に確定
+
+## 参照
+
+- spec: `docs/superpowers/specs/2026-04-26-p2-c-learning-cache-design.md`
+- plan: `docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.md`
+- ADR 0014(LearningCache 設計方針、Phase B 実装根拠)
+- ADR 0015(Reader/Writer ISP split、Phase A 実装根拠)
+- P2-B WBS: `docs/wbs/2026-04-25-feature-98-p2-b-user-dictionary.md`
+- ISSUE: https://github.com/std-koh-hinooka/kotoha-ime/issues/105

--- a/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
+++ b/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
@@ -27,12 +27,12 @@ parent-plan: docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.m
 | 項目 | 値 |
 |---|---|
 | `default` features 合計 | **320 PASS**(P2-B baseline 281 から +39) |
-| `dict` features 合計 | **368 PASS**(P2-B baseline 340 から +28) |
-| `dict-persist` features 合計(P2-C 新 baseline) | **411 PASS**(P2-B baseline 355 から +56) |
+| `dict` features 合計 | **379 PASS**(P2-B baseline 340 から +39) |
+| `dict-persist` features 合計(P2-C 新 baseline) | **394 PASS**(P2-B baseline 355 から +39) |
 | 工数(実) | 1 セッション(plan 執筆 + 実装 + Phase D fix を subagent dispatch で消化) |
 | 変更 file 数 | 20(WBS 含めると 21) |
 | 変更 lines | +1756 / -166(WBS 除く、`git diff 130a214..HEAD --stat` 出力) |
-| commit 数 | 26(`git log --oneline 130a214..HEAD` 集計、Phase A 7 + B 12 + C 3 + D 2 + Phase D fix 1) |
+| commit 数 | 27(`git log --oneline 130a214..HEAD` 集計、Phase A 8 + B 12 + C 3 + D 2 + Phase D fix 1 + Phase E WBS 1) |
 | production binary 検査 | `nm -C` で test-only symbol 0 件(`CapOverrideGuard` / `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` / `CAP_OVERRIDE_LOCK` / `effective_max_rows` を全件 grep で確認) |
 | clippy 警告 | 0(`--features kotoha-storage/test-helpers -- -D warnings`) |
 | `cargo audit` | 0 vulnerability |

--- a/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
+++ b/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
@@ -99,17 +99,67 @@ parent-plan: docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.m
 
 ## 4-dim review 結果
 
-本 Phase E 前半(E1〜E4)時点では未実施。**Phase E 後半(E5)で `agent-teams:team-review` skill を 4 dimension(security / architecture / testing / performance)で実行予定**。
+`agent-teams:team-review` skill を 4 dimension(security / architecture / testing / performance)で逐次実行(memory 9Gi 帯のため並列回避、global CLAUDE.md System Resource Management)。各 reviewer は実機検証(grep / cargo build / cargo test / EXPLAIN QUERY PLAN / nm -C 等)の verbatim 出力を report に含めた。
 
-| dimension | Critical | High | Medium | Low |
-|---|---|---|---|---|
-| security | pending | pending | pending | pending |
-| architecture | pending | pending | pending | pending |
-| testing | pending | pending | pending | pending |
-| performance | pending | pending | pending | pending |
-| **合計** | (E5 で確定)| (E5 で確定)| (新規 Issue に移管)| (新規 Issue に移管)|
+### Verdict 一覧
 
-E6 で Critical / High finding を全消化、Medium / Low は新規 follow-up Issue に移管予定(spec §7.3 deferred Issue 方針準拠)。
+| dimension | Critical | High | Medium | Low | Verdict |
+|---|---|---|---|---|---|
+| security | 0 | 0 | 1 | 4 | ⚠ MINOR_FINDINGS |
+| architecture | 0 | 0 | 4 | 3 | ⚠ MINOR_FINDINGS |
+| testing | 0 | 0 | 4 | 6 | ⚠ MINOR_FINDINGS |
+| performance | 0 | 0 | 2 | 3 | ⚠ MINOR_FINDINGS |
+| **合計** | **0** | **0** | **11** | **16** | **MINOR_FINDINGS** |
+
+Critical / High = 0 のため、本 PR で fix する必要なし。Medium / Low 計 27 件は **follow-up Issue #107** に集約済(plan §7.3 / §E7 規定通り)。
+
+### 追加実施した security 検査
+
+- **secrets-check**(Large tier 必須項目): 0 secrets found
+  - API key / token / password / private key / connection string パターン: 0 hit
+  - user-specific path(`/home/<user>/`)混入: 0 hit
+  - sensitive file extension(`.env` / `.pem` / `.key` 等): 0 hit
+  - `.gitignore` に `.env` / `.pem` / `.key` パターン 7 件登録済
+- **cargo audit**(Large tier 必須項目): 0 vulnerabilities
+  - 167 crate dependencies、RustSec advisory database hit 0 件
+- **production binary 検査**(test-only API leak): 0 hit
+  - `nm -C target/release/kotoha-dict` で `CapOverrideGuard` / `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` / `CAP_OVERRIDE_LOCK` / `effective_max_rows` 全て検出されず
+  - `--features test-helpers` 同時指定時のみ rlib に symbol が現れることを確認(feature gate が compile-time に機能している実証)
+
+### 主要 finding 概要(詳細は #107)
+
+#### Phase 3 prerequisite 候補(Medium / Low から)
+
+1. **S-1** `usize as i64` lossy cast(`learning_cache/sqlite.rs:196,228`)→ `i64::try_from` への切替で IBus engine `limit` 経路の防御
+2. **S-4** `Database::lock_conn` の Mutex poison panic(`database.rs:81`)→ `unwrap_or_else(|p| p.into_inner())` で IME プロセスごと落ちる経路を防ぐ
+3. **A-2** `MockLearningCacheStore` 不在 → P2-D Ranker / Phase 3 IBus engine の test 注入で必要
+4. **P-1** `evict_to_cap` の COUNT_SQL が `prepare_cached` 経由していない → record_choice latency 11% 削減 + コード規約一貫性
+
+#### performance 実機計測(Phase 3 IBus engine 要件との比較)
+
+| 項目 | 計測値 | 要件 | 余裕 |
+|---|---|---|---|
+| `lookup` latency | 13.69 μs/op | < 10 ms | 1/700 |
+| `record_choice` latency | 36.05 μs/op | < 50 ms | 1/1400 |
+| proptest 全 invariant 実行時間 | 0.27 s | (CI 時間) | 十分 |
+| L2 integration test 実行時間 | 4.40 s | (CI 時間) | 十分(うち sleep 5.5s 分散) |
+
+Phase 3 IBus engine の hot-path latency budget に対して **3 桁余裕** あり、release blocker 不在。
+
+### EXPLAIN QUERY PLAN 検証(performance reviewer 計測、cap 5_000 行)
+
+- **LOOKUP_SQL**: `SEARCH learning_cache USING INDEX idx_learning_cache_kana (kana_input=?)` + `USE TEMP B-TREE FOR ORDER BY`(P-2 finding の根拠、Phase 3 telemetry 観測後に v003 複合 index 検討)
+- **COUNT_SQL**: `SCAN learning_cache USING COVERING INDEX idx_learning_cache_last_used`(v002 効果)
+- **EVICT_SQL**: `LIST SUBQUERY ... SCAN learning_cache USING COVERING INDEX idx_learning_cache_last_used`(v002 効果、cap 10_000 でも sub-ms)
+- v002 を drop すると EVICT_SQL が `SCAN + USE TEMP B-TREE` に降格(v002 必要性の定量裏付け)
+
+### Phase 3 / 5 への申送り(各 reviewer 共通項)
+
+1. Phase 3 着手前に S-1 / S-4 / A-2 / P-1 の 4 件を fix(別 PR、軽量)
+2. Phase 3 telemetry で「lookup p99 latency > 5ms」または「同 kana_input に対する候補数 p95 ≥ 100」が観測されたら v003 複合 index(`idx_learning_cache_kana_freq_lastused`)を検討
+3. Phase 5 personalization で動的 cap が必要になった場合、`Database` 構造体への `cap_override: AtomicUsize` field 追加を検討(現状の static AtomicUsize ベースは production の dynamic cap と排他制御が衝突する設計)
+4. ADR 0016「kotoha-storage における ISP split と test-helpers feature 方針」を別 PR で起票(arch-M-2 + test-helpers feature の判断根拠を ADR 化)
+5. proptest strategy の collision 強化(invariant 1 / 2 が trivial に成立しないよう、kana 集合を 5 種類に固定 + record 件数下限を cap × 2 に引き上げる)
 
 ## deferred 項目(新規 Issue に移管予定)
 

--- a/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
+++ b/docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md
@@ -31,8 +31,8 @@ parent-plan: docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.m
 | `dict-persist` features 合計(P2-C 新 baseline) | **394 PASS**(P2-B baseline 355 から +39) |
 | 工数(実) | 1 セッション(plan 執筆 + 実装 + Phase D fix を subagent dispatch で消化) |
 | 変更 file 数 | 20(WBS 含めると 21) |
-| 変更 lines | +1756 / -166(WBS 除く、`git diff 130a214..HEAD --stat` 出力) |
-| commit 数 | 27(`git log --oneline 130a214..HEAD` 集計、Phase A 8 + B 12 + C 3 + D 2 + Phase D fix 1 + Phase E WBS 1) |
+| 変更 lines | +1756 / -166(WBS 除く、`git diff 130a214..HEAD --stat` 出力)。+39 each(default = dict = dict-persist の +39 は L1 unit 26 + L2 integration 5 + proptest 3 + v002 runner 3 + factory test 2 = 39 件、全 feature gate しないため 3 構成共通) |
+| commit 数 | 29(本 commit 反映前、`git log --oneline 130a214..HEAD` 集計、Phase A 8 + B 12 + C 3 + D 2 + Phase D fix 1 + Phase E WBS 3 = 29、本 commit 反映後 32、最終 merge 時に確定数) |
 | production binary 検査 | `nm -C` で test-only symbol 0 件(`CapOverrideGuard` / `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` / `CAP_OVERRIDE_LOCK` / `effective_max_rows` を全件 grep で確認) |
 | clippy 警告 | 0(`--features kotoha-storage/test-helpers -- -D warnings`) |
 | `cargo audit` | 0 vulnerability |
@@ -97,21 +97,43 @@ parent-plan: docs/superpowers/plans/2026-04-26-feature-105-p2-c-learning-cache.m
 - `evict_lru` の `ORDER BY last_used_at ASC LIMIT N` を index で走査可能にし、cap eviction の計算量を O(N) から O(log N + cap) に改善。
 - runner test(`90132af`)で fresh DB / v001 から v002 への自動 upgrade の双方を検証済み。
 
-## 4-dim review 結果
+## Review 結果(全 7 review tier)
 
-`agent-teams:team-review` skill を 4 dimension(security / architecture / testing / performance)で逐次実行(memory 9Gi 帯のため並列回避、global CLAUDE.md System Resource Management)。各 reviewer は実機検証(grep / cargo build / cargo test / EXPLAIN QUERY PLAN / nm -C 等)の verbatim 出力を report に含めた。
+PR #106 に対して、以下 7 tier の review を逐次実行した(memory 9Gi 帯のため並列回避、global CLAUDE.md System Resource Management)。各 reviewer は実機検証(grep / cargo build / cargo test / EXPLAIN QUERY PLAN / nm -C 等)の verbatim 出力を report に含めた。
+
+実施 review 一覧:
+
+1. `agent-teams:team-review` security
+2. `agent-teams:team-review` architecture
+3. `agent-teams:team-review` testing
+4. `agent-teams:team-review` performance
+5. `secrets-check`(Large tier 必須)
+6. `cargo audit`(Large tier 必須)
+7. `pr-review-toolkit:review-pr`(code-reviewer / comment-analyzer / type-design-analyzer の 3 sub-agent)
 
 ### Verdict 一覧
 
 | dimension | Critical | High | Medium | Low | Verdict |
 |---|---|---|---|---|---|
-| security | 0 | 0 | 1 | 4 | ⚠ MINOR_FINDINGS |
-| architecture | 0 | 0 | 4 | 3 | ⚠ MINOR_FINDINGS |
-| testing | 0 | 0 | 4 | 6 | ⚠ MINOR_FINDINGS |
-| performance | 0 | 0 | 2 | 3 | ⚠ MINOR_FINDINGS |
-| **合計** | **0** | **0** | **11** | **16** | **MINOR_FINDINGS** |
+| security | 0 | 0 | 1 | 4 | ⚠ MINOR |
+| architecture | 0 | 0 | 4 | 3 | ⚠ MINOR |
+| testing | 0 | 0 | 4 | 6 | ⚠ MINOR |
+| performance | 0 | 0 | 2 | 3 | ⚠ MINOR |
+| code-reviewer | 0 | 0 | 4 | 3 | ⚠ MERGE_AFTER_MINOR_FIX(M-1, M-3 既 fix) |
+| comment-analyzer | 0 | **2** | 5 | 3 | ⚠ MINOR(H-1, H-2 既 fix) |
+| type-design-analyzer | 0 | 0 | 3 | 6 | ⚠ APPROVE with MEDIUM |
+| **合計** | **0** | **2** | **23** | **28** | **MINOR(merge ready)** |
 
-Critical / High = 0 のため、本 PR で fix する必要なし。Medium / Low 計 27 件は **follow-up Issue #107** に集約済(plan §7.3 / §E7 規定通り)。
+Critical = 0、High = 2 のうち 2 件は本 PR 内 commit `334ac23` で fix 済み。code-reviewer M-1 / M-3 も本 PR 内 commit `094fb35` で fix 済み。残 Medium 21 件 / Low 28 件は merge blocker でないため **follow-up Issue #107** に集約する(plan §7.3 / §E7 規定通り)。
+
+### Review 後の本 PR 内 fix(merge ready 状態)
+
+| commit | finding | 修正内容 |
+|---|---|---|
+| `094fb35` | code-reviewer M-1 | glossary.md の旧 trait 名 `UserVocabStore` / `LearningCacheStore` を `UserVocabReader/Writer` / `LearningCacheReader/Writer` に更新、`test-helpers` feature / `CapOverrideGuard` / `evict_to_cap` の 3 用語を新規追加 |
+| `094fb35` | code-reviewer M-3 | spec §6.6 に 2026-04-26 実測値(default 320 / dict 379 / dict-persist 394)note を追記、+16/+16/+10 deviation の根拠(B-followup `726b07d` + v002 runner test)を明記 |
+| `334ac23` | comment-analyzer H-1 | `user_vocab/sqlite.rs:1` の module-level doc を `UserVocabStore の SQLite 実装` から `UserVocabReader + UserVocabWriter の SQLite 実装(arch-M-2)` に修正 |
+| `334ac23` | comment-analyzer H-2 | `database.rs` 4 factory method の Postconditions に `Arc<Sqlite*Store>` 保持と記述された誤りを `Box` で `SqliteStore` を保持し、内部 `Arc<Database>` を `Arc::clone` で共有する正しい記述に統一 |
 
 ### 追加実施した security 検査
 
@@ -160,16 +182,28 @@ Phase 3 IBus engine の hot-path latency budget に対して **3 桁余裕** あ
 3. Phase 5 personalization で動的 cap が必要になった場合、`Database` 構造体への `cap_override: AtomicUsize` field 追加を検討(現状の static AtomicUsize ベースは production の dynamic cap と排他制御が衝突する設計)
 4. ADR 0016「kotoha-storage における ISP split と test-helpers feature 方針」を別 PR で起票(arch-M-2 + test-helpers feature の判断根拠を ADR 化)
 5. proptest strategy の collision 強化(invariant 1 / 2 が trivial に成立しないよう、kana 集合を 5 種類に固定 + record 件数下限を cap × 2 に引き上げる)
+6. **F-1**(comment-analyzer 由来): Phase 3 着手前に doc comment 内 stale phase 名(`P2-C 本実装`)を spec 参照のみに置換(該当箇所の固定名を排除し spec へのリンクで代用)
+7. **F-2**(type-design-analyzer 由来): Phase 5 personalization 着手時に Record 型を `pub(crate)` 化 + smart constructor 化、`Score(f32)` / `Timestamp(i64)` newtype を導入(現状 `pub` 露出の primitive 型を domain newtype で置換し型安全性を強化)
 
-## deferred 項目(新規 Issue に移管予定)
+## deferred 項目(follow-up Issue #107 に集約)
 
-以下の Medium / Low finding は PR merge 後に新規 follow-up Issue を起票して管理する候補である。E5 review 結果に応じて確定する。
+以下の Medium / Low finding は本 PR の merge 後に follow-up Issue #107 へ追記する形で管理する。Issue #107 は 4-dim review 由来 27 件で起票済みであり、本セッションで実施した追加 3 review 由来の 22 件を `gh issue comment` で追記する(本 PR merge 完了後)。
+
+### 4-dim review 由来(既登録、計 27 件)
 
 - **connection pool(perf-M-1)**: `Mutex<Connection>` をコネクションプールに置き換える。Phase 3 IBus engine から高頻度で呼び出す前提で遅延を測定し、必要性が確認された場合に実施する
 - **Mutex poison handling 改善(sec-L-2)**: `lock_conn` が panic する代わりに `StorageError::Sqlite` を返す recover 経路を追加する
 - **LearningCache CLI 公開検討(Phase 3-A 以降)**: `kotoha-dict cache list` / `kotoha-dict cache flush` の subcommand を Phase 3 kick-off で判断する
 - **cap 値の動的化 / config 化(Phase 5)**: `LEARNING_CACHE_MAX_ROWS` を設定ファイルから読み込む機構を Phase 5 personalization で追加する
-- **review 由来の Medium / Low finding**: E5 実行後に確定
+- security / architecture / testing / performance 各 dimension の Medium / Low 残件(計 23 件)
+
+### 追加 3 review 由来(本セッションで確定、計 22 件)
+
+- **comment-analyzer**: Medium 5 件(M-1〜M-5)+ Low 3 件(L-1〜L-3)
+- **type-design-analyzer**: Medium 3 件(M-1〜M-3、すべて Phase 5 personalization 着手時対応)+ Low 6 件(L-1〜L-6)
+- **code-reviewer 残**: Medium 2 件(M-2 WBS commit 数 27→29、M-4 WBS metric +39 補足)+ Low 3 件
+
+これら 22 件は本 PR merge 直後に main agent が `gh issue comment 107` で Issue #107 へ追記する。M-2 / M-4 は本 commit で WBS に直接反映済(commit 数 29、+39 each の breakdown)。
 
 ## 参照
 

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -184,7 +184,7 @@
 
 ### Phase 2 Dictionary layer (P2-A 以降)
 
-以下 15 entry は ADR 0014 (`docs/adr/0014-phase-2-dictionary-layer-architecture.md`) / ADR 0015 (`docs/adr/0015-kotoha-storage-sqlite-adoption.md`) および Phase 2 spec / P2-A spec / P2-B spec で初出した用語を集約する。実装 identifier は P2-A で確定済のもの、P2-B で確定したもの (kotoha-dict / kotoha-storage / kotoha.db / UserVocab / UserVocabStore の 5 entry)、P2-D 以降で確定予定のものを含む。
+以下 15 entry は ADR 0014 (`docs/adr/0014-phase-2-dictionary-layer-architecture.md`) / ADR 0015 (`docs/adr/0015-kotoha-storage-sqlite-adoption.md`) および Phase 2 spec / P2-A spec / P2-B spec / P2-C spec で初出した用語を集約する。実装 identifier は P2-A で確定済のもの、P2-B で確定したもの (kotoha-dict / kotoha-storage / kotoha.db / UserVocab / UserVocabStore の 5 entry。P2-C で `UserVocabStore` は `UserVocabReader` / `UserVocabWriter` の 2 trait に分割した)、P2-C で確定したもの (`LearningCacheReader` / `LearningCacheWriter` / `test-helpers` feature flag / `CapOverrideGuard` / `evict_to_cap` helper の 5 entry)、P2-D 以降で確定予定のものを含む。
 
 ### 形態素解析 (Morphological Analysis)
 
@@ -239,8 +239,8 @@
 
 - **定義**: ユーザの変換候補選択履歴を永続化し、後続の rerank に利用する cache。永続化形式は SQLite 共用 DB `kotoha.db` の `learning_cache` table である (ADR 0015 / P2-B spec §5.2、2026-04-25 P2-B kick-off で確定)。runtime での in-memory LRU 形態を採るか SQLite 直読みのみとするかは P2-C kick-off で empirical 確定する。同一 kana 入力に対するユーザ選択の偏りを時系列で反映する目的で導入する。
 - **初出**: ADR 0014 D3 / Phase 2 spec §5 / ADR 0015
-- **対応する identifier**: `kotoha_storage::learning_cache::LearningCacheStore` trait (P2-B で skeleton 先出し、P2-C で `SqliteLearningCacheStore` 本実装)
-- **備考**: LRU 容量上限 (暫定 10,000 entry) / eviction 方針 / pruning 閾値は P2-C で empirical 確定する。Phase 5 `KotohaNative` backend でも再利用可能な layer として設計する (ADR 0014 D6)。
+- **対応する identifier**: `kotoha_storage::learning_cache::{LearningCacheReader, LearningCacheWriter}` trait (P2-B で `LearningCacheStore` 1 trait の skeleton として先出し、P2-C で arch-M-2 ISP split + 本実装に置換)。SQLite 実装は `kotoha_storage::learning_cache::sqlite::SqliteLearningCacheStore` が両 trait を impl する。
+- **備考**: P2-B 段階では skeleton(stub)であったが、P2-C(PR #106)で UPSERT(`record_choice`)+ 自動 LRU eviction(行数上限超過時に `last_used_at ASC` 順で削除)+ lookup(`frequency DESC, last_used_at DESC` 順)の本実装に置換した。LRU 容量上限は `LEARNING_CACHE_MAX_ROWS` 定数(暫定 10,000 entry)で表現し、Phase 5 personalization での動的 cap 化を後段 Issue として残す。Phase 5 `KotohaNative` backend でも再利用可能な layer として設計する (ADR 0014 D6)。
 
 ### Ranker / Reranker
 
@@ -265,10 +265,10 @@
 
 ### kotoha-storage
 
-- **定義**: Phase 2 P2-B で新規導入する Rust crate。SQLite ベースの永続化層を提供し、`Database` 構造体 / Migration runner / `UserVocabStore` / `LearningCacheStore` の 2 trait + 各実装(Sqlite + Mock)を含む。`rusqlite + bundled` を採用し、SQLite C library の依存を本 crate 内に閉じ込める。
+- **定義**: Phase 2 P2-B で新規導入する Rust crate。SQLite ベースの永続化層を提供し、`Database` 構造体 / Migration runner / `UserVocabReader` / `UserVocabWriter` / `LearningCacheReader` / `LearningCacheWriter` の 4 trait + 各実装(Sqlite + Mock)を含む。`rusqlite + bundled` を採用し、SQLite C library の依存を本 crate 内に閉じ込める。
 - **初出**: ADR 0015 / Phase 2 P2-B spec §4
-- **対応する identifier**: `crates/kotoha-storage/`(crate root)、`kotoha_storage::Database` / `kotoha_storage::user_vocab::UserVocabStore` 等
-- **備考**: Clean Architecture「Interface 依存」/ SOLID DIP に整合させるため、`kotoha-core` に逆依存しない。`kotoha-core::dict::user_vocab::UserVocab` が `Box<dyn UserVocabStore>` を field 保持することで `kotoha-core` 単体 build は SQLite C library コンパイル不要となる。
+- **対応する identifier**: `crates/kotoha-storage/`(crate root)、`kotoha_storage::Database` / `kotoha_storage::user_vocab::{UserVocabReader, UserVocabWriter}` / `kotoha_storage::learning_cache::{LearningCacheReader, LearningCacheWriter}` 等
+- **備考**: Clean Architecture「Interface 依存」/ SOLID DIP に整合させるため、`kotoha-core` に逆依存しない。`kotoha-core::dict::user_vocab::UserVocab` が `Box<dyn UserVocabReader>` を field 保持することで `kotoha-core` 単体 build は SQLite C library コンパイル不要となる。P2-B 着地時点では `UserVocabStore` / `LearningCacheStore` の 2 trait 構成であったが、P2-C(2026-04-26、PR #106)で arch-M-2 ISP split を適用し Reader/Writer の 4 trait 構成に置換した。
 
 ### kotoha.db
 
@@ -284,12 +284,40 @@
 - **対応する identifier**: `crates/kotoha-core/src/dict/user_vocab.rs` の `UserVocab` 構造体 (`impl VocabularyLookup`)
 - **備考**: `UserVocab::lookup` は SQLite backend エラー時に空 Vec を返す (`unwrap_or_default()`) ことで、`VocabularyLookup::lookup` の sync signature を維持しつつ MorphologicalEngine 経路と CustomVocab 経路の recall を保護する。
 
-### UserVocabStore
+### UserVocabReader / UserVocabWriter (ISP split)
 
-- **定義**: `kotoha-storage` crate 内で定義する trait。UserVocab の永続化抽象境界として `find_by_reading` / `list_all` / `insert` / `delete_by_id` / `delete_by_surface_reading` の 5 method を提供する。SQLite 実装 (`SqliteUserVocabStore`) と Mock 実装 (`MockUserVocabStore`) を持ち、Clean Architecture「Interface 依存」/ SOLID DIP に整合させる。
-- **初出**: Phase 2 P2-B spec §6.1
-- **対応する identifier**: `kotoha_storage::user_vocab::UserVocabStore` trait
-- **備考**: `Send + Sync` 制約を持ち、`Box<dyn UserVocabStore>` で `kotoha-core::dict::user_vocab::UserVocab` に注入される。`MockUserVocabStore` は SQLite 不在環境での Layer 2 integration test を可能にする目的で同 crate 内に配置する (P2-A `MockEngine` / `MockVocab` と同 pattern)。
+- **定義**: `kotoha-storage` crate 内で定義する 2 trait。`UserVocabReader` は read-only(`find_by_id` / `find_by_reading` / `find_by_prefix` / `list_all` の 4 method)、`UserVocabWriter` は write-only(`insert` / `delete_by_id` / `delete_by_surface_reading` の 3 method)である。SOLID Interface Segregation Principle(arch-M-2)に従い、Phase 3 IBus engine などの read-only consumer に Writer 系 method を露出しない設計とする。SQLite 実装(`SqliteUserVocabStore`)と Mock 実装(`MockUserVocabStore`)が両 trait を impl する。
+- **初出**: Phase 2 P2-B spec §6.1(`UserVocabStore` 1 trait として導入) / Phase 2 P2-C spec §3.2(arch-M-2 ISP split で 2 trait に分割)
+- **対応する identifier**: `kotoha_storage::user_vocab::store::{UserVocabReader, UserVocabWriter}`
+- **備考**: 両 trait とも `Send + Sync` 制約を持ち、`Box<dyn UserVocabReader>` / `Box<dyn UserVocabWriter>` で `kotoha-core::dict::user_vocab::UserVocab` 等の上位層に注入される。`MockUserVocabStore` は SQLite 不在環境での Layer 2 integration test を可能にする目的で同 crate 内に配置する(P2-A `MockEngine` / `MockVocab` と同 pattern)。履歴: P2-B(2026-04-25、PR #101)で `UserVocabStore` 1 trait として導入したが、P2-C(2026-04-26、PR #106)で arch-M-2 ISP split を適用し Reader / Writer の 2 trait に分割した。旧 `UserVocabStore` trait は P2-C で削除済。
+
+### LearningCacheReader / LearningCacheWriter (ISP split)
+
+- **定義**: `kotoha-storage` crate 内で定義する 2 trait。`LearningCacheReader` は read-only(`lookup(kana_input, limit) -> Vec<LearningCacheRecord>` の 1 method、`frequency DESC, last_used_at DESC` 順で返す)、`LearningCacheWriter` は write-only(`record_choice(kana_input, chosen_kanji)` UPSERT + 自動 LRU eviction、明示 eviction 用 `evict_lru(max_entries) -> usize` の 2 method)である。SOLID Interface Segregation Principle に従い、rerank consumer に Writer 系 method を露出しない設計とする。SQLite 実装(`SqliteLearningCacheStore`)が両 trait を impl する。
+- **初出**: Phase 2 P2-C spec §3.1 / §6.1(P2-B 段階の `LearningCacheStore` skeleton を ISP split で 2 trait に分割)
+- **対応する identifier**: `kotoha_storage::learning_cache::{LearningCacheReader, LearningCacheWriter}` trait + `kotoha_storage::learning_cache::sqlite::SqliteLearningCacheStore` 実装
+- **備考**: 両 trait とも `Send + Sync` 制約を持ち、`Box<dyn LearningCacheReader>` / `Box<dyn LearningCacheWriter>` で上位層に注入される。`record_choice` 内部では `effective_max_rows()` を cap として `evict_to_cap` helper を呼出し自動 LRU eviction を行うため、通常の consumer は `evict_lru` を明示呼出しする必要は少ない。履歴: P2-B(2026-04-25、PR #101)で `LearningCacheStore` 1 trait の skeleton として先出ししたが、P2-C(2026-04-26、PR #106)で arch-M-2 ISP split + 本実装に置換した。旧 `LearningCacheStore` trait は P2-C で削除済。
+
+### test-helpers feature flag
+
+- **定義**: `kotoha-storage` crate の Cargo feature。test-only API(`CapOverrideGuard` / `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` / `CAP_OVERRIDE_LOCK` / `effective_max_rows`)を `#[cfg(any(test, feature = "test-helpers"))]` で gate し、production binary に test-only API が漏出しない設計を実現する。default では off であり、integration test crate(`crates/kotoha-storage/tests/learning_cache_*`)が `[[test]] required-features = ["test-helpers"]` で要求する。
+- **初出**: Phase 2 P2-C spec §4.5 / §4.6(commit `42f5cd2` で導入)
+- **対応する identifier**: `crates/kotoha-storage/Cargo.toml` の `[features]` 節 `test-helpers = []` + 各 test-only 定義の `#[cfg(any(test, feature = "test-helpers"))]` gate
+- **備考**: lefthook pre-push の test step が `--features kotoha-storage/test-helpers` を強制することで、production-only build と test build の両方を CI で機械検証する。本 feature gate により「test-only RAII guard が production API に漏出する」という arch-M-2 / sec-M finding を構造的に防止する。
+
+### CapOverrideGuard
+
+- **定義**: `kotoha-storage` crate の test-only RAII guard。`#[cfg(any(test, feature = "test-helpers"))]` で gate される。`new(cap)` は test override 値設定 + `CAP_OVERRIDE_LOCK` 取得を同時に行い、`lock_only()` は override 値変更なしに `CAP_OVERRIDE_LOCK` のみを取得する(parallel 実行される他 test の `record_choice` 内 auto eviction を小さな cap で発火させない用途)。Drop 時に override 値を 0 に戻す。
+- **初出**: Phase 2 P2-C spec §4.5(commit `1af6d6b` で `LEARNING_CACHE_MAX_ROWS` cap const と同時導入、`eef7cc9` で `lock_only` API 追加、`42f5cd2` で test-helpers feature gate 化)
+- **対応する identifier**: `kotoha_storage::learning_cache::sqlite::CapOverrideGuard` 構造体(`crates/kotoha-storage/src/learning_cache/sqlite.rs`)
+- **備考**: `kotoha_storage::user_vocab::sqlite::QuotaOverrideGuard`(P2-B 由来)と同 pattern であり、static `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize` の値を test scope で一時的に上書きする。process 全体の static を変更する性質上、test 間の race を `CAP_OVERRIDE_LOCK: Mutex<()>` で serialize する。
+
+### evict_to_cap helper
+
+- **定義**: `kotoha-storage` crate の `pub(crate)` 内部関数。signature は `pub(crate) fn evict_to_cap(conn: &Connection, cap: usize) -> Result<usize, StorageError>`。`COUNT(*)` で `learning_cache` table の行数を取得し、`cap` を超過していれば超過分の entry を `last_used_at ASC, id ASC` 順に DELETE し、削除件数を返す。
+- **初出**: Phase 2 P2-C spec §4.6(commit `fd124b7` で抽出)
+- **対応する identifier**: `kotoha_storage::learning_cache::sqlite::evict_to_cap`(`crates/kotoha-storage/src/learning_cache/sqlite.rs`)
+- **備考**: `record_choice` の自動 eviction(commit `fd124b7`)と `evict_lru` の明示 eviction(commit `3c8391d`)で共通化された helper。tie-breaker `id ASC` を併用することで `last_used_at` が同値の場合でも決定論的な削除順序を保証する。
 
 ## 5. LLM 推論とプロンプト
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -46,7 +46,7 @@ pre-push:
     test:
       run: |
         if [ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]; then
-          cargo test --workspace
+          cargo test --workspace --features kotoha-storage/test-helpers
         else
           echo "lefthook: skip test (no crates/ yet; enforced from M2)"
         fi
@@ -59,7 +59,7 @@ pre-push:
     test-dict:
       run: |
         if [ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]; then
-          cargo test --workspace --features dict
+          cargo test --workspace --features dict,kotoha-storage/test-helpers
         else
           echo "lefthook: skip test-dict (no crates/ yet; enforced from M2)"
         fi
@@ -71,7 +71,7 @@ pre-push:
     test-dict-persist:
       run: |
         if [ -d crates ] && [ -n "$(ls -A crates 2>/dev/null)" ]; then
-          cargo test --workspace --features kotoha-cli/dict-persist
+          cargo test --workspace --features kotoha-cli/dict-persist,kotoha-storage/test-helpers
         else
           echo "lefthook: skip test-dict-persist (no crates/ yet; enforced from M2)"
         fi


### PR DESCRIPTION
## Summary

Implement Phase 2-C: full SqliteLearningCacheStore implementation (lookup / record_choice / evict_lru) plus arch-M-2 (Interface Segregation Principle) — split UserVocabStore / LearningCacheStore into Reader/Writer trait pairs. Add v002 migration with idx_learning_cache_last_used index.

## Scope

- LearningCache full implementation: `lookup` (exact match, ORDER BY frequency DESC, last_used_at DESC), `record_choice` (UPSERT via `ON CONFLICT DO UPDATE` + auto LRU eviction), `evict_lru(max_entries)`
- arch-M-2 ISP split: 4 traits (`UserVocabReader` / `UserVocabWriter` / `LearningCacheReader` / `LearningCacheWriter`); legacy `UserVocabStore` / `LearningCacheStore` removed
- `Database` factory: 4 methods; legacy 2-method factory removed
- v002 migration: `CREATE INDEX idx_learning_cache_last_used ON learning_cache(last_used_at)`
- Validation: reuse `validate_reading` / `validate_surface` (P2-B compliance)
- Test coverage: 23 L1 unit + 5 L2 integration + 3 proptest invariants (PROPTEST_CASES=64)
- New crate feature: `test-helpers` (gates `CapOverrideGuard` et al. out of production binary)

## Test plan

- [x] `cargo test --workspace --features kotoha-storage/test-helpers` PASSes (default 320, dict 379, dict-persist 394; +39 each from P2-B baseline)
- [x] `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers -- -D warnings` zero warnings
- [x] `cargo audit` 0 vulnerabilities
- [x] `lefthook run pre-push` all 6 steps PASS (build / clippy / manifest-check / test / test-dict / test-dict-persist)
- [x] Production binary verified clean of test-only symbols via `nm -C` (0 hits for CapOverrideGuard / LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE / CAP_OVERRIDE_LOCK / effective_max_rows)
- [x] proptest 3 invariants PASS at PROPTEST_CASES=64
- [x] v002 migration applies cleanly on fresh DB and upgrades from v001 (3 dedicated runner tests)

## Acceptance criteria (spec §8)

- [x] `cargo test --workspace` passes for `default` / `dict` / `dict-persist` (3 configurations); zero regression
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo audit` shows 0 vulnerabilities
- [x] lefthook pre-push 3-feature gate passes
- [x] 4 traits established (`*Reader` / `*Writer` for both stores)
- [x] Legacy `UserVocabStore` / `LearningCacheStore` traits removed
- [x] 4 factory methods established; legacy factories removed
- [x] v002 migration runs on fresh DB and auto-upgrades existing v001 DB
- [x] proptest 3 invariants pass (PROPTEST_CASES=64)
- [x] WBS log committed to `docs/wbs/2026-04-26-feature-105-p2-c-learning-cache.md`
- [x] team-review (4 dim: security / architecture / testing / performance) completed; 0 Critical / 0 High; 11 Medium / 16 Low deferred to follow-up Issue #107

## Branch Scope Policy

- 20 files / +1756 / -166 lines (within 20-file limit; over 1000-line guideline due to bundled ISP split + LearningCache impl + test coverage)
- Single PR scope justified: ISP split is a prerequisite for LearningCache integration; splitting would leave LearningCache disabled mid-Phase
- Large tier review applies (per CLAUDE.md PR Review Matrix); team-review 4 dim + owasp-security + secrets-check + pr-review-toolkit:review-pr scheduled in Phase E follow-up

## Notes

- Per CLAUDE.md "Sub-agent Self-Report is Untrusted" rule, all gating commands' verbatim output captured in WBS log
- `CapOverrideGuard::lock_only()` added (test-only, production unaffected) to serialize cap override against parallel test execution

Refs: #105