### PR TITLE
feat(engine-core): kotoha-engine-core crate with Ranker trait + cancel token (P2-D M1, #120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kotoha-engine-core"
+version = "0.1.0"
+dependencies = [
+ "kotoha-core",
+ "kotoha-storage",
+ "proptest",
+ "serial_test",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "kotoha-storage"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,11 +578,7 @@ name = "kotoha-engine-core"
 version = "0.1.0"
 dependencies = [
  "kotoha-core",
- "kotoha-storage",
- "proptest",
- "serial_test",
  "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/kotoha-core",
     "crates/kotoha-cli",
     "crates/kotoha-storage",
+    "crates/kotoha-engine-core",
 ]
 
 [workspace.package]

--- a/crates/kotoha-engine-core/Cargo.toml
+++ b/crates/kotoha-engine-core/Cargo.toml
@@ -9,16 +9,13 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+# M1 では trait + types 定義のみ。`kotoha-core`(Candidate type 参照)+ `thiserror`
+# (RankerError derive)のみを使う。`tracing` / `kotoha-storage` / `proptest` /
+# `serial_test` は M2 以降で実需が surface した PR で追加する(YAGNI)。
 thiserror = { workspace = true }
-tracing = { workspace = true }
 kotoha-core = { path = "../kotoha-core" }
-kotoha-storage = { path = "../kotoha-storage" }
-
-[dev-dependencies]
-proptest = { workspace = true }
-serial_test = { workspace = true }
 
 [features]
 default = []
-# Mock backends / fixtures for cross-crate test injection.
+# Mock backends / fixtures for cross-crate test injection. M2 以降で需要 surface。
 test-helpers = []

--- a/crates/kotoha-engine-core/Cargo.toml
+++ b/crates/kotoha-engine-core/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "kotoha-engine-core"
+description = "Kotoha IME engine domain core (host-agnostic, Phase 3-A spec §3.1)"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+tracing = { workspace = true }
+kotoha-core = { path = "../kotoha-core" }
+kotoha-storage = { path = "../kotoha-storage" }
+
+[dev-dependencies]
+proptest = { workspace = true }
+serial_test = { workspace = true }
+
+[features]
+default = []
+# Mock backends / fixtures for cross-crate test injection.
+test-helpers = []

--- a/crates/kotoha-engine-core/src/cancel/mod.rs
+++ b/crates/kotoha-engine-core/src/cancel/mod.rs
@@ -1,0 +1,32 @@
+//! Cancellation token abstraction for in-flight `RankRequest` propagation.
+//!
+//! Phase 3-A spec §4.4 で凍結された自作 trait。tokio_util::sync::CancellationToken と
+//! 同形式の interface だが、tokio runtime に直接依存しない。Phase 3-A 初期は
+//! [`StdCancellationToken`](std_token::StdCancellationToken) を std::sync ベース impl
+//! として同梱、Phase 5/6 で tokio runtime を導入する場合は別 crate で
+//! `TokioCancellationToken` adapter を実装し差し替え可能とする。
+
+use std::future::Future;
+use std::pin::Pin;
+
+mod std_token;
+pub use std_token::StdCancellationToken;
+
+/// In-flight `RankRequest` の cancel signal を伝搬する抽象境界。
+///
+/// # Implementor 要件
+///
+/// - `cancel()` は idempotent(複数回呼ばれても 2 回目以降は no-op で副作用なし)
+/// - `is_cancelled()` は `cancel()` 呼び出し後 `true` を永続的に返す
+/// - `cancelled()` は `cancel()` 呼び出し後即時 ready な future を返す
+/// - `Send + Sync` を要求(複数 thread から `is_cancelled()` を listen される)
+pub trait CancellationToken: Send + Sync {
+    /// Cancel 状態に遷移させる。
+    fn cancel(&self);
+
+    /// 現在の cancel 状態を返す。
+    fn is_cancelled(&self) -> bool;
+
+    /// Cancel 待機 future を返す。`cancel()` 後即時 ready。
+    fn cancelled<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+}

--- a/crates/kotoha-engine-core/src/cancel/std_token.rs
+++ b/crates/kotoha-engine-core/src/cancel/std_token.rs
@@ -1,0 +1,150 @@
+//! `StdCancellationToken` — std::sync ベースの `CancellationToken` impl。
+//!
+//! Phase 3-A spec §4.4 で凍結された自作 trait の Phase 3-A 初期 impl。
+//! `Arc<AtomicBool>` + `(Mutex, Condvar)` ペアで cancel signal の永続化と
+//! future 待機を実装する。`Mutex` poison は kotoha-storage で確立した規約
+//! (PR #111、`unwrap_or_else(PoisonError::into_inner)`)を流用する。
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::task::{Context, Poll, Waker};
+
+use super::CancellationToken;
+
+/// std::sync ベースの cancel token impl。`Arc` で clone 可能、複数 thread から共有できる。
+#[derive(Clone)]
+pub struct StdCancellationToken {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    flag: AtomicBool,
+    notify: Mutex<Vec<Waker>>,
+    condvar: Condvar,
+}
+
+impl StdCancellationToken {
+    /// 新しい未 cancel な token を作成する。
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                flag: AtomicBool::new(false),
+                notify: Mutex::new(Vec::new()),
+                condvar: Condvar::new(),
+            }),
+        }
+    }
+}
+
+impl Default for StdCancellationToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CancellationToken for StdCancellationToken {
+    fn cancel(&self) {
+        self.inner.flag.store(true, Ordering::SeqCst);
+        // Future 経由で待機している waker を起こす
+        let mut wakers = self
+            .inner
+            .notify
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        for waker in wakers.drain(..) {
+            waker.wake();
+        }
+        // sync 経由(`Condvar::wait`)で待機しているスレッドを起こす
+        self.inner.condvar.notify_all();
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.inner.flag.load(Ordering::SeqCst)
+    }
+
+    fn cancelled<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(CancelledFuture {
+            inner: self.inner.clone(),
+        })
+    }
+}
+
+struct CancelledFuture {
+    inner: Arc<Inner>,
+}
+
+impl Future for CancelledFuture {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.inner.flag.load(Ordering::SeqCst) {
+            return Poll::Ready(());
+        }
+        let mut wakers = self
+            .inner
+            .notify
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        // double-check after taking the lock to avoid lost-wakeup
+        if self.inner.flag.load(Ordering::SeqCst) {
+            return Poll::Ready(());
+        }
+        wakers.push(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    /// spec §4.4 不変条件: cancel() 前は is_cancelled() == false
+    #[test]
+    fn fresh_token_is_not_cancelled() {
+        let t = StdCancellationToken::new();
+        assert!(!t.is_cancelled());
+    }
+
+    /// spec §4.4 不変条件: cancel() 後は is_cancelled() == true (永続)
+    #[test]
+    fn cancel_persists() {
+        let t = StdCancellationToken::new();
+        t.cancel();
+        assert!(t.is_cancelled());
+        assert!(t.is_cancelled()); // 2 回目も true
+    }
+
+    /// spec §4.4 不変条件: cancel() は idempotent
+    #[test]
+    fn cancel_is_idempotent() {
+        let t = StdCancellationToken::new();
+        t.cancel();
+        t.cancel(); // 2 回目以降 no-op
+        assert!(t.is_cancelled());
+    }
+
+    /// 複数 thread から共有された clone は同一 cancel state を共有する
+    #[test]
+    fn clones_share_state() {
+        let t1 = StdCancellationToken::new();
+        let t2 = t1.clone();
+        let handle = thread::spawn(move || {
+            // 100ms 待ってから cancel(t1 thread が wait できる時間)
+            thread::sleep(Duration::from_millis(100));
+            t2.cancel();
+        });
+        // t1 で cancel を観測できる
+        let start = std::time::Instant::now();
+        while !t1.is_cancelled() {
+            if start.elapsed() > Duration::from_secs(1) {
+                panic!("cancel propagation timeout");
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        handle.join().unwrap();
+    }
+}

--- a/crates/kotoha-engine-core/src/cancel/std_token.rs
+++ b/crates/kotoha-engine-core/src/cancel/std_token.rs
@@ -1,14 +1,18 @@
 //! `StdCancellationToken` — std::sync ベースの `CancellationToken` impl。
 //!
 //! Phase 3-A spec §4.4 で凍結された自作 trait の Phase 3-A 初期 impl。
-//! `Arc<AtomicBool>` + `(Mutex, Condvar)` ペアで cancel signal の永続化と
+//! `Arc<AtomicBool>` + `Mutex<Vec<Waker>>` で cancel signal の永続化と async
 //! future 待機を実装する。`Mutex` poison は kotoha-storage で確立した規約
 //! (PR #111、`unwrap_or_else(PoisonError::into_inner)`)を流用する。
+//!
+//! 同期 thread block-wait は現状 trait に含まれない(`cancelled() -> Future` のみ)
+//! ため `Condvar` は配置しない。将来 sync wait API を追加する場合に Condvar 復活と
+//! `wait_blocking()` method を同時導入する。
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::task::{Context, Poll, Waker};
 
 use super::CancellationToken;
@@ -22,7 +26,6 @@ pub struct StdCancellationToken {
 struct Inner {
     flag: AtomicBool,
     notify: Mutex<Vec<Waker>>,
-    condvar: Condvar,
 }
 
 impl StdCancellationToken {
@@ -32,7 +35,6 @@ impl StdCancellationToken {
             inner: Arc::new(Inner {
                 flag: AtomicBool::new(false),
                 notify: Mutex::new(Vec::new()),
-                condvar: Condvar::new(),
             }),
         }
     }
@@ -56,8 +58,6 @@ impl CancellationToken for StdCancellationToken {
         for waker in wakers.drain(..) {
             waker.wake();
         }
-        // sync 経由(`Condvar::wait`)で待機しているスレッドを起こす
-        self.inner.condvar.notify_all();
     }
 
     fn is_cancelled(&self) -> bool {

--- a/crates/kotoha-engine-core/src/lib.rs
+++ b/crates/kotoha-engine-core/src/lib.rs
@@ -1,0 +1,26 @@
+//! `kotoha-engine-core`: Kotoha IME engine domain core (host-agnostic).
+//!
+//! 本 crate は Phase 3-A spec §3.1 で凍結された engine domain core layer に対応する。
+//! IBus / fcitx5 / 将来の input-method protocol を含む host adapter から
+//! 直接依存される一方、本 crate は host 層の identifier(`ibus` / `zbus` /
+//! `fcitx5` 等)に依存しない。Hexagonal Architecture の core 配置である。
+//!
+//! 本 crate の主要 trait / types:
+//!
+//! - [`ranker::Ranker`] — 候補生成 trait(P2-D で `HybridRanker` として impl)
+//! - [`ranker::ConversionContext`] / [`ranker::ConversionMode`] — Ranker 入力 context
+//! - [`ranker::CandidateUpdate`] — 候補差分通知 enum
+//! - [`cancel::CancellationToken`] — cancel signal trait
+//! - [`cancel::StdCancellationToken`] — std::sync ベース impl
+//!
+//! 本 crate は Phase 3-A engine 本体(`KotohaEngine` 状態機械、`IMEEngine` /
+//! `IMEHostBridge` trait、`RankerWorker`)を含まない。それらは Phase 3-A 本番
+//! 実装段階で本 crate に追加される。
+
+pub mod cancel;
+pub mod ranker;
+
+pub use cancel::{CancellationToken, StdCancellationToken};
+pub use ranker::{
+    CandidateUpdate, ConversionContext, ConversionMode, Ranker, RankerError, RankerOutput,
+};

--- a/crates/kotoha-engine-core/src/ranker/context.rs
+++ b/crates/kotoha-engine-core/src/ranker/context.rs
@@ -1,0 +1,77 @@
+//! `ConversionContext` / `ConversionMode` — Ranker 入力 context types.
+//!
+//! Phase 3-A spec §4.3(2026-05-02、ISSUE #116)で凍結。Phase 5 で
+//! `partial_input` / `typo_distance` field が non-breaking で追加される予定。
+
+use std::time::Duration;
+
+/// Ranker `rank()` の context 引数。focus session 内 commit 履歴と変換 mode を含む。
+///
+/// `commit_history` は engine 内部の `VecDeque<String>` の snapshot を `Vec<String>`
+/// として clone して詰める設計(Phase 3-A spec §4.3 備考参照)。本 struct は
+/// non-exhaustive で Phase 5 field 追加時の互換性を担保する。
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct ConversionContext {
+    /// focus session 内の直前 N 文字(default 200、Phase 3-A spec §13 Open Q 1)の
+    /// commit 履歴 surface(古い順)。
+    pub commit_history: Vec<String>,
+    /// 直前 commit からの経過時間(personalization signal、Phase 5 で活用)。
+    pub time_since_last_commit: Duration,
+    /// 変換 mode:Live(typing 中)か Commit(space 後)か。
+    pub mode: ConversionMode,
+}
+
+impl ConversionContext {
+    /// 空 context を作成する(test / focus_in 直後の初期状態用)。
+    pub fn empty(mode: ConversionMode) -> Self {
+        Self {
+            commit_history: Vec::new(),
+            time_since_last_commit: Duration::from_secs(0),
+            mode,
+        }
+    }
+}
+
+/// 変換 mode。Live(typing 中、毎 keystroke で Ranker 起動)と
+/// Commit(space 後、coalescing 拡張で LLM 待機)の 2 種。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionMode {
+    /// Typing 中、dict only fast path、LLM は best-effort。
+    Live,
+    /// Space 確定後、coalescing window 拡張、LLM 完了まで待機。
+    Commit,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// spec §4.3: ConversionContext::empty(Live) で Live mode の空 context が作れる
+    #[test]
+    fn empty_context_live_mode() {
+        let ctx = ConversionContext::empty(ConversionMode::Live);
+        assert_eq!(ctx.mode, ConversionMode::Live);
+        assert!(ctx.commit_history.is_empty());
+        assert_eq!(ctx.time_since_last_commit, Duration::from_secs(0));
+    }
+
+    /// spec §4.3: ConversionMode は Live と Commit の 2 種
+    #[test]
+    fn conversion_modes_are_distinct() {
+        assert_ne!(ConversionMode::Live, ConversionMode::Commit);
+    }
+
+    /// spec §4.3 備考: ConversionContext は Clone 可能(snapshot として Ranker に渡される)
+    #[test]
+    fn context_is_clone() {
+        let ctx = ConversionContext {
+            commit_history: vec!["琴葉".into()],
+            time_since_last_commit: Duration::from_secs(5),
+            mode: ConversionMode::Commit,
+        };
+        let cloned = ctx.clone();
+        assert_eq!(cloned.commit_history, ctx.commit_history);
+        assert_eq!(cloned.mode, ctx.mode);
+    }
+}

--- a/crates/kotoha-engine-core/src/ranker/mod.rs
+++ b/crates/kotoha-engine-core/src/ranker/mod.rs
@@ -1,0 +1,70 @@
+//! `Ranker` trait + `RankerError` + `RankerOutput`.
+//!
+//! Phase 3-A spec §4.3 で凍結された候補生成 trait。P2-D で `HybridRanker` として
+//! 実装される。本 module は trait + types のみで、impl は `hybrid` sub-module
+//! (P2-D Milestone 2 以降で追加される)。
+
+mod context;
+mod update;
+
+pub use context::{ConversionContext, ConversionMode};
+pub use update::CandidateUpdate;
+
+use std::sync::mpsc;
+use std::sync::Arc;
+
+use crate::cancel::CancellationToken;
+
+/// Ranker は `kana` 入力に対して候補一覧を生成し、`sink` channel 経由で
+/// engine に逐次 push する。Phase 3-A spec §4.3 で凍結された contract。
+///
+/// # 動作モデル
+///
+/// - `rank()` は **同期に return**(channel 送信のみ)、heavy lifting は背後
+///   thread / async runtime に dispatch される(impl 内部の自由)。
+/// - `cancel.is_cancelled() == true` を検出したら以降の `sink.send()` を停止する。
+/// - backend 個別の cancel propagation:
+///   - SudachiDict / UserVocab / LearningCache: μs オーダーで完結のため cancel
+///     check は不要(完了時に request_id mismatch なら engine 側で discard)。
+///   - LLM: 10 token 毎に `cancel.is_cancelled()` を check、true なら inference 中断。
+///
+/// # Thread safety
+///
+/// `Send + Sync` を要求(engine の `RankerWorker` thread と engine 主 thread の
+/// 双方から `Arc<dyn Ranker>` で参照される)。
+pub trait Ranker: Send + Sync {
+    /// 候補生成の起動。同期 return、heavy work は impl 内 thread に dispatch。
+    ///
+    /// # Errors
+    ///
+    /// - [`RankerError::Busy`]: 直前の rank 呼び出しが完了前で受け付け不可
+    /// - [`RankerError::Internal`]: impl 内部の不可避エラー
+    fn rank(
+        &self,
+        kana: &str,
+        ctx: &ConversionContext,
+        cancel: Arc<dyn CancellationToken>,
+        sink: mpsc::Sender<RankerOutput>,
+    ) -> Result<(), RankerError>;
+}
+
+/// Ranker から engine への通知 message。
+#[derive(Debug, Clone)]
+pub struct RankerOutput {
+    /// engine 主 thread 側で active_request.id と mismatch なら discard する識別子。
+    /// engine が `RankRequest` 発行時に採番した値を Ranker 内部で保持し送出する
+    /// (Phase 3-A spec §7.5)。
+    pub request_id: u64,
+    /// 差分通知本体。
+    pub update: CandidateUpdate,
+}
+
+/// Ranker error 列挙。
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum RankerError {
+    #[error("ranker is busy")]
+    Busy,
+    #[error("ranker internal error: {0}")]
+    Internal(String),
+}

--- a/crates/kotoha-engine-core/src/ranker/update.rs
+++ b/crates/kotoha-engine-core/src/ranker/update.rs
@@ -1,0 +1,68 @@
+//! `CandidateUpdate` enum — 候補差分通知。
+//!
+//! Phase 3-A spec §4.2(2026-05-02、ISSUE #116)で凍結。
+//! Worker thread から engine 主 thread へ、または engine から host adapter へ
+//! 送られる差分通知 message。
+
+use kotoha_core::Candidate;
+use std::ops::Range;
+
+/// 候補 list の差分通知。
+///
+/// IBus 1.x は `update_lookup_table` で全置換のみのため、IBus adapter は
+/// `Append` / `Remove` を内部 buffer 蓄積後の `Replace` に変換する
+/// (Phase 3-A spec §4.2 mapping 表)。
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum CandidateUpdate {
+    /// 候補 list 全置換(Phase 3-A での主用法)。
+    Replace(Vec<Candidate>),
+    /// 末尾追加(coalescing 後の LLM 結果到着時)。
+    Append(Vec<Candidate>),
+    /// 範囲削除(Phase 5 beam search で beam 削減時、Phase 3-A 初期は未使用)。
+    Remove(Range<usize>),
+    /// 全 clear。
+    Clear,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kotoha_core::Candidate;
+
+    /// spec §4.2: Replace variant が Vec<Candidate> を保持できる
+    #[test]
+    fn replace_holds_candidates() {
+        let upd = CandidateUpdate::Replace(vec![Candidate::new("琴葉", -1.5)]);
+        match upd {
+            CandidateUpdate::Replace(v) => {
+                assert_eq!(v.len(), 1);
+                assert_eq!(v[0].surface, "琴葉");
+            }
+            _ => panic!("expected Replace"),
+        }
+    }
+
+    /// spec §4.2: Clear variant が引数なしで構築できる
+    #[test]
+    fn clear_is_unit_variant() {
+        let upd = CandidateUpdate::Clear;
+        match upd {
+            CandidateUpdate::Clear => {}
+            _ => panic!("expected Clear"),
+        }
+    }
+
+    /// spec §4.2: CandidateUpdate は Clone 可能(adapter 内部 buffer 等で複製される)
+    #[test]
+    fn update_is_clone() {
+        let upd = CandidateUpdate::Replace(vec![Candidate::new("琴葉", -1.5)]);
+        let cloned = upd.clone();
+        match (upd, cloned) {
+            (CandidateUpdate::Replace(a), CandidateUpdate::Replace(b)) => {
+                assert_eq!(a[0].surface, b[0].surface);
+            }
+            _ => panic!("expected Replace"),
+        }
+    }
+}

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -365,6 +365,13 @@
 - **対応する identifier**: `kotoha_engine_core::ConversionContext`
 - **備考**: KotohaEngine 内部 state の `commit_history: VecDeque<String>` の snapshot を `Vec<String>` として clone して context に詰める設計(VecDeque は engine 内 pop_front 効率性、Vec は context 不変性と clone の単純さ)。
 
+### StdCancellationToken (std::sync ベース cancel token impl)
+
+- **定義**: Phase 3-A spec §4.4 で凍結された `CancellationToken` trait の Phase 3-A 初期 impl。`Arc<AtomicBool>` + `Mutex<Vec<Waker>>` で cancel signal の永続化と async future 待機を実装する。`Mutex` poison は `unwrap_or_else(PoisonError::into_inner)` で recover する(PR #111 規約と整合)。
+- **初出**: P2-D Milestone 1(2026-05-02、ISSUE #120 / branch `feature/120-p2d-trait-skeleton`)
+- **対応する identifier**: `kotoha_engine_core::cancel::StdCancellationToken`(`crates/kotoha-engine-core/src/cancel/std_token.rs`)
+- **備考**: tokio runtime 導入は Phase 5 / 6 で再評価。それまで Phase 3-A は std::sync ベースで運用。同期 thread block-wait API は現状未提供、将来追加時に Condvar 復活と `wait_blocking()` method を同時導入する。
+
 ## 5. LLM 推論とプロンプト
 
 ### PromptTemplate


### PR DESCRIPTION
## Summary

P2-D Hybrid Ranker(ISSUE #120)Milestone 1 — `kotoha-engine-core` 新 crate の skeleton + trait/types 定義のみ。`HybridRanker` concrete impl は M2 以降の独立 PR で追加する。

Phase 3-A spec § 3.1 / §4.2 / §4.3 / §4.4 で凍結された contract を本 PR で凍結:
- `Ranker` trait(`Send + Sync`、`rank(kana, ctx, cancel, sink)`)
- `CancellationToken` trait + `StdCancellationToken` std::sync impl
- `ConversionContext` + `ConversionMode`
- `CandidateUpdate` enum(4 variants、forward-compat `#[non_exhaustive]`)
- `RankerError` + `RankerOutput`

## Changes

| file | role | LOC |
|------|------|-----|
| `Cargo.toml`(workspace root) | members に新 crate 追加 | +1 |
| `Cargo.lock` | 新 package entry | +8 |
| `crates/kotoha-engine-core/Cargo.toml` | crate manifest(M1 では `thiserror` + `kotoha-core` のみ依存、他は実需 PR で追加)| +21 |
| `crates/kotoha-engine-core/src/lib.rs` | crate root + re-export | +26 |
| `crates/kotoha-engine-core/src/cancel/mod.rs` | `CancellationToken` trait | +32 |
| `crates/kotoha-engine-core/src/cancel/std_token.rs` | `StdCancellationToken`(`Arc<AtomicBool>` + `Mutex<Vec<Waker>>`)| +145 |
| `crates/kotoha-engine-core/src/ranker/mod.rs` | `Ranker` trait + `RankerError` + `RankerOutput` | +70 |
| `crates/kotoha-engine-core/src/ranker/context.rs` | `ConversionContext` + `ConversionMode` | +77 |
| `crates/kotoha-engine-core/src/ranker/update.rs` | `CandidateUpdate` enum | +68 |
| `docs/wiki/glossary.md` | StdCancellationToken entry 追加 | +7 |

3 commits(squash merge で 1 commit に統合):
- `daa9374` initial implementation
- `b03bde6` review fix(unused deps + dead Condvar 削除、Important I-1〜I-4)
- `c1af2dc` glossary entry

## Test plan

- [x] `cargo build -p kotoha-engine-core` PASS
- [x] `cargo clippy -p kotoha-engine-core --all-targets -- -D warnings` PASS
- [x] `cargo test --workspace --features kotoha-storage/test-helpers --no-fail-fast` 353 PASS / 0 FAIL(343 baseline + 10 new = 353、0 regression)
- [x] `lefthook run pre-push` 6/6 PASS
- [x] `gitleaks git --redact` 0 findings
- [x] subagent spec compliance review: ✅ 全 trait API contract spec §4.2/§4.3/§4.4 と一致、out-of-scope items 不在
- [x] subagent code quality review: APPROVED_WITH_NITS、Critical/Important fix 適用済(I-1〜I-4)

## Architectural decisions reflected

| spec § | content | impl location |
|--------|---------|---------------|
| §3.1 | Hexagonal core layer、host 非依存 | `lib.rs` doc-comment + dep declaration(`ibus`/`zbus`/`tokio` 不参照)|
| §4.4 | 自作 `CancellationToken` trait、std::sync impl 同梱、tokio 差し替え可能 | `cancel/mod.rs` + `std_token.rs` |
| §4.3 | `Ranker::rank(kana, ctx, cancel, sink)` 同期 return、heavy work は impl 内 thread に dispatch | `ranker/mod.rs` |
| §4.3 | `ConversionContext` `#[non_exhaustive]`、Phase 5 で `partial_input` field 追加予定 | `ranker/context.rs` |
| §4.2 | `CandidateUpdate` 4 variants、IBus adapter で全置換変換 | `ranker/update.rs` |

## Out of scope(M2 以降で扱う)

- `IMEEngine` / `IMEHostBridge` trait(Phase 3-A 本番)
- `KotohaEngine` 状態機械 / `RankerWorker`(同上)
- `HybridRanker` concrete impl(M2)
- LLM backend integration(M3)
- proptest invariants(M4)
- Phase 1 14/15 regression test through Ranker(M3)

## Follow-up notes(scope-out from M1 review)

1. **Doc-comment language policy**(reviewer Important I-5):workspace 内 rustdoc 言語が mixed(kotoha-core English / kotoha-storage 日本語)。Project-level policy 統一は別 ISSUE 起票推奨
2. **Memory ordering**(reviewer M-2):`SeqCst` を `Acquire`/`Release` に最適化する余地あり、Phase 5 perf-tuning で再評価
3. **`cancelled()` future direct test coverage**(reviewer M-6):current tests are `is_cancelled()`-based、futures 直接 poll する test を M2/M3 で追加推奨
4. **`#[non_exhaustive]` on `ConversionMode`**(reviewer M-non-exhaustive):3 つ目の mode 追加可能性を見越して付与検討、M2 / M3 でアプリケーション

## Related

- Issue: #120
- Plan: `docs/superpowers/plans/2026-05-02-feature-120-p2d-hybrid-ranker.md` § Milestone 1
- Phase 3-A spec: `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` §3.1 / §4.2 / §4.3 / §4.4
- ADR 0011: kanji backend trait design(related pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)