### PR TITLE
feat(romaji): kunrei/Hepburn/waapuro 3-way trie coverage verification + completion (#119)

### DIFF
--- a/crates/kotoha-core/src/romaji/rules.rs
+++ b/crates/kotoha-core/src/romaji/rules.rs
@@ -164,6 +164,20 @@ pub(crate) const RULES: &[(&str, &str)] = &[
     ("ju", "じゅ"),
     ("je", "じぇ"),
     ("jo", "じょ"),
+    // waapuro hybrid (j + y*): supported by MS-IME / Google IME / Mozc.
+    // Bridges Hepburn-`j` and kunrei-`y` conventions for typists who mix them.
+    ("jya", "じゃ"),
+    ("jyi", "じぃ"),
+    ("jyu", "じゅ"),
+    ("jye", "じぇ"),
+    ("jyo", "じょ"),
+    // waapuro c-row yoon (alternative to t-row 拗音 chi-glide):
+    // accepted by Google IME / Mozc as a parallel form to cha/chu/cho.
+    ("cya", "ちゃ"),
+    ("cyi", "ちぃ"),
+    ("cyu", "ちゅ"),
+    ("cye", "ちぇ"),
+    ("cyo", "ちょ"),
     ("dya", "ぢゃ"),
     ("dyi", "ぢぃ"),
     ("dyu", "ぢゅ"),
@@ -184,6 +198,23 @@ pub(crate) const RULES: &[(&str, &str)] = &[
     ("fi", "ふぃ"),
     ("fe", "ふぇ"),
     ("fo", "ふぉ"),
+    // Hepburn-extended f-row yoon (loanword 拡張): フュージョン etc.
+    ("fya", "ふゃ"),
+    ("fyu", "ふゅ"),
+    ("fyo", "ふょ"),
+    // Loanword "th-" (English) → て + small-vowel: ティーチ / テューバ etc.
+    // Convention adopted by MS-IME / Google IME / Mozc.
+    ("tha", "てぁ"),
+    ("thi", "てぃ"),
+    ("thu", "てゅ"),
+    ("the", "てぇ"),
+    ("tho", "てょ"),
+    // Loanword "dh-" (English voiced) → で + small-vowel: ディスク etc.
+    ("dha", "でぁ"),
+    ("dhi", "でぃ"),
+    ("dhu", "でゅ"),
+    ("dhe", "でぇ"),
+    ("dho", "でょ"),
     ("va", "ゔぁ"),
     ("vi", "ゔぃ"),
     ("vu", "ゔ"),

--- a/crates/kotoha-core/src/romaji/rules.rs
+++ b/crates/kotoha-core/src/romaji/rules.rs
@@ -204,13 +204,13 @@ pub(crate) const RULES: &[(&str, &str)] = &[
     ("fyo", "ふょ"),
     // Loanword "th-" (English) → て + small-vowel: ティーチ / テューバ etc.
     // Convention adopted by MS-IME / Google IME / Mozc.
-    ("tha", "てぁ"),
+    ("tha", "てゃ"),
     ("thi", "てぃ"),
     ("thu", "てゅ"),
     ("the", "てぇ"),
     ("tho", "てょ"),
     // Loanword "dh-" (English voiced) → で + small-vowel: ディスク etc.
-    ("dha", "でぁ"),
+    ("dha", "でゃ"),
     ("dhi", "でぃ"),
     ("dhu", "でゅ"),
     ("dhe", "でぇ"),

--- a/crates/kotoha-core/tests/fixtures/romaji_cases.tsv
+++ b/crates/kotoha-core/tests/fixtures/romaji_cases.tsv
@@ -353,14 +353,14 @@ fyu	ふゅ
 fyo	ふょ	
 
 # --- loanword th-row (English "th-" → て + small-vowel) ---
-tha	てぁ	
+tha	てゃ	
 thi	てぃ	
 thu	てゅ	
 the	てぇ	
 tho	てょ	
 
 # --- loanword dh-row (English voiced "dh-" → で + small-vowel) ---
-dha	でぁ	
+dha	でゃ	
 dhi	でぃ	
 dhu	でゅ	
 dhe	でぇ	

--- a/crates/kotoha-core/tests/fixtures/romaji_cases.tsv
+++ b/crates/kotoha-core/tests/fixtures/romaji_cases.tsv
@@ -329,3 +329,39 @@ xwa	ゎ
 xtsu	っ	
 lwa	ゎ	
 ltsu	っ	
+
+# --- 3-way yoon waapuro hybrid (jy*: hybrid of Hepburn-j + kunrei-y) ---
+# ISSUE #119: complete kunrei / Hepburn / waapuro coverage for typists who
+# mix conventions (e.g. "ji" + "ya" → "jya"). MS-IME / Google IME / Mozc all
+# accept these.
+jya	じゃ	
+jyi	じぃ	
+jyu	じゅ	
+jye	じぇ	
+jyo	じょ	
+
+# --- 3-way yoon waapuro c-row (parallel form to cha/chu/cho) ---
+cya	ちゃ	
+cyi	ちぃ	
+cyu	ちゅ	
+cye	ちぇ	
+cyo	ちょ	
+
+# --- Hepburn-extended f-row yoon (loanword フャ/フュ/フョ) ---
+fya	ふゃ	
+fyu	ふゅ	
+fyo	ふょ	
+
+# --- loanword th-row (English "th-" → て + small-vowel) ---
+tha	てぁ	
+thi	てぃ	
+thu	てゅ	
+the	てぇ	
+tho	てょ	
+
+# --- loanword dh-row (English voiced "dh-" → で + small-vowel) ---
+dha	でぁ	
+dhi	でぃ	
+dhu	でゅ	
+dhe	でぇ	
+dho	でょ	


### PR DESCRIPTION
## Summary

Phase 3-A IBus engine integration design spec(`docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md`)§12.2 prerequisite Task B の実装。`crates/kotoha-core/src/romaji/rules.rs` の RULES table が kunrei / Hepburn / waapuro 3 方式並立で網羅されているか empirical 確認し、不足分を追加した。

## 3-way coverage analysis result

**Pre-existing(既に網羅済)**:
- 母音 5 + 基本 gojuon CV 45(両 kunrei `si/ti/tu/hu/zi` + Hepburn `shi/chi/tsu/fu/ji` 並立済)
- 拗音 s/t/z 3-way 完備(`sya/syu/syo` + `sha/shu/sho`、`tya/tyu/tyo` + `cha/chu/cho`、`zya/zyu/zyo` + `ja/ju/jo`)
- 促音 / 撥音 は state machine が consonant class で扱うため RULES entry 不要

**Newly added(23 entries)**:
- waapuro hybrid j-row yoon(`jya/jyi/jyu/jye/jyo`、5 件)
- waapuro c-row yoon(`cya/cyi/cyu/cye/cyo`、5 件)
- Hepburn-extended f-row yoon(`fya/fyu/fyo`、3 件)
- loanword th-row(`tha/thi/thu/the/tho`、5 件)
- loanword dh-row(`dha/dhi/dhu/dhe/dho`、5 件)

## Changes

- `crates/kotoha-core/src/romaji/rules.rs`: +23 entries(23 + 2 修正、+31 行 / -2 行)
- `crates/kotoha-core/tests/fixtures/romaji_cases.tsv`: 同 23 entries の golden fixture 行追加 + trailing tab 正規化
- 2 commits(squash merge で 1 commit に統合)

## Ambiguous cases identified — NOT adopted, ADR follow-up 推奨

acceptance criteria #5 に従い、曖昧 cases は本 PR scope 外:

| key | option | issue |
|-----|--------|-------|
| 「ぢ」 | `di`(kunrei、現採用) vs `ji`(Hepburn) | Hepburn は「じ」と collide、現状 `di` を維持 |
| 「づ」 | `du`(kunrei、現採用) vs `zu`(Hepburn) | Hepburn は「ず」と collide、現状 `du` を維持 |
| 「を」 | `wo`(現採用) vs `o`(Hepburn) | Hepburn は「お」と collide、`wo` 一択 |
| `wu` | Mozc / Google IME は「う」、MS-IME は無 | major IME 間で慣行差、現状未採用 |

→ 別 ISSUE 起票推奨:`ADR: ambiguous romaji mappings for ぢ / づ / を / wu`

## Code review iteration history

1. Initial commit `24e7137`: 23 entries 追加、ただし `tha → てぁ` / `dha → でぁ`(small ぁ)が誤り
2. Spec compliance reviewer(subagent)が Critical Issue として検出:Mozc 公式は `tha → てゃ` / `dha → でゃ`(small ゃ)
3. Fix commit `a184cbf`: tha/dha を Mozc 慣行に整合(small-ya 系、thi/thu/the/tho との対称性も確保)
4. Verification: 343 PASS / 0 FAIL maintained、lefthook pre-push 6/6 PASS、Mozc source URL を commit body に reference

## Test plan

- [x] `cargo build -p kotoha-core` PASS
- [x] `cargo clippy -p kotoha-core --all-targets -- -D warnings` PASS
- [x] `cargo test --workspace --features kotoha-storage/test-helpers --no-fail-fast` 343 PASS / 0 FAIL(0 regression)
- [x] `lefthook run pre-push` PASS
- [x] `gitleaks git --redact` 0 findings
- [x] subagent spec compliance review: Critical 1 件検出 → fix 適用 → 再 verification PASS

## Acceptance criteria(from #119)

- [x] 3 方式網羅状況の現状分析を文書化(本 PR body 参照、commit body 含む)
- [x] 不足 entry 追加(23 件)
- [x] golden fixture 拡張(23 行追加 + trailing tab 正規化)
- [x] 既存 baseline 0 regression
- [x] 曖昧 cases は採用せず、ADR / ISSUE 候補として明記

## Follow-up notes(scope-out)

1. `crates/kotoha-core/src/romaji/state.rs:33` の docstring 内 "207-entry rule table" は historical performance rationale note としてそのまま、現 rule 数(232)への literal 更新は scope-out(reviewer Important #3 確認済、historical note の正確性は保たれる)
2. ADR 起票候補:`ぢ / づ / を / wu` collision 設計判断の formalization

## Related

- Spec: `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` §12.2
- ADR 0005: `docs/adr/0005-romaji-trie-over-hashmap.md`
- Mozc reference: https://raw.githubusercontent.com/google/mozc/master/src/data/preedit/romanji-hiragana.tsv

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)