### PR TITLE
perf(storage): use `prepare_cached` for `COUNT_SQL` in `evict_to_cap` (#114)

### DIFF
--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -186,7 +186,11 @@ const EVICT_SQL: &str = "DELETE FROM learning_cache
 ///
 /// - [`StorageError::Sqlite`][]: SQLite backend 障害の場合
 pub(crate) fn evict_to_cap(conn: &rusqlite::Connection, cap: usize) -> Result<usize, StorageError> {
-    let total: i64 = conn.query_row(COUNT_SQL, [], |r| r.get(0))?;
+    // perf-H1: prepare_cached により COUNT_SQL の compile を初回のみとし、
+    // 以降は statement cache から再利用する。`record_choice` は Phase 3 IBus engine の
+    // 打鍵毎に呼ばれるため、~1.4 µs/op の compile cost を毎打鍵分削減する。
+    let mut stmt = conn.prepare_cached(COUNT_SQL)?;
+    let total: i64 = stmt.query_row([], |r| r.get(0))?;
     // sec-F4: bind 方向と対称に、SQLite -> Rust 方向の変換も `as` cast ではなく
     // `try_from + clamp` を使用する。64-bit target では `i64::MAX < usize::MAX`
     // のため変換は必ず成功し、32-bit target では clamp により切り捨てを防ぐ
@@ -315,6 +319,11 @@ mod tests {
     // `record_trace` は callback、`TRACED_SQL` は accumulator、`TRACE_LOCK` は
     // 並列 trace test 同士の直列化 mutex。
     static TRACED_SQL: std::sync::Mutex<String> = std::sync::Mutex::new(String::new());
+
+    /// 並列 trace test 同士の直列化 mutex。`Connection::trace`(PR #109、`record_trace`
+    /// callback) と `sqlite3_trace_v2`(PR #114、`count_sql_stmt_trace` callback)の
+    /// 両方が共有する。新しい trace test を追加する場合も、この同じ `TRACE_LOCK` を
+    /// 取得して直列化すること(個別の lock を作らない)。
     static TRACE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn record_trace(sql: &str) {
@@ -324,6 +333,82 @@ mod tests {
             buf.push('\n');
         }
         buf.push_str(sql);
+    }
+
+    // --- trace_v2 (SQLITE_TRACE_STMT) infrastructure ---
+    //
+    // `sqlite3_trace_v2` を `SQLITE_TRACE_STMT` mask で attach すると、prepared
+    // statement が **実行開始** する瞬間に callback が発火し、第 2 引数で当該
+    // `sqlite3_stmt*` が渡される。同一の prepared statement instance が
+    // 複数回実行されるたびに同じ pointer 値が観測される一方、毎回 new prepare
+    // される場合は異なる pointer 値が観測される。
+    //
+    // すなわち pointer 値の `unique count` を測れば「prepared statement instance が
+    // 何個 compile されたか」が機械的に判定できる:
+    //
+    // - `prepare_cached(SQL)` を N 回呼ぶ → unique pointer = 1
+    // - `query_row(SQL, ...)` を N 回呼ぶ(毎回 prepare + finalize) → unique pointer = N
+    //
+    // SQL text は `sqlite3_sql(stmt)` で取得し、`COUNT_SQL` の prefix で filter する
+    // (UPSERT_SQL や EVICT_SQL の compile を分離するため)。
+    //
+    // pointer は `usize` に cast して static `Mutex<HashSet<usize>>` に蓄える
+    // (raw pointer は `Send`/`Sync` でないため)。
+    //
+    // NOTE: rusqlite 0.32 は `Connection::trace_v2` を safe API として export していない
+    // (rusqlite/issues/977 で TODO)。将来 safe wrapper が提供されたら、本 FFI 実装は
+    // closure-captured な `Arc<Mutex<...>>` の safe 版に折り畳める。
+    //
+    // IMPORTANT: 本 statics を使用する test は test 開頭で必ず clear する
+    // (`COUNT_SQL_STMT_PTRS.lock()...clear()` と `COUNT_SQL_STMT_EVENTS.store(0, ...)`)。
+    // `TRACE_LOCK` は serialization のみで auto-reset しないため、cross-test の
+    // state leak を防ぐ責任は test 側にある。
+    static COUNT_SQL_STMT_PTRS: std::sync::Mutex<std::collections::BTreeSet<usize>> =
+        std::sync::Mutex::new(std::collections::BTreeSet::new());
+    static COUNT_SQL_STMT_EVENTS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    /// `SQLITE_TRACE_STMT` callback。`COUNT_SQL` を実行している prepared statement
+    /// pointer を `COUNT_SQL_STMT_PTRS` に蓄積する。
+    ///
+    /// # Safety
+    ///
+    /// - `_p_ctx` / `p_stmt` / `_x` は SQLite が管理する有効ポインタ。
+    /// - `p_stmt` は active な prepared statement で、`sqlite3_sql` の呼び出しは
+    ///   safe(NUL 終端 C 文字列を返す)。
+    /// - callback は `catch_unwind` で panic を抑止し、SQLite 側に unwind を
+    ///   逃さない(C ABI からの unwind は UB)。
+    unsafe extern "C" fn count_sql_stmt_trace(
+        _event: std::os::raw::c_uint,
+        _p_ctx: *mut std::os::raw::c_void,
+        p_stmt: *mut std::os::raw::c_void,
+        _x: *mut std::os::raw::c_void,
+    ) -> std::os::raw::c_int {
+        let _ = std::panic::catch_unwind(|| {
+            if p_stmt.is_null() {
+                return;
+            }
+            let stmt = p_stmt as *mut rusqlite::ffi::sqlite3_stmt;
+            // SAFETY: `stmt` is non-null and SQLite guarantees `sqlite3_sql`
+            // returns a static C string for the duration of the statement.
+            let sql_ptr = unsafe { rusqlite::ffi::sqlite3_sql(stmt) };
+            if sql_ptr.is_null() {
+                return;
+            }
+            // SAFETY: SQLite-owned NUL-terminated C string.
+            let sql = unsafe { std::ffi::CStr::from_ptr(sql_ptr) }.to_string_lossy();
+            // COUNT_SQL の prefix で filter する(UPSERT / EVICT は除外)。
+            // ハードコードした SQL literal ではなく定数を直接参照することで、
+            // `COUNT_SQL` 定数の表記を変更しても自動的に追従する。
+            if sql.contains(COUNT_SQL) {
+                let mut set = COUNT_SQL_STMT_PTRS
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner());
+                set.insert(stmt as usize);
+                COUNT_SQL_STMT_EVENTS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        });
+        0
     }
 
     /// `lookup` は存在しない kana_input に対して空 Vec を返す。
@@ -722,6 +807,143 @@ mod tests {
         assert!(
             traced.contains("SELECT id, kana_input"),
             "trace must capture LOOKUP_SQL; got: {traced}"
+        );
+    }
+
+    /// `sqlite3_trace_v2` を attach した状態で `body` を実行し、終了時 / panic 時の
+    /// どちらでも必ず detach する panic-safe な closure helper。
+    ///
+    /// # Why a closure instead of a Drop-based RAII guard
+    ///
+    /// `Mutex<Connection>` の都合で、attach / detach は短い lock scope で行い、
+    /// `body` 内の `record_choice` は別 lock scope で `db.lock_conn()` を取得する
+    /// 必要がある(`MutexGuard<Connection>` を `body` 全体で保持すると
+    /// `record_choice` 内部の `lock_conn()` が deadlock する)。
+    /// SQLite 側の trace callback は connection 単位で保存されるため、attach 後に
+    /// MutexGuard を解放しても `body` の `record_choice` 呼び出しでは callback が
+    /// 引き続き発火する。`Drop` ベースの guard は `&'a Connection` を抱え込んで
+    /// MutexGuard の lifetime と結合してしまうため、本 helper では closure 形で
+    /// 「attach -> `catch_unwind(body)` -> detach -> `resume_unwind`」の順で
+    /// 強制 detach を担保する設計を採る。
+    ///
+    /// # Safety contract
+    ///
+    /// - `count_sql_stmt_trace` は `unsafe extern "C"` で、内部で `catch_unwind`
+    ///   により panic を抑止しているため、C ABI 越しの unwind は起きない。
+    /// - attach と detach は同じ connection の `sqlite3*` 上で対称に呼ばれる。
+    fn with_trace<F: FnOnce() + std::panic::UnwindSafe>(store: &SqliteLearningCacheStore, body: F) {
+        // attach
+        {
+            let conn = store.db.lock_conn();
+            // SAFETY: `handle()` is valid for the lifetime of `conn`. We attach
+            // here while holding the MutexGuard and detach later via the same
+            // path; SQLite stores the callback per-connection, so the callback
+            // remains active even after we release the MutexGuard.
+            let rc = unsafe {
+                rusqlite::ffi::sqlite3_trace_v2(
+                    conn.handle(),
+                    rusqlite::ffi::SQLITE_TRACE_STMT as std::os::raw::c_uint,
+                    Some(count_sql_stmt_trace),
+                    std::ptr::null_mut(),
+                )
+            };
+            assert_eq!(
+                rc,
+                rusqlite::ffi::SQLITE_OK,
+                "sqlite3_trace_v2 attach must succeed (rc={rc})"
+            );
+        }
+        // body を catch_unwind で実行し、panic でも detach に到達させる。
+        let result = std::panic::catch_unwind(body);
+        // detach (always runs)
+        {
+            let conn = store.db.lock_conn();
+            // SAFETY: same Connection; passing None removes the callback.
+            unsafe {
+                rusqlite::ffi::sqlite3_trace_v2(
+                    conn.handle(),
+                    rusqlite::ffi::SQLITE_TRACE_STMT as std::os::raw::c_uint,
+                    None,
+                    std::ptr::null_mut(),
+                );
+            }
+        }
+        if let Err(panic) = result {
+            std::panic::resume_unwind(panic);
+        }
+    }
+
+    /// `evict_to_cap` の `COUNT_SQL` が `prepare_cached` 経由で statement cache から
+    /// 再利用され、`record_choice` を 4 連続呼び出ししても **prepared statement instance
+    /// は 1 個** しか作られないことを実測検証する(perf-H1)。
+    ///
+    /// # Background
+    ///
+    /// 旧実装の `evict_to_cap` は `conn.query_row(COUNT_SQL, [], ...)` を呼び、
+    /// 内部で prepare → step → finalize を毎回繰り返していた。Phase 3 IBus engine では
+    /// `record_choice` が打鍵毎に呼ばれるため、~1.4 µs/op の compile cost が打鍵数に
+    /// 比例して累積する(`record_choice` latency の約 11%)。
+    /// 新実装は `prepare_cached(COUNT_SQL)` により初回のみ compile し、以降は
+    /// statement cache から同一 `sqlite3_stmt*` を再利用する。
+    ///
+    /// # Detection mechanism
+    ///
+    /// SQLite の `sqlite3_trace_v2(db, SQLITE_TRACE_STMT, cb, ctx)` は、prepared
+    /// statement が **実行開始** する瞬間に第 3 引数で当該 `sqlite3_stmt*` を渡す。
+    /// `prepare_cached` で再利用された場合は同一 pointer 値が観測され、毎回 prepare
+    /// される場合は異なる pointer 値が観測される。callback で `sqlite3_sql(stmt)` を
+    /// 呼んで SQL text を取得し、`COUNT_SQL` で filter した上で **unique pointer count** を
+    /// 数えれば「何個の prepared statement instance が compile されたか」が分かる。
+    ///
+    /// # Assertions
+    ///
+    /// - 4 回の `record_choice` 呼び出しで `COUNT_SQL` の trace event が **4 回以上** 発火する
+    ///   (実行回数の sanity check、現状は厳密に 4 回)
+    /// - `COUNT_SQL` を実行している prepared statement の **unique pointer count = 1**
+    ///   (prepare_cached が cache hit している証拠)
+    ///
+    /// 旧 `query_row` 実装ではこの test は unique pointer count = 4 となり FAIL する。
+    #[test]
+    fn evict_to_cap_uses_prepare_cached_for_count_sql() {
+        let _serialize = TRACE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _cap_lock = CapOverrideGuard::lock_only();
+        let store = fresh_store_b();
+
+        // capture 用 static を初期化する(他 test の leftover 防止)。
+        COUNT_SQL_STMT_PTRS
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
+        COUNT_SQL_STMT_EVENTS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        // 4 回 record_choice を呼ぶ。各 call の `evict_to_cap` で COUNT_SQL が走る。
+        // `with_trace` は attach / detach を panic-safe に巻き取る(panic でも detach)。
+        with_trace(&store, || {
+            for (reading, kanji) in [("あ", "亜"), ("い", "以"), ("う", "宇"), ("え", "江")]
+            {
+                store.record_choice(reading, kanji).expect("record ok");
+            }
+        });
+
+        let unique_ptr_count = COUNT_SQL_STMT_PTRS
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .len();
+        let event_count = COUNT_SQL_STMT_EVENTS.load(std::sync::atomic::Ordering::SeqCst);
+
+        // sanity: COUNT_SQL は record_choice 毎に少なくとも 1 回実行される(現状は 4 回)。
+        // 厳密に 4 を要求すると将来 evict_to_cap が追加で COUNT_SQL を呼ぶ refactor で
+        // false-FAIL するため、`>= 4` で plumbing の正常性を確認するに留める。
+        assert!(
+            event_count >= 4,
+            "COUNT_SQL trace fired fewer times than record_choice calls (got {event_count}, unique_ptrs={unique_ptr_count}); plumbing is broken"
+        );
+
+        // perf-H1 assertion: prepare_cached により COUNT_SQL の prepared statement
+        // は 1 個しか作られない。旧 `query_row` 実装では unique_ptr_count = 4 となる。
+        assert_eq!(
+            unique_ptr_count, 1,
+            "evict_to_cap must reuse a single cached prepared statement for COUNT_SQL across multiple record_choice calls (got {unique_ptr_count} distinct sqlite3_stmt* over {event_count} executions); old `conn.query_row(COUNT_SQL, ...)` regression would yield {event_count} distinct pointers"
         );
     }
 


### PR DESCRIPTION
## Summary

**Final Phase 3 prerequisite (4/4 complete after this PR merges).** Switches `evict_to_cap`'s `COUNT_SQL` invocation from per-call recompile to cached prepared statement, eliminating ~1.4 µs of fixed compile cost per `record_choice` call. After this PR, all four hot-path SQL strings in the LearningCache module use `prepare_cached`.

Closes #114. Resolves the P-1 line item from #107.

## Why

`record_choice` invokes `evict_to_cap` per keystroke in the Phase 3 IBus engine. Pre-fix, `evict_to_cap` called `conn.query_row(COUNT_SQL, [], ...)` directly, which does `prepare → step → finalize` each time. The 4-dim review on PR #106 measured the compile cost at ~1.4 µs/op = a meaningful fraction of `record_choice`'s end-to-end latency.

The fix is structurally trivial — switch to `let mut stmt = conn.prepare_cached(COUNT_SQL)?; stmt.query_row(...)?` so the statement enters the connection's `StatementCache` and is reused for all subsequent calls. This puts COUNT_SQL on the same fast path as LOOKUP_SQL, UPSERT_SQL, and EVICT_SQL — all four hot-path SQL strings in the LearningCache module are now uniformly cached.

| SQL | Cached after PR | Site |
|-----|----------------|------|
| `LOOKUP_SQL` | ✅ | `lookup` |
| `UPSERT_SQL` | ✅ | `record_choice` |
| `EVICT_SQL` | ✅ | `evict_to_cap` (already, since PR #106) |
| `COUNT_SQL` | ✅ (this PR) | `evict_to_cap` |

## Production change

```rust
// Before (sqlite.rs:189)
let total: i64 = conn.query_row(COUNT_SQL, [], |r| r.get(0))?;

// After
let mut stmt = conn.prepare_cached(COUNT_SQL)?;
let total: i64 = stmt.query_row([], |r| r.get(0))?;
```

The intermediate `let mut stmt = ...` binding matches the surrounding `prepare_cached` sites in the same file (LOOKUP_SQL at L237, UPSERT_SQL at L267, EVICT_SQL at L204), per the architecture review's style consistency finding.

## Regression test

Adds `evict_to_cap_uses_prepare_cached_for_count_sql`. The test uses SQLite's `sqlite3_trace_v2(SQLITE_TRACE_STMT)` to count distinct `sqlite3_stmt*` pointers — when `prepare_cached` is used, all calls reuse the same cached statement (1 unique pointer); when `query_row` is used directly, each call allocates a fresh statement (N distinct pointers).

**Empirically verified**:
- OLD `query_row(COUNT_SQL, ...)` code: test FAILS with `unique_ptr_count = 4` over 4 `record_choice` calls
- NEW `prepare_cached` code: test PASSES with `unique_ptr_count = 1`

The test runs `record_choice` 4 times and asserts `unique_ptr_count == 1` (strict — this is the regression detector). The `event_count >= 4` sanity assertion is intentionally a lower-bound, so future refactors that add additional COUNT_SQL invocations don't false-FAIL.

### Test scaffolding notes

`rusqlite` 0.32 doesn't expose a safe `Connection::trace_v2` wrapper (rusqlite/issues/977). The test uses `rusqlite::ffi::sqlite3_trace_v2` directly. The unsafe FFI is well-bounded:

- The callback is `unsafe extern "C"` and wraps the body in `std::panic::catch_unwind` to prevent UB on cross-ABI unwind.
- `sqlite3_sql(stmt)` returns a NUL-terminated C string for the lifetime of the prepared statement; the callback only reads it inside the FFI call.
- `sqlite3_stmt*` pointer values are stored as `usize` in a static `BTreeSet<usize>` (raw pointers are not `Send + Sync`).
- attach/detach is wrapped in a `with_trace` closure helper using `catch_unwind + resume_unwind` — detach runs even if `record_choice` panics. A Drop-based RAII guard would deadlock because `MutexGuard<Connection>` can't live across `record_choice` calls (each one re-acquires the inner `lock_conn`).
- `TRACE_LOCK` (added by PR #109) serializes all trace tests and is now shared across PR #109's `record_trace` family and PR #114's `count_sql_stmt_trace` family. Documented at the static definition.
- `bundled-sqlite` feature (default) brings `rusqlite::ffi::*` and `SQLITE_TRACE_STMT` symbols. No new dependency added.

## Verification

| Layer | Result |
|-------|--------|
| `cargo build --workspace --features kotoha-storage/test-helpers` | clean |
| `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers -- -D warnings` | warnings 0 |
| `cargo test --workspace --features kotoha-storage/test-helpers --no-fail-fast -- --test-threads=2` | **340 passed / 0 failed / 0 ignored** (339 baseline + 1 new) |
| `cargo fmt --all -- --check` | clean |
| `grep -c "Issue #" sqlite.rs` | **0** (issue refs cleanup complete) |
| Empirical FAIL/PASS reconfirmation | ✓ OLD code FAILS with `unique_ptr_count = 4`; NEW code PASSES |
| lefthook pre-commit + pre-push | green |

## Review process

4-dim parallel review (security / architecture / testing / performance) + secrets-check.

| Dim | Verdict | Round-2 cleanup applied |
|-----|---------|------------------------|
| Security | APPROVED | RAII/closure refactor (Low #1: panic-path detach skip) — applied. Low #2 (CStr byte comparison) — deferred, not material |
| Architecture | APPROVED_WITH_MINOR | **Med 1** trace-infra `TRACE_LOCK` documented as shared; **Med 2** production style aligned with surrounding sites; Low: rusqlite upgrade signal NOTE added; Low: Issue # references removed; FFI cost-benefit & doc length accepted |
| Testing | APPROVED | **Med 1** `event_count` strict equality weakened to `>= 4`; Low: static state cleanup contract documented; Low: hard-coded SQL filter replaced with `COUNT_SQL` constant |
| Performance | APPROVED | Low: claim "11% of record_choice" was for a sub-path measurement context; absolute saving is 1.4 µs/op which is what matters for Phase 3 budget — noted here in PR body |
| Secrets | CLEAN | 0 |

No Critical, no High, no CHANGES_REQUESTED.

## Phase 3 prerequisite progress (after this merge)

- ✅ S-1 (`as i64` lossy cast) — PR #109 / `4e43927`
- ✅ S-4 (Mutex poison cascade death) — PR #111 / `e7f226d`
- ✅ A-2 (`MockLearningCacheStore`) — PR #113 / `bdde9a2`
- ✅ **P-1 (COUNT_SQL prepare_cached)** — this PR
- 🎉 All four highest-priority Phase 3 prerequisites from Issue #107 are now resolved.

Issue #107 retains 17 open Medium / Low items beyond the highest-priority subset.

## Test plan

- [x] `cargo build --workspace --all-targets --features kotoha-storage/test-helpers` clean
- [x] `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers -- -D warnings` 0 warnings
- [x] `cargo test --workspace --features kotoha-storage/test-helpers` 340 PASS / 0 FAIL
- [x] Empirical: OLD `query_row(COUNT_SQL, ...)` FAILS with 4 distinct stmt pointers; NEW PASSES with 1
- [x] No new Cargo.toml dependencies
- [x] lefthook pre-push gate green

## Refs

- #105 #106 (P2-C spec / merge — established the prepare_cached convention)
- #107 (P-1 line resolved by this PR; Phase 3 prerequisite 4/4 complete)
- #108 #109 (S-1 — the rusqlite/trace test infrastructure this PR builds on)
- #110 #111 (S-4 Mutex poison)
- #112 #113 (A-2 MockLearningCacheStore)
- #114 (this PR — closes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)