### PR TITLE
fix(storage): recover from `Mutex<Connection>` poison instead of panicking (#110)

### DIFF
--- a/crates/kotoha-storage/src/database.rs
+++ b/crates/kotoha-storage/src/database.rs
@@ -1,7 +1,7 @@
 //! `Database` 構造体: Mutex<Connection> + Arc 共有 ownership(spec §6.4)。
 
 use std::path::Path;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use rusqlite::Connection;
 
@@ -74,11 +74,17 @@ impl Database {
     /// `UserVocabReader/Writer` / `LearningCacheReader/Writer` 抽象境界を
     /// 通すことを強制する(review A-H2)。
     ///
-    /// # Panics
+    /// # Postconditions
     ///
-    /// poison された場合 panic する(other thread が panic 中に lock を保持していた場合)。
+    /// - 戻り値は使用可能な `MutexGuard<Connection>` で、本関数自体は panic を伝播しない
+    /// - 他 thread の panic で `Mutex` が poisoned 状態になっていた場合も、
+    ///   `PoisonError::into_inner` で guard を回収して continuation する
+    ///   (Phase 3 IBus engine の thread cascade death 防止 / sec-F4)
+    /// - 各 SQL 文は SQLite の auto-commit により atomic に確定するため、recovery 時点で
+    ///   partial-statement state が観測されることはない(本 crate は現時点で明示
+    ///   transaction を使用していない)
     pub(crate) fn lock_conn(&self) -> MutexGuard<'_, Connection> {
-        self.conn.lock().expect("Database mutex poisoned")
+        self.conn.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     /// `Arc<Database>` を `Box<dyn UserVocabReader>` として公開する(arch-M-2 ISP split)。
@@ -350,5 +356,50 @@ mod tests {
         let reader = db.user_vocab_reader();
         let result = reader.list_all(100, 0).unwrap();
         assert_eq!(result.len(), 8);
+    }
+
+    /// `lock_conn` が poisoned `Mutex` から recovery することを実測検証する。
+    ///
+    /// # シナリオ
+    ///
+    /// Phase 3 IBus engine は input dispatch / auto-eviction / UI thread を併走させる
+    /// multi-threaded 構成である。いずれかの thread が `Mutex<Connection>` を保持中に
+    /// panic すると、`Mutex` は poisoned となり、後続の `Mutex::lock()` は `Err(PoisonError)`
+    /// を返す。修正前の `.expect("Database mutex poisoned")` は その `Err` を panic に
+    /// 変換していたため、1 件の panic が他 thread にも cascade death を誘発していた。
+    ///
+    /// # 実測検証
+    ///
+    /// 本 test は旧実装(`.expect`)上では「2 回目の `lock_conn()` が panic」によって
+    /// FAIL する性質を持ち、修正後の `unwrap_or_else(PoisonError::into_inner)` でのみ
+    /// PASS する。`PRAGMA user_version` の round-trip が、recovery 後の Connection が
+    /// 引き続き使用可能であることの smoke check として機能する。
+    #[test]
+    fn lock_conn_recovers_from_poisoned_mutex() {
+        let db = Database::open_in_memory().expect("memory open");
+
+        let db_clone = Arc::clone(&db);
+        let handle = std::thread::spawn(move || {
+            let guard = db_clone.lock_conn();
+            // SQL を 1 回 round-trip させ、guard が optimizer に elide されないようにする。
+            let _: i32 = guard
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .expect("query within poisoning thread must succeed");
+            // guard を保持したまま panic することで、unwind 時に Mutex が poisoned になる。
+            panic!("intentional panic to poison the mutex");
+        });
+        let join_result = handle.join();
+        assert!(
+            join_result.is_err(),
+            "spawned thread must have panicked to poison the mutex"
+        );
+
+        // 修正後の `lock_conn` は poisoned `Mutex` から recovery し、panic を伝播しない。
+        // 旧実装(`.expect`)では本行で 2 段目の panic が発生し、test は FAIL する。
+        let conn = db.lock_conn();
+        let version: i32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .expect("recovered connection must remain usable");
+        assert_eq!(version, crate::migrations::LATEST_VERSION);
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 IBus prerequisite. Replaces the panic-on-poison behavior in `Database::lock_conn` with recovery via `PoisonError::into_inner`, preventing a single panic in any DB-touching thread from cascading to the entire IME process.

Closes #110. Resolves the S-4 line item from #107 (Phase 3 prerequisite 2/4).

## Why

`Mutex::lock()` returns `Err(PoisonError)` if any prior thread panicked while holding the guard. The current `.expect("Database mutex poisoned")` converts that into a second panic on every subsequent call from any other thread. Phase 3 IBus engine is multi-threaded by design (input dispatch + auto-eviction + UI thread), so a panic in any one path takes down the whole IME.

`PoisonError::into_inner` recovers the `MutexGuard` and lets callers continue. This is safe because:

- Each SQL statement is atomic at the SQLite level (auto-commit). The crate has no explicit `BEGIN ... COMMIT` blocks, so no partial-statement state is observable post-poison.
- The codebase never reads `Mutex::is_poisoned()` and never relies on poison-as-signal — confirmed via grep.
- The pattern is already used 5+ times in the same crate's test helpers (`CapOverrideGuard`, `record_trace`).

## Production change

| Site | Before | After |
|------|--------|-------|
| `database.rs:80-82` | `self.conn.lock().expect("Database mutex poisoned")` | `self.conn.lock().unwrap_or_else(PoisonError::into_inner)` |

Doc block reorganized per code review:
- `# Panics` block (which incorrectly documented post-fix behavior) replaced with canonical `# Postconditions` (matches lang-rust.md recognized sections and surrounding code style in `database.rs:22, 29, 98, 113, 128, 143`).
- Inline body rationale comment removed — the postcondition block is the single source of truth.
- Recovery rationale now describes "SQLite auto-commit atomicity" instead of "中断 transaction の自動 rollback" — more accurate since the crate has no explicit transactions.

## Test

Adds `lock_conn_recovers_from_poisoned_mutex` (placed near the existing parallelism tests). The test:

1. Spawns a thread, acquires `lock_conn()`, runs `PRAGMA user_version`.
2. Panics while still holding the guard. The unwind drops the guard, marking the Mutex poisoned.
3. Joins the panicked thread; asserts `is_err()`.
4. From the main thread, calls `lock_conn()` again — must NOT panic.
5. Runs `PRAGMA user_version` through the recovered guard, asserts `LATEST_VERSION`.

**Empirical regression-protection authenticity** (per the lessons-learned from PR #109):
- Against OLD `.expect()` code: the test FAILS with verbatim cascade panic at `database.rs:90:26 'Database mutex poisoned: PoisonError { .. }'` — the second panic from `.expect()` propagating the poison.
- Against NEW code: PASSES deterministically; only the spawned thread's intentional panic appears in stderr.

## Verification

| Layer | Result |
|-------|--------|
| `cargo build --workspace --features kotoha-storage/test-helpers` | clean |
| `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers -- -D warnings` | warnings 0 |
| `cargo test --workspace --features kotoha-storage/test-helpers --no-fail-fast -- --test-threads=2` | **325 passed / 0 failed / 0 ignored** (324 baseline + 1 new) |
| `cargo fmt --all -- --check` | clean |
| lefthook pre-commit (doc-naming-self-test + fmt-check) | green |
| lefthook pre-push (build / clippy / manifest-check / test / test-dict / test-dict-persist) | green |

## Review process

3-dimension parallel review (security / architecture / testing) + secrets-check.

| Dimension | Verdict | Findings (in-PR resolution) |
|-----------|---------|----------------------------|
| Security | APPROVED_WITH_MINOR | Medium 1 (pre-existing #107 S-2, NOT introduced by this PR — defer); Low 1 (doc accuracy — folded into the `# Postconditions` consolidation) |
| Architecture | APPROVED_WITH_MINOR | Medium 1 (`# Recovery` non-standard rustdoc section — fixed by replacing with `# Postconditions`); Low 2 (redundant inline comment removed; policy doc deferred to PR body) |
| Testing | APPROVED_WITH_MINOR | Medium 1 (panic noise in CI logs — quality-of-life, deferred); Low 2 (PRAGMA assertion strength acceptable for scope; factory-trait gap deferred to future PR) |
| Secrets | CLEAN | 0 |

No Critical, no High, no CHANGES_REQUESTED. All resolution recommendations folded into a single cleanup commit.

## Out of scope

- Issue #107 S-2 (non-transactional UPSERT + auto-eviction) is a pre-existing latent issue not introduced by this PR. The poison-recovery fix actually *reduces* its blast radius (replaces "service-wide thread cascade death" with "self-healing one-row cap overshoot"). Stays open in #107.
- Factory-via-trait-object regression test (Test review LL-2) deferred — meaningful gap but out of scope for the surgical Phase 3 prerequisite fix.

## Test plan

- [x] `cargo build --workspace --all-targets --features kotoha-storage/test-helpers` clean
- [x] `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers -- -D warnings` 0 warnings
- [x] `cargo test --workspace --features kotoha-storage/test-helpers` 325 PASS / 0 FAIL
- [x] Empirical: OLD `.expect()` code FAILS new test with verbatim cascade panic; NEW code PASSES
- [x] lefthook pre-push gate green

## Refs

- #107 (S-4 line resolved by this PR; S-2 / S-3 / S-5 / etc. stay open)
- #105 (P2-C spec)
- #106 (P2-C merge)
- #108 (S-1 issue)
- #109 (S-1 PR — merged just before this one)
- #110 (this PR — closes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)