### PR TITLE
feat(engine-core): HybridRanker LLM backend integration + Phase 1 regression scaffolding (P2-D M3, #120)

### DIFF
--- a/crates/kotoha-engine-core/Cargo.toml
+++ b/crates/kotoha-engine-core/Cargo.toml
@@ -31,3 +31,14 @@ kotoha-storage = { path = "../kotoha-storage" }
 default = []
 # Mock backends / fixtures for cross-crate test injection. M2 以降で需要 surface。
 test-helpers = []
+# `mock-backend` は kotoha-core::kanji::MockBackend を pull する pass-through。
+# M3 で `tests/hybrid_ranker_llm.rs` が `Arc<dyn KanjiBackend + Send + Sync>`
+# 経由で MockBackend を `with_llm()` builder に注入するため必要。
+mock-backend = ["kotoha-core/mock-backend"]
+# `llama-cpp` は kotoha-core::kanji::llama_cpp::LlamaCppBackend を pull する
+# pass-through。lefthook pre-push の default features では feature off のため、
+# llama.cpp C++ build は走らない。
+llama-cpp = ["kotoha-core/llama-cpp"]
+# `llama-cpp-smoke` は Layer 3 live-inference smoke test の opt-in gate。
+# `regression_phase1.rs` の `mod smoke` は本 feature 有効時のみ compile される。
+llama-cpp-smoke = ["kotoha-core/llama-cpp-smoke"]

--- a/crates/kotoha-engine-core/src/ranker/hybrid.rs
+++ b/crates/kotoha-engine-core/src/ranker/hybrid.rs
@@ -105,13 +105,16 @@ impl HybridRanker {
 
 impl Ranker for HybridRanker {
     /// 並列 backend 呼び出しは `std::thread::spawn` で行い、`rank()` は同期 return する
-    /// (Phase 3-A spec §4.3 contract)。`cancel.is_cancelled()` を以下の **4 phase** で
-    /// 観測し、true ならば以降の sink push を停止する:
+    /// (Phase 3-A spec §4.3 contract)。`cancel.is_cancelled()` を以下の **5 観測点** で
+    /// check し、true ならば以降の sink push を停止する。spec §4.3 で要求される 4 phase
+    /// (entry / dict 完了後 / LLM 前 / LLM 後)に加え、M2 既存の dict-stage send 直前
+    /// guard を保持しているため計 5 観測点となる:
     ///
-    /// 1. entry — thread 起動直後
-    /// 2. dict backends 完了直後
-    /// 3. LLM convert 呼び出し直前
-    /// 4. LLM convert 完了直後
+    /// 1. **entry** — thread 起動直後(spec phase 1)
+    /// 2. **dict 完了後** — SudachiDict / UserVocab / LearningCache の並列実行完了直後(spec phase 2)
+    /// 3. **dict-stage send 直前**(M2 互換 guard、redundant だが 1 段目 send の最終 gate)
+    /// 4. **LLM 前** — `KanjiBackend::convert` 呼び出し直前(spec phase 3)
+    /// 5. **LLM 後** — `convert()` 完了直後の send 前 gate(spec phase 4)
     ///
     /// SudachiDict / UserVocab / LearningCache は μs オーダーで完結するため backend
     /// 個別の token 確認は行わない(spec §4.3 動作モデル)。LLM convert の token-level

--- a/crates/kotoha-engine-core/src/ranker/hybrid.rs
+++ b/crates/kotoha-engine-core/src/ranker/hybrid.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 use std::thread;
 
 use kotoha_core::dict::MorphologicalEngine;
-use kotoha_core::Candidate;
+use kotoha_core::kanji::KanjiBackend;
+use kotoha_core::{Candidate, ConvertOptions};
 use kotoha_storage::learning_cache::LearningCacheReader;
 use kotoha_storage::user_vocab::UserVocabReader;
 
@@ -39,11 +40,21 @@ pub struct HybridRanker {
     sudachi: Arc<dyn MorphologicalEngine + Send + Sync>,
     user_vocab: Arc<dyn UserVocabReader>,
     learning_cache: Arc<dyn LearningCacheReader>,
+    /// LLM backend(Phase 1 Gemma-2-2B-jpn-it / MockBackend / 将来 backend)。
+    /// `None` なら dict-only 動作(M2 path、lefthook pre-push 既定)。
+    /// `Some(_)` を builder [`Self::with_llm`] で設定すると、`rank()` 内で
+    /// dict 結果 push 後に LLM convert を呼び、結果 merge 後の 2 段 push が走る。
+    ///
+    /// `Send + Sync` を要求するのは `rank()` 内の `thread::spawn` で
+    /// closure に move する必要があるため(`KanjiBackend` trait 自体は
+    /// `Send + Sync` 不要、Phase 1 単 thread CLI 由来の歴史的設計、
+    /// kotoha-core spec §5.3)。
+    llm: Option<Arc<dyn KanjiBackend + Send + Sync>>,
     request_id_seed: AtomicU64,
 }
 
 impl HybridRanker {
-    /// `HybridRanker` を構築する。
+    /// `HybridRanker` を構築する(dict-only 構成)。
     ///
     /// # Preconditions
     ///
@@ -51,6 +62,11 @@ impl HybridRanker {
     ///   test は in-tree stub)
     /// - `user_vocab` / `learning_cache` は production / test 双方の実装が
     ///   `kotoha-storage` 側で提供される(`Sqlite*Store` / `Mock*Store`)
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は LLM backend を持たない(`llm = None`)。LLM を有効化するには
+    ///   [`Self::with_llm`] を chain する。
     pub fn new(
         sudachi: Arc<dyn MorphologicalEngine + Send + Sync>,
         user_vocab: Arc<dyn UserVocabReader>,
@@ -60,8 +76,26 @@ impl HybridRanker {
             sudachi,
             user_vocab,
             learning_cache,
+            llm: None,
             request_id_seed: AtomicU64::new(0),
         }
+    }
+
+    /// LLM backend を設定する builder method(consume self / return Self)。
+    ///
+    /// # Preconditions
+    ///
+    /// - `llm` は `KanjiBackend + Send + Sync` を満たす(`thread::spawn` 越しに
+    ///   move されるため)。`MockBackend` / `LlamaCppBackend` は両者を満たす。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値の `rank()` は dict 結果 push 後に LLM convert を呼ぶ 2 段 push 動作に切り替わる。
+    /// - LLM 失敗(`Err`)は `tracing::warn!` を残し、第 2 段 push は走らない
+    ///   (dict-only fallback、Phase 3-A spec §10.4 graceful degradation)。
+    pub fn with_llm(mut self, llm: Arc<dyn KanjiBackend + Send + Sync>) -> Self {
+        self.llm = Some(llm);
+        self
     }
 
     fn next_request_id(&self) -> u64 {
@@ -71,10 +105,33 @@ impl HybridRanker {
 
 impl Ranker for HybridRanker {
     /// 並列 backend 呼び出しは `std::thread::spawn` で行い、`rank()` は同期 return する
-    /// (Phase 3-A spec §4.3 contract)。`cancel.is_cancelled()` を 3 phase
-    /// (entry / backend 完了直後 / send 直前)で観測し、true ならば以降の sink push を
-    /// 停止する。SudachiDict / UserVocab / LearningCache は μs オーダーで完結するため
-    /// backend 個別の token 確認は行わない(spec §4.3 動作モデル)。
+    /// (Phase 3-A spec §4.3 contract)。`cancel.is_cancelled()` を以下の **4 phase** で
+    /// 観測し、true ならば以降の sink push を停止する:
+    ///
+    /// 1. entry — thread 起動直後
+    /// 2. dict backends 完了直後
+    /// 3. LLM convert 呼び出し直前
+    /// 4. LLM convert 完了直後
+    ///
+    /// SudachiDict / UserVocab / LearningCache は μs オーダーで完結するため backend
+    /// 個別の token 確認は行わない(spec §4.3 動作モデル)。LLM convert の token-level
+    /// (10 token 毎)cancel check は `KanjiBackend::convert` の signature 拡張要のため
+    /// **Phase 3-A 本番** で対応する(spec §13 Open Q 4)。M3 では convert() 完了後の
+    /// cancel check で止まる単純実装に留める。
+    ///
+    /// # Push 仕様
+    ///
+    /// - LLM 無効(`llm = None`):dict 結果のみ 1 段 push(M2 と同等)。
+    /// - LLM 有効 + LLM 成功:dict 結果を 1 段目 push、続けて dict + llm を再 merge した
+    ///   全置換 candidates を 2 段目 push。両段とも `CandidateUpdate::Replace`。
+    /// - LLM 有効 + LLM 失敗:dict 結果のみ 1 段 push(graceful degradation)。
+    ///   LLM 失敗は `tracing::warn!` で観測する(global feedback「silent_failure 禁止」)。
+    ///
+    /// # ConversionContext.commit_history
+    ///
+    /// LLM prompt への `commit_history` 注入は `ConvertOptions` への context field
+    /// 追加が必要(現在 top_k / temperature / seed のみ)。M3 は注入なしで動作確認に
+    /// 留め、context-aware prompt は P2-D 後続 ISSUE で別 spec として扱う。
     fn rank(
         &self,
         kana: &str,
@@ -84,11 +141,13 @@ impl Ranker for HybridRanker {
     ) -> Result<(), RankerError> {
         let request_id = self.next_request_id();
         let kana_owned = kana.to_string();
-        // ConversionContext は M3 LLM 統合で活用する。M2 では mode のみ debug 用に capture。
+        // ConversionContext.mode は debug 用 capture(将来 Live mode で LLM skip など
+        // mode-dependent behavior を実装する余地)。commit_history 注入は M3 範囲外。
         let _mode = ctx.mode;
         let sudachi = Arc::clone(&self.sudachi);
         let user_vocab = Arc::clone(&self.user_vocab);
         let learning_cache = Arc::clone(&self.learning_cache);
+        let llm_opt = self.llm.as_ref().map(Arc::clone);
 
         // 並列 backend 呼び出し用 thread を spawn(`rank()` は即時 return)。
         thread::spawn(move || {
@@ -156,11 +215,17 @@ impl Ranker for HybridRanker {
                 return;
             }
 
-            // merge / dedupe / sort
+            // merge / dedupe / sort(dict 段)
             // UserVocab と SudachiDict を同一 WEIGHT_DICT で merge する。同一 surface が
             // 競合した場合は max-score 採用のため、UserVocab 側の score が高ければ
             // 自然に優先される(挿入順は無関係、merge_candidates の dedupe コメント参照)。
             // caller(本関数)は UserVocab 由来 entry の score を意図的に高く付ける前提。
+            //
+            // LLM 段で再 merge するため、dict / user candidates の owned copy を
+            // clone しておく(merge は move semantics で消費する)。
+            let dict_cands_for_llm = dict_cands.clone();
+            let user_cands_for_llm = user_cands.clone();
+            let cache_surfaces_for_llm = cache_surfaces.clone();
             let merged = merge_candidates(
                 vec![
                     (user_cands, CandidateSource::Dict),
@@ -170,20 +235,70 @@ impl Ranker for HybridRanker {
                 DEFAULT_TOP_K,
             );
 
-            // Phase 3: send 直前 cancel check
+            // Phase 3 (M2 互換): dict 結果 send 直前 cancel check
             if cancel.is_cancelled() {
                 return;
             }
 
-            // sink に push。receiver が drop されてたら send error が返るが、
-            // 「receiver 側 thread が先に終わる」のは正常 path(engine 側で
-            // active request が更新済みのケース、Phase 3-A spec §7.5)。
-            // Caller が cleanup 中のため tracing::trace で吸収する。
+            // 1 段目 push:dict 結果。
+            // receiver が drop されてたら send error が返るが、「receiver 側 thread が
+            // 先に終わる」のは正常 path(engine 側で active request が更新済みのケース、
+            // Phase 3-A spec §7.5)。Caller が cleanup 中のため tracing::trace で吸収する。
             if let Err(e) = sink.send(RankerOutput {
                 request_id,
                 update: CandidateUpdate::Replace(merged),
             }) {
-                tracing::trace!(error = ?e, "ranker sink closed before send");
+                tracing::trace!(error = ?e, "ranker sink closed before dict send");
+                // 1 段目 send で receiver 不在なら 2 段目 LLM 段は試みない
+                // (resource waste 回避、cancellation の lazy effect)。
+                return;
+            }
+
+            // LLM path(`llm = None` なら skip し dict-only 動作 = M2 完全互換)。
+            let Some(llm) = llm_opt else {
+                return;
+            };
+
+            // Phase 3 (LLM 前): LLM convert 呼び出し直前 cancel check
+            if cancel.is_cancelled() {
+                return;
+            }
+
+            // M3 段階では ConvertOptions::default() で呼ぶ(top_k=5 / greedy / seed=0)。
+            // commit_history → prompt 注入は ConvertOptions 拡張要のため P2-D 後続
+            // ISSUE で対応する(spec §13 Open Q 4 関連)。
+            let opts = ConvertOptions::default();
+            match llm.convert(&kana_owned, &opts) {
+                Ok(llm_cands) => {
+                    // Phase 4 (LLM 後): LLM convert 完了直後 cancel check
+                    if cancel.is_cancelled() {
+                        return;
+                    }
+                    // 既存 dict + user 結果に LLM 結果を append、改めて merge して全置換 push。
+                    let combined = merge_candidates(
+                        vec![
+                            (user_cands_for_llm, CandidateSource::Dict),
+                            (dict_cands_for_llm, CandidateSource::Dict),
+                            (llm_cands, CandidateSource::Llm),
+                        ],
+                        &cache_surfaces_for_llm,
+                        DEFAULT_TOP_K,
+                    );
+                    if let Err(e) = sink.send(RankerOutput {
+                        request_id,
+                        update: CandidateUpdate::Replace(combined),
+                    }) {
+                        tracing::trace!(error = ?e, "ranker sink closed before LLM send");
+                    }
+                }
+                Err(e) => {
+                    // graceful degradation: dict-only fallback、第 2 段 push なし。
+                    tracing::warn!(
+                        error = ?e,
+                        kana = %kana_owned,
+                        "LLM backend failed, dict candidates only"
+                    );
+                }
             }
         });
 

--- a/crates/kotoha-engine-core/tests/hybrid_ranker_llm.rs
+++ b/crates/kotoha-engine-core/tests/hybrid_ranker_llm.rs
@@ -24,6 +24,7 @@
 
 #![cfg(feature = "mock-backend")]
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Duration;
@@ -62,7 +63,25 @@ impl MorphologicalEngine for StubEngine {
 /// 側に追加する案も検討したが、production surface(`pub use mock::MockBackend`)
 /// に test-only API を漏らすコストが大きいため、本 test ファイルに局所 impl を
 /// 置く方を採用した(`FailingBackend` は本ファイル外に export しない)。
-struct FailingBackend;
+///
+/// `convert()` の呼び出し回数を `Arc<AtomicUsize>` で公開し、test 側で「実際に
+/// 呼ばれた事実」を直接観測する(theater pattern 防止、Kotoha
+/// `feedback_test_theater_pattern.md` 準拠)。
+struct FailingBackend {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl FailingBackend {
+    fn new() -> (Self, Arc<AtomicUsize>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                call_count: count.clone(),
+            },
+            count,
+        )
+    }
+}
 
 impl KanjiBackend for FailingBackend {
     fn model_id(&self) -> &str {
@@ -74,9 +93,44 @@ impl KanjiBackend for FailingBackend {
         _input: &str,
         _options: &ConvertOptions,
     ) -> Result<Vec<Candidate>, KanjiError> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
         Err(KanjiError::Backend {
             reason: "FailingBackend always fails (test stub)".into(),
         })
+    }
+}
+
+/// 呼び出し回数を観測可能な MockBackend wrapper。cancel test で「LLM が呼ばれて
+/// いない」事実を直接観測するため(theater pattern 防止)。
+///
+/// MockBackend が public API として返すのと同じ deterministic fixture を委譲で
+/// 通しつつ、call_count を内部 `Arc<AtomicUsize>` で expose する。
+struct CountingMockBackend {
+    inner: MockBackend,
+    call_count: Arc<AtomicUsize>,
+}
+
+impl CountingMockBackend {
+    fn new() -> (Self, Arc<AtomicUsize>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                inner: MockBackend::new(),
+                call_count: count.clone(),
+            },
+            count,
+        )
+    }
+}
+
+impl KanjiBackend for CountingMockBackend {
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+
+    fn convert(&self, input: &str, options: &ConvertOptions) -> Result<Vec<Candidate>, KanjiError> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.convert(input, options)
     }
 }
 
@@ -180,10 +234,12 @@ fn hybrid_ranker_with_llm_returns_combined_candidates_in_two_stages() {
 }
 
 /// 即時 cancel:`rank()` 起動前に cancel すると dict 段すら send されない
-/// (Phase 1: entry cancel check が effective)。
+/// (Phase 1: entry cancel check が effective)。LLM が **呼ばれていない事実**
+/// を call counter で直接観測する(theater pattern 防止)。
 #[test]
 fn hybrid_ranker_with_llm_respects_cancel_before_invocation() {
-    let llm: Arc<dyn KanjiBackend + Send + Sync> = Arc::new(MockBackend::new());
+    let (counting_llm, llm_call_count) = CountingMockBackend::new();
+    let llm: Arc<dyn KanjiBackend + Send + Sync> = Arc::new(counting_llm);
     let ranker = build_ranker_with_backend(nihongo_dict_candidates(), llm);
     let cancel = Arc::new(StdCancellationToken::new());
     let (tx, rx) = mpsc::channel();
@@ -201,13 +257,24 @@ fn hybrid_ranker_with_llm_respects_cancel_before_invocation() {
         res.is_err(),
         "expected timeout (no send after pre-cancel), got {res:?}"
     );
+
+    // theater pattern 防止:LLM convert が **一度も呼ばれていない** 事を直接観測
+    // (entry cancel check が pre-LLM phase より前に effective であることを担保)
+    assert_eq!(
+        llm_call_count.load(Ordering::SeqCst),
+        0,
+        "LLM convert must NOT have been invoked when cancel fires before rank()"
+    );
 }
 
 /// LLM 失敗 fallback:`KanjiBackend::convert` が `Err` を返した場合、
 /// dict 段(1 段目)のみ push し、2 段目は **送らない**(graceful degradation)。
+/// FailingBackend が **実際に呼ばれた事実** を call counter で直接観測する
+/// (theater pattern 防止)。
 #[test]
 fn hybrid_ranker_llm_failure_falls_back_to_dict_only() {
-    let llm: Arc<dyn KanjiBackend + Send + Sync> = Arc::new(FailingBackend);
+    let (failing, llm_call_count) = FailingBackend::new();
+    let llm: Arc<dyn KanjiBackend + Send + Sync> = Arc::new(failing);
     let ranker = build_ranker_with_backend(nihongo_dict_candidates(), llm);
     let cancel = Arc::new(StdCancellationToken::new());
     let (tx, rx) = mpsc::channel();
@@ -236,5 +303,13 @@ fn hybrid_ranker_llm_failure_falls_back_to_dict_only() {
     assert!(
         res.is_err(),
         "expected no second send after LLM failure, got {res:?}"
+    );
+
+    // theater pattern 防止:FailingBackend が **実際に 1 回呼ばれた事実** を
+    // 直接観測(LLM path に到達せず fallback したケースと区別する)
+    assert_eq!(
+        llm_call_count.load(Ordering::SeqCst),
+        1,
+        "FailingBackend.convert() must have been invoked exactly once before fallback"
     );
 }

--- a/crates/kotoha-engine-core/tests/hybrid_ranker_llm.rs
+++ b/crates/kotoha-engine-core/tests/hybrid_ranker_llm.rs
@@ -1,0 +1,240 @@
+//! L2 integration test: HybridRanker with LLM backend (MockBackend / local failing stub).
+//!
+//! Phase 3-A spec §10.3 + §10.4 で要求される LLM integrated path を、kotoha-core の
+//! `MockBackend`(deterministic fixture)と本テストファイル内 `FailingBackend`
+//! (常に `Err` を返す stub)で検証する。
+//!
+//! # MockBackend と SudachiAdapter を直接構築しない理由
+//!
+//! - SudachiAdapter は `pub(crate)` のため外部 crate から構築不可。本 test は
+//!   M2 dict-only 系と同じ in-test `StubEngine` で `MorphologicalEngine` を満たす
+//!   (`hybrid_ranker_dict.rs` と同 pattern)。dict-smoke 系は別 ISSUE で扱う。
+//! - LLM 失敗 path 用の "always failing" MockBackend variant は kotoha-core 側に
+//!   未実装(`MockBackend::new()` のみ公開)。MockBackend 拡張は P2-D 範囲外と
+//!   判断し、本 test ファイル内に最小 `FailingBackend` を local impl で書き起こす
+//!   (Plan 2026-05-02-feature-120-p2d-hybrid-ranker.md §M3 Adaptation 5)。
+//!
+//! # Feature gate
+//!
+//! `MockBackend` は `kotoha-core/mock-backend` feature gated のため、本ファイル
+//! 全体を `#[cfg(feature = "mock-backend")]` で gate する。default features
+//! (lefthook pre-push)では本 test は **compile されない / 実行されない**。
+//! 実行は `cargo test -p kotoha-engine-core --features mock-backend
+//! --test hybrid_ranker_llm` で明示する。
+
+#![cfg(feature = "mock-backend")]
+
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use kotoha_core::dict::{EngineCandidate, MorphologicalEngine};
+use kotoha_core::kanji::{KanjiBackend, KanjiError, MockBackend};
+use kotoha_core::{Candidate, ConvertOptions};
+use kotoha_engine_core::{
+    cancel::StdCancellationToken, CancellationToken, CandidateUpdate, ConversionContext,
+    ConversionMode, HybridRanker, Ranker,
+};
+use kotoha_storage::learning_cache::{LearningCacheReader, MockLearningCacheStore};
+use kotoha_storage::user_vocab::{MockUserVocabStore, UserVocabReader};
+
+/// dict-smoke 不要な stub engine。`hybrid_ranker_dict.rs` と同 pattern。
+struct StubEngine {
+    canned: Vec<EngineCandidate>,
+}
+
+impl MorphologicalEngine for StubEngine {
+    fn tokenize(&self, reading: &str) -> Result<Vec<EngineCandidate>, KanjiError> {
+        if reading.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(self.canned.clone())
+    }
+
+    fn engine_id(&self) -> &str {
+        "stub-engine"
+    }
+}
+
+/// 常に `KanjiError::Backend` を返す LLM stub。LLM 失敗 fallback path 検証用。
+///
+/// 設計判断:`MockBackend` に `with_always_failing()` を生やす拡張を kotoha-core
+/// 側に追加する案も検討したが、production surface(`pub use mock::MockBackend`)
+/// に test-only API を漏らすコストが大きいため、本 test ファイルに局所 impl を
+/// 置く方を採用した(`FailingBackend` は本ファイル外に export しない)。
+struct FailingBackend;
+
+impl KanjiBackend for FailingBackend {
+    fn model_id(&self) -> &str {
+        "failing-stub"
+    }
+
+    fn convert(
+        &self,
+        _input: &str,
+        _options: &ConvertOptions,
+    ) -> Result<Vec<Candidate>, KanjiError> {
+        Err(KanjiError::Backend {
+            reason: "FailingBackend always fails (test stub)".into(),
+        })
+    }
+}
+
+/// 「にほんご」に対する代表的な dict 候補(`MockBackend` の hiragana fixture と
+/// reading が一致する句)。MockBackend は `"にほんご"` で `[日本語, 二本後]` を返す。
+fn nihongo_dict_candidates() -> Vec<EngineCandidate> {
+    vec![
+        EngineCandidate {
+            surface: "日本語".into(),
+            reading: "にほんご".into(),
+            score: -1.5,
+        },
+        EngineCandidate {
+            surface: "二本語".into(),
+            reading: "にほんご".into(),
+            score: -3.0,
+        },
+    ]
+}
+
+fn build_ranker_with_backend(
+    engine_cands: Vec<EngineCandidate>,
+    llm: Arc<dyn KanjiBackend + Send + Sync>,
+) -> HybridRanker {
+    let sudachi: Arc<dyn MorphologicalEngine + Send + Sync> = Arc::new(StubEngine {
+        canned: engine_cands,
+    });
+    let user_vocab = Arc::new(MockUserVocabStore::new()) as Arc<dyn UserVocabReader>;
+    let learning_cache = Arc::new(MockLearningCacheStore::new()) as Arc<dyn LearningCacheReader>;
+    HybridRanker::new(sudachi, user_vocab, learning_cache).with_llm(llm)
+}
+
+/// LLM 成功 path:dict 段(1 段目)の後に LLM 統合段(2 段目)が push される。
+///
+/// 確認ポイント:
+/// - sink には 2 個の `RankerOutput` が届く(両方 `CandidateUpdate::Replace`)
+/// - 2 段目には MockBackend が返した「日本語」(LLM 由来 score 0.9 + WEIGHT_LLM=1.0=1.9)
+///   または dict 由来「日本語」(stub score -1.5 + WEIGHT_DICT=0.95=-0.55)が
+///   max-score 採用 で merge され、weighted score = 1.9(LLM 勝ち)で top に来る
+#[test]
+fn hybrid_ranker_with_llm_returns_combined_candidates_in_two_stages() {
+    let llm: Arc<dyn KanjiBackend + Send + Sync> = Arc::new(MockBackend::new());
+    let ranker = build_ranker_with_backend(nihongo_dict_candidates(), llm);
+    let cancel = Arc::new(StdCancellationToken::new());
+    let (tx, rx) = mpsc::channel();
+
+    let ctx = ConversionContext::empty(ConversionMode::Commit);
+    ranker
+        .rank("にほんご", &ctx, cancel.clone(), tx)
+        .expect("rank should accept request");
+
+    // 1 段目: dict 段(LLM 待ちなし、即時)
+    let dict_output = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("dict response within 5s");
+    let dict_cands = match dict_output.update {
+        CandidateUpdate::Replace(cands) => cands,
+        other => panic!("expected Replace for dict stage, got {other:?}"),
+    };
+    assert!(
+        !dict_cands.is_empty(),
+        "dict stage should have at least one candidate (stub returned 2)"
+    );
+    // 1 段目には MockBackend の「日本語」(score=0.9)はまだ含まれていない
+    // (1 段目は dict only)。
+    let dict_top_score = dict_cands[0].score;
+
+    // 2 段目: dict + LLM 結合 段
+    let llm_output = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("LLM-merged response within 5s");
+    let combined = match llm_output.update {
+        CandidateUpdate::Replace(cands) => cands,
+        other => panic!("expected Replace for LLM stage, got {other:?}"),
+    };
+
+    assert!(
+        !combined.is_empty(),
+        "LLM stage should not be empty when MockBackend returns a fixture"
+    );
+    // MockBackend が「日本語」(0.9) を返すため、combined top は LLM 由来の
+    // 「日本語」(weighted = 0.9 + 1.0 = 1.9)になる。
+    let combined_top = &combined[0];
+    assert_eq!(
+        combined_top.surface, "日本語",
+        "expected LLM-derived 日本語 at top of combined stage, got {combined:?}"
+    );
+    assert!(
+        combined_top.score > dict_top_score,
+        "combined top score ({}) should exceed dict-only top score ({})",
+        combined_top.score,
+        dict_top_score
+    );
+
+    // 3 個目以降は来ない(sink close 後の追加 push は無い)
+    let res = rx.recv_timeout(Duration::from_millis(200));
+    assert!(
+        res.is_err(),
+        "expected only 2 RankerOutput messages, got 3rd: {res:?}"
+    );
+}
+
+/// 即時 cancel:`rank()` 起動前に cancel すると dict 段すら send されない
+/// (Phase 1: entry cancel check が effective)。
+#[test]
+fn hybrid_ranker_with_llm_respects_cancel_before_invocation() {
+    let llm: Arc<dyn KanjiBackend + Send + Sync> = Arc::new(MockBackend::new());
+    let ranker = build_ranker_with_backend(nihongo_dict_candidates(), llm);
+    let cancel = Arc::new(StdCancellationToken::new());
+    let (tx, rx) = mpsc::channel();
+
+    cancel.cancel(); // rank() 起動前に cancel
+
+    let ctx = ConversionContext::empty(ConversionMode::Commit);
+    ranker
+        .rank("にほんご", &ctx, cancel.clone(), tx)
+        .expect("rank should accept request even if pre-cancelled");
+
+    // dict / LLM どちらも send されない
+    let res = rx.recv_timeout(Duration::from_millis(500));
+    assert!(
+        res.is_err(),
+        "expected timeout (no send after pre-cancel), got {res:?}"
+    );
+}
+
+/// LLM 失敗 fallback:`KanjiBackend::convert` が `Err` を返した場合、
+/// dict 段(1 段目)のみ push し、2 段目は **送らない**(graceful degradation)。
+#[test]
+fn hybrid_ranker_llm_failure_falls_back_to_dict_only() {
+    let llm: Arc<dyn KanjiBackend + Send + Sync> = Arc::new(FailingBackend);
+    let ranker = build_ranker_with_backend(nihongo_dict_candidates(), llm);
+    let cancel = Arc::new(StdCancellationToken::new());
+    let (tx, rx) = mpsc::channel();
+
+    let ctx = ConversionContext::empty(ConversionMode::Commit);
+    ranker
+        .rank("にほんご", &ctx, cancel.clone(), tx)
+        .expect("rank should accept request");
+
+    // 1 段目 dict 段は届く
+    let dict_output = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("dict response within 5s");
+    let dict_cands = match dict_output.update {
+        CandidateUpdate::Replace(cands) => cands,
+        other => panic!("expected Replace for dict stage, got {other:?}"),
+    };
+    assert!(
+        !dict_cands.is_empty(),
+        "dict stage should have candidates regardless of LLM outcome"
+    );
+
+    // 2 段目は LLM 失敗で **送られない**(silent_failure 防止のため warn が出るが
+    // sink には送らない、graceful degradation)。
+    let res = rx.recv_timeout(Duration::from_millis(500));
+    assert!(
+        res.is_err(),
+        "expected no second send after LLM failure, got {res:?}"
+    );
+}

--- a/crates/kotoha-engine-core/tests/regression_phase1.rs
+++ b/crates/kotoha-engine-core/tests/regression_phase1.rs
@@ -1,0 +1,59 @@
+//! Phase 1 14/15 regression test through `HybridRanker`.
+//!
+//! Phase 3-A spec §10.1 Regression / §10.4 で要求される Phase 1 baseline 維持
+//! 確認。本 test は、LLM 統合済み HybridRanker を経由しても Phase 1 で達成済の
+//! 14/15 fixture PASS が維持されることを確認するための **frame** を提供する。
+//!
+//! # Feature gate
+//!
+//! - `llama-cpp-smoke` feature **有効** 時:`mod smoke` を compile し、
+//!   `LlamaCppBackend` + Phase 1 既存 fixture(`crates/kotoha-core/tests/
+//!   kanji_llama_cpp_smoke.rs` の 14/15 セット)を Ranker 経由で実行する
+//!   smoke test を提供する。本 test の **本実装 placeholder** は P2-D 後続
+//!   ISSUE で完成させる(Plan 2026-05-02-feature-120-p2d-hybrid-ranker.md
+//!   §M3 Adaptation 4)。M3 段階では smoke variant は **structure-only**
+//!   (実 fixture loader を持たない)に留め、`llama-cpp-smoke` を有効にした
+//!   開発環境で compile できることのみ保証する。
+//!
+//! - `llama-cpp-smoke` feature **無効** 時(default):lefthook pre-push が
+//!   この場合に該当する。compile-only sanity test 1 件を提供し、本ファイル
+//!   全体が default features で compile error を起こさないことを観測する。
+
+#[cfg(feature = "llama-cpp-smoke")]
+mod smoke {
+    //! Live LLM smoke variant — `llama-cpp-smoke` feature 必須。
+    //!
+    //! 本 module は M3 で **structure-only**。実 fixture(Phase 1 14/15)を
+    //! `HybridRanker` 経由で run する完全 impl は Phase 3-A 本番 / P2-D 後続
+    //! ISSUE で追加する。M3 段階では下記項目のみ保証する:
+    //!
+    //! 1. `llama-cpp-smoke` feature 有効時に compile が通ること
+    //! 2. `LlamaCppBackend` を Arc<dyn KanjiBackend + Send + Sync> として
+    //!    HybridRanker::with_llm() に渡せる型が成立すること(現実の load 呼び出しは
+    //!    GGUF model file path を要するため smoke test 本体では行わない)
+
+    use std::sync::Arc;
+
+    use kotoha_core::kanji::{KanjiBackend, LlamaCppBackend};
+
+    /// `LlamaCppBackend` が `KanjiBackend + Send + Sync` の trait object として
+    /// `HybridRanker::with_llm` に渡せる型であることを compile time で確認する。
+    /// 実 model load + inference は GGUF file が必要なので本 test では行わず、
+    /// Phase 3-A 本番(別 ISSUE)で fixture-driven smoke を追加する。
+    #[allow(dead_code)]
+    fn _llama_cpp_backend_is_compatible_with_hybrid_ranker_llm_slot(
+        backend: LlamaCppBackend,
+    ) -> Arc<dyn KanjiBackend + Send + Sync> {
+        Arc::new(backend)
+    }
+}
+
+/// `llama-cpp-smoke` 無効時の compile-only sanity。本 test は assertion を
+/// 持たず、ファイル全体が default features で compile することのみ観測する。
+#[test]
+#[cfg(not(feature = "llama-cpp-smoke"))]
+fn regression_test_compiles_without_llama_smoke_feature() {
+    // Intentional empty body. The presence of this test under default features
+    // ensures the file is exercised by `cargo test` without requiring the
+    // optional `llama-cpp-smoke` toolchain (llama.cpp + GGUF model).
+}


### PR DESCRIPTION
## Summary

P2-D Hybrid Ranker(ISSUE #120)Milestone 3 — `HybridRanker` に LLM backend(`KanjiBackend`)統合を additive に追加。`with_llm(llm)` builder + `rank()` 内 LLM path(dict 段 → LLM 統合段の 2 段 push)+ 4-phase cancel propagation(spec)+ 1 M2 互換 guard = 計 5 観測点。

LLM 失敗時は `tracing::warn` 残しで dict-only fallback、silent_failure 規約遵守。

Phase 1 14/15 regression test の structure(`tests/regression_phase1.rs`)は `llama-cpp-smoke` feature gated mod として scaffold、実 LLM smoke の本格実装は Phase 3-A 本番で対応(別 ISSUE 候補)。

## Key implementation

| Component | Behavior |
|-----------|----------|
| `HybridRanker.llm` field | `Option<Arc<dyn KanjiBackend + Send + Sync>>`、None なら dict-only fallback |
| `with_llm(llm)` builder | chainable、existing `new()` signature 不変(M2 backward compat) |
| Cancel propagation | 5 観測点(entry / dict 完了後 / dict-stage send 直前 / LLM 前 / LLM 後) |
| LLM Err handling | `tracing::warn` + dict-only fallback(2 段目 send なし) |
| LLM Ok handling | `dict + llm` 再 merge → `CandidateUpdate::Replace(combined)` 2 段目 push |
| Feature gating | `mock-backend` / `llama-cpp` / `llama-cpp-smoke`、すべて default 非含 |

## Changes(squash 対象、2 commits)

- `7695f51` initial implementation:LLM path + with_llm builder + 3 LLM integration tests + regression_phase1 scaffolding + Cargo.toml features
- `ed61ed4` review fixes:theater pattern 解消(call counter で LLM 呼び出し直接観測)+ docstring 5 観測点明記

## Test plan

- [x] `cargo build -p kotoha-engine-core` PASS
- [x] `cargo clippy -p kotoha-engine-core --all-targets -- -D warnings` PASS
- [x] `cargo test --workspace --features kotoha-storage/test-helpers --no-fail-fast` 413 PASS / 0 FAIL(M2 baseline 412 + regression sanity 1)
- [x] `cargo test -p kotoha-engine-core --features mock-backend --test hybrid_ranker_llm` 3 PASS / 0 FAIL
- [x] `lefthook run pre-push` 6/6 PASS
- [x] `gitleaks git --redact` 0 findings
- [x] subagent spec compliance review: 0 Critical / 3 Important detected → fix 適用 → re-verify(theater pattern 解消、docstring 5-phase 明記)

## Acceptance criteria(from #120 — partial、M3 範囲)

- [x] LLM backend(`KanjiBackend`)統合
- [x] cancel check 4 phase + 1 M2 互換 guard = 5 観測点
- [x] silent_failure ban 遵守(LLM 失敗 warn、不送信 fallback)
- [x] L2 integration test 3 cases、theater pattern 無し
- [x] regression_phase1 scaffolding(llama-cpp-smoke feature gated)
- [x] 既存 baseline 0 regression

未充足(M4 で対応):
- [ ] glossary `HybridRanker` entry(M4)
- [ ] proptest invariants(M4)

未充足(別 PR / 別 ISSUE 候補):
- [ ] commit_history → LLM prompt 注入(`ConvertOptions` field 拡張要、別 ISSUE)
- [ ] LLM token-level cancel propagation(`KanjiBackend::convert` signature 拡張要、Phase 3-A 本番、spec §13 Open Q 4)
- [ ] real SudachiDict + real LLM の dict-smoke gated end-to-end test(Phase 3-A 本番)

## Plan adaptations(implementer report)

| # | Adaptation |
|---|-----------|
| 1 | `MockBackend::with_always_failing()` 不在 → local `FailingBackend` stub を test 内に impl(call counter 付き) |
| 2 | `KanjiBackend` trait に Send+Sync 不在 → `Arc<dyn KanjiBackend + Send + Sync>` trait-object bound、`LlamaCppBackend` compat は compile-time check で confirm(`regression_phase1::smoke::_llama_cpp_backend_is_compatible_with_hybrid_ranker_llm_slot`) |
| 3 | `#![cfg(feature = "mock-backend")]` を test file top に配置(default features clippy hygiene) |
| 4 | dict-stage receiver drop 後の早期 return 追加(LLM convert を無駄に呼ばない) |
| 5 | `commit_history` LLM prompt 注入は `ConvertOptions` 拡張要 → 別 ISSUE 候補(本 PR scope 外) |
| 6 | review fix:CountingMockBackend wrapper(MockBackend 委譲 + call counter)、FailingBackend に call counter 追加 |

## Related

- Issue: #120
- Plan: `docs/superpowers/plans/2026-05-02-feature-120-p2d-hybrid-ranker.md` § Milestone 3
- Phase 3-A spec: `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` §4.3 / §8 / §13 Open Q 4
- Phase 2 spec: `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` §3.3
- ADR 0009: Phase 1 default model
- ADR 0011: KanjiBackend trait design

🤖 Generated with [Claude Code](https://claude.com/claude-code)