### PR TITLE
fix(romaji): add RomajiConverter::reset_pending() for Phase 3-A backspace (#118)

### DIFF
--- a/crates/kotoha-core/src/romaji/mod.rs
+++ b/crates/kotoha-core/src/romaji/mod.rs
@@ -152,6 +152,27 @@ impl RomajiConverter {
         self.machine.reset();
     }
 
+    /// pending romaji buffer を空にする。
+    ///
+    /// 例: 「sh」を typing 後 backspace で「し」を削除する場合、engine が
+    /// preedit kana から「し」を pop した後、本 method で「sh」も clear する。
+    /// 既に空なら no-op。
+    ///
+    /// 参照: spec `2026-05-02-p3-a-ibus-engine-design.md` §12.1。
+    /// engine 側は kana buffer (current_preedit) の責務、本 converter 側は
+    /// romaji buffer の責務という Single Responsibility 分離を前提とした
+    /// 同期 API(ISSUE #118)。
+    ///
+    /// 名前について: 既存 [`Self::reset`] と機能的に等価だが、engine 統合
+    /// 側で `preedit.pop()` と並ぶ「pending を reset する」semantic を明示
+    /// するために別名で公開する。後方互換のため [`Self::reset`] は残す。
+    ///
+    /// # Postconditions
+    /// - The pending buffer is empty.
+    pub fn reset_pending(&mut self) {
+        self.machine.reset();
+    }
+
     /// Normalizes the pending buffer into a stable form and returns any
     /// salvaged kana as an owned `String`.
     ///
@@ -376,6 +397,45 @@ mod tests {
         c.reset();
         // After reset, pushing 'a' commits 'あ' not 'か'.
         assert_eq!(c.push('a'), ConvertStep::Committed(Cow::Borrowed("あ")));
+    }
+
+    #[test]
+    fn reset_pending_clears_sh_buffer() {
+        // ISSUE #118 / Phase 3-A spec §12.1 acceptance case 1:
+        // 「sh」pending 中の reset_pending() で buffer が空になり、
+        // 後続 char が独立判定される(本来 "shi" で「し」になるはずが、
+        // reset 後の 'i' は単独で「い」として commit される)。
+        let mut c = RomajiConverter::new();
+        assert_eq!(c.push('s'), ConvertStep::Pending);
+        assert_eq!(c.push('h'), ConvertStep::Pending);
+        c.reset_pending();
+        assert_eq!(c.push('i'), ConvertStep::Committed(Cow::Borrowed("い")));
+    }
+
+    #[test]
+    fn reset_pending_on_empty_buffer_is_noop() {
+        // ISSUE #118 acceptance case 2: 空 buffer に対する reset_pending は
+        // no-op で、その後の通常 push が影響を受けない。
+        let mut c = RomajiConverter::new();
+        c.reset_pending();
+        c.reset_pending(); // 連続呼び出しでも無害
+        assert_eq!(c.push('a'), ConvertStep::Committed(Cow::Borrowed("あ")));
+        assert_eq!(c.flush(), "");
+    }
+
+    #[test]
+    fn reset_pending_makes_next_char_independent() {
+        // ISSUE #118 acceptance case 3: reset_pending() 後の新 char 入力は
+        // 独立判定される。「sh」pending → reset → 'a' を push したとき、
+        // 「sha」期待(=「しゃ」)ではなく単独「あ」として commit されること
+        // を確認する。
+        let mut c = RomajiConverter::new();
+        let _ = c.push('s');
+        let _ = c.push('h');
+        c.reset_pending();
+        assert_eq!(c.push('a'), ConvertStep::Committed(Cow::Borrowed("あ")));
+        // pending も残っていないこと(flush で残骸が出ない)
+        assert_eq!(c.flush(), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 3-A IBus engine integration spec(`docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md`)§12.1 prerequisite Task A の実装。`RomajiConverter::reset_pending(&mut self)` method を追加し、Phase 3-A backspace path で engine 側の `current_preedit.pop()` 後に romaji 側 pending buffer を同期 reset できるようにする。

Single Responsibility split:
- engine が kana 状態管理(`current_preedit: String`)
- RomajiConverter が romaji 状態管理(`pending` buffer = `StateMachine::buffer`)
- backspace handler は両者を呼び分ける

実装は 1-line delegate(`self.machine.reset()`)で side effect なし。既存 `reset()` method は preserve(Phase 0 API surface 安定性、新 method はエンジン統合側からの呼び出し意図を明示する alias 関係)。

## Changes

- `crates/kotoha-core/src/romaji/mod.rs`: `reset_pending()` method (lines 155-174) + 3 unit tests (lines 403-439)、+60 lines / 1 file

## Test plan

- [x] `cargo build -p kotoha-core` PASS
- [x] `cargo clippy -p kotoha-core --all-targets -- -D warnings` PASS(0 warnings)
- [x] `cargo test --workspace --features kotoha-storage/test-helpers --no-fail-fast` 343 PASS / 0 FAIL(340 baseline + 3 new、0 regression)
- [x] `lefthook run pre-push` PASS
- [x] `gitleaks git --redact` 0 findings
- [x] subagent spec compliance review: ✅ 全 acceptance criteria 達成、test theater 無し
- [x] subagent code quality review: APPROVED_WITH_NITS(Critical/Important 0、Minor 5 件)

## Acceptance criteria(from #118)

- [x] `RomajiConverter::reset_pending(&mut self)` 追加
- [x] unit test 3 ケース(「sh」pending → reset → empty / 空 buffer reset → no-op / post-reset 新 char 独立判定)
- [x] 既存 baseline 0 regression
- [x] glossary.md 追補なし(spec §12.1 既存記述で十分)

## Follow-up notes(scope-out)

Code reviewer の Minor #1:`reset()` の doc-comment に `reset_pending()` への cross-reference を追加して symmetric documentation 化する改善余地あり。本 PR scope 外として follow-up ISSUE 候補(同 PR で fix も可だが merge を急ぐため defer)。

## Pre-existing flaky test discovered

実装中、`kotoha-storage::user_vocab::sqlite::tests::insert_duplicate_returns_duplicate_entry_error` が散発的に `QuotaExceeded { table: "user_vocab", max: 1 }` で失敗(4 attempts のうち 3 attempts で再現)。Root cause:`USER_VOCAB_MAX_ROWS_TEST_OVERRIDE` の process-static `AtomicUsize` race(`CapOverrideGuard` 経由 serialize されない `effective_max_rows()` 読み取り経路)。本 PR とは無関係の pre-existing race condition、別 ISSUE 起票推奨(label: bug + flaky-test、`crates/kotoha-storage/src/user_vocab/sqlite.rs` 周辺)。

## Related

- Spec: `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` §12.1
- Phase 3-A ISSUE: #116(closed)
- Phase 0 spec: `docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md`

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)