### PR TITLE
docs(engine-core): HybridRanker glossary + proptest invariants (P2-D M4 wrap-up, #120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,7 @@ version = "0.1.0"
 dependencies = [
  "kotoha-core",
  "kotoha-storage",
+ "proptest",
  "thiserror 1.0.69",
  "tracing",
 ]

--- a/crates/kotoha-engine-core/Cargo.toml
+++ b/crates/kotoha-engine-core/Cargo.toml
@@ -26,6 +26,10 @@ kotoha-storage = { path = "../kotoha-storage" }
 # `MockLearningCacheStore` を直接構築して使う。両者は kotoha-storage の
 # `default features` で公開されており、test-helpers feature は不要。
 kotoha-storage = { path = "../kotoha-storage" }
+# `tests/proptest_invariants.rs` で merge_candidates の不変条件
+# (top_k respect / sorted descending / dedupe by surface) を property test
+# する。M4 で再導入(M1 review fix で一旦削除した dev-dep)。
+proptest = { workspace = true }
 
 [features]
 default = []

--- a/crates/kotoha-engine-core/tests/proptest_invariants.rs
+++ b/crates/kotoha-engine-core/tests/proptest_invariants.rs
@@ -1,0 +1,74 @@
+//! Property-based invariant tests for `merge_candidates`.
+//!
+//! Phase 3-A spec §10.1 で要求される proptest による invariant test。
+//! 主要 invariant:
+//!
+//! - merge 結果の長さは `top_k` 以下
+//! - merge 結果の score は降順
+//! - 同 surface の重複は除去される
+//!
+//! `arb_candidate` の score range は `-100.0..100.0` に制限し NaN / +-Inf を
+//! 排除する。`merge_candidates` 内の sort は `partial_cmp` を `Ordering::Equal`
+//! fallback で扱うため NaN が混入すると invariant が崩れるが、生成段階で
+//! 排除することで test の root cause を「merge logic 側」に局所化する。
+
+use proptest::prelude::*;
+
+use kotoha_core::Candidate;
+use kotoha_engine_core::ranker::merge::{merge_candidates, CandidateSource};
+
+/// `Candidate` の任意値生成 strategy。
+///
+/// - `surface`: `c{0..=255}` の 256 種で衝突が起こるように設計(dedupe invariant の
+///   「同 surface が複数生成された場合の重複除去」を test 可能にする)。
+/// - `score`: `-100.0..100.0` の bounded f32(NaN / +-Inf を排除)。
+fn arb_candidate() -> impl Strategy<Value = Candidate> {
+    (any::<u8>(), -100.0_f32..100.0_f32).prop_map(|(idx, score)| {
+        let surface = format!("c{idx}");
+        Candidate::new(surface, score)
+    })
+}
+
+proptest! {
+    /// invariant: merge 結果の長さは `top_k` 以下
+    #[test]
+    fn merge_respects_top_k(
+        cands in prop::collection::vec(arb_candidate(), 0..50),
+        top_k in 1usize..30,
+    ) {
+        let merged = merge_candidates(
+            vec![(cands, CandidateSource::Dict)],
+            &[],
+            top_k,
+        );
+        prop_assert!(merged.len() <= top_k);
+    }
+
+    /// invariant: merge 結果は score 降順
+    #[test]
+    fn merge_is_sorted_descending(cands in prop::collection::vec(arb_candidate(), 0..50)) {
+        let merged = merge_candidates(
+            vec![(cands, CandidateSource::Dict)],
+            &[],
+            50,
+        );
+        for window in merged.windows(2) {
+            prop_assert!(window[0].score >= window[1].score);
+        }
+    }
+
+    /// invariant: 同一 surface の重複は merge で除去される
+    #[test]
+    fn merge_dedupes_by_surface(cands in prop::collection::vec(arb_candidate(), 0..50)) {
+        let merged = merge_candidates(
+            vec![(cands, CandidateSource::Dict)],
+            &[],
+            50,
+        );
+        let mut surfaces: Vec<&str> = merged.iter().map(|c| c.surface.as_str()).collect();
+        surfaces.sort();
+        let len_before = surfaces.len();
+        surfaces.dedup();
+        prop_assert_eq!(surfaces.len(), len_before, "duplicate surfaces detected");
+    }
+}

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -372,6 +372,13 @@
 - **対応する identifier**: `kotoha_engine_core::cancel::StdCancellationToken`(`crates/kotoha-engine-core/src/cancel/std_token.rs`)
 - **備考**: tokio runtime 導入は Phase 5 / 6 で再評価。それまで Phase 3-A は std::sync ベースで運用。同期 thread block-wait API は現状未提供、将来追加時に Condvar 復活と `wait_blocking()` method を同時導入する。
 
+### HybridRanker
+
+- **定義**: Phase 3-A spec §4.3 で凍結された `Ranker` trait の concrete impl。SudachiDict + UserVocab + LearningCache + LLM の 4 backend を統合し、`mpsc::Sender<RankerOutput>` 経由で逐次候補を engine に push する。Phase 2 spec §3.3 で凍結された初期重み(dict 0.95 / LLM 1.0 / cache hit bonus +0.5)で merge / dedupe / scoring を行う。
+- **初出**: P2-D Milestone 2(2026-05-02、ISSUE #120 / branch `feature/120-p2d-hybrid-ranker-dict`)
+- **対応する identifier**: `kotoha_engine_core::ranker::HybridRanker`(`crates/kotoha-engine-core/src/ranker/hybrid.rs`)
+- **備考**: LLM backend は `Option<Arc<dyn KanjiBackend>>` で None なら dict-only で動作。Live mode は best-effort、Commit mode は LLM 完了まで待機する設計だが、token-level cancel propagation(spec §13 Open Q 4)は Phase 3-A 本番実装で対応する。
+
 ## 5. LLM 推論とプロンプト
 
 ### PromptTemplate


### PR DESCRIPTION
## Summary

P2-D Hybrid Ranker(ISSUE #120)Milestone 4 — final wrap-up:

1. **glossary**:`HybridRanker` entry を category 4 Phase 3 IBus engine sub-section に追加(7 lines)
2. **proptest invariants**:`tests/proptest_invariants.rs` 新規、3 不変条件 test(merge 結果長さ ≤ top_k / score 降順 / surface dedupe)、各 default 256 case
3. **proptest dev-dep**:M1 review fix で削除した `proptest = { workspace = true }` を `[dev-dependencies]` に再導入(M4 で実需 surface)

## Changes

- `Cargo.lock`(proptest 1.5 entry)
- `crates/kotoha-engine-core/Cargo.toml`(proptest dev-dep 再導入、M1→M4 lifecycle コメント)
- `crates/kotoha-engine-core/tests/proptest_invariants.rs`(新規 74 lines、3 proptest fn)
- `docs/wiki/glossary.md`(+7 lines、`### HybridRanker` entry)

## Test plan

- [x] `cargo build -p kotoha-engine-core` PASS
- [x] `cargo clippy -p kotoha-engine-core --all-targets -- -D warnings` PASS
- [x] `cargo test -p kotoha-engine-core --test proptest_invariants` 3 PASS / 0 FAIL(各 256 case 完走)
- [x] `cargo test --workspace --features kotoha-storage/test-helpers --no-fail-fast` 416 PASS / 0 FAIL(M3 baseline 413 + 3 proptest = 416、0 regression)
- [x] `lefthook run pre-push` 6/6 PASS
- [x] `gitleaks git --redact` 0 findings

## proptest design notes(implementer self-review より抜粋)

- `arb_candidate` の score range は `-100.0..100.0`(NaN / Inf 除外)。`merge_candidates` の sort は `partial_cmp(...).unwrap_or(Ordering::Equal)` で NaN-poisoned 入力を silently 通すが、bounded strategy で invariant attribution を merge logic に局所化
- Surface domain は `c{0..=255}`(256 個)。vector 長 0..50 → Birthday-bound ~5 expected collisions per 50-elem vec、dedupe 不変条件が genuinely exercised(vacuous 通過しない)

## P2-D 完成状態(本 PR で wrap-up)

| Milestone | PR | status |
|-----------|----|----|
| M1: trait skeleton | #124 | ✅ merged(`3253301`)|
| M2: dict-only impl | #125 | ✅ merged(`7898e62`)|
| M3: LLM integration | #126 | ✅ merged(`522919c`)|
| **M4: wrap-up** | **本 PR** | 🟢 review 中 |

merge 後の develop tip で ISSUE #120 全 acceptance criteria 充足、close 可能状態。

## Acceptance criteria(from #120 — 最終)

- [x] `kotoha-engine-core` 新 crate 作成、Ranker / ConversionContext / CandidateUpdate / CancellationToken trait + types(M1 で完了)
- [x] `HybridRanker` struct(SudachiDict + UserVocab + LearningCache + LLM 統合)(M2 + M3)
- [x] candidate merge / dedupe(Phase 2 spec §3.3 重み実装)(M2)
- [x] cancel propagation 5 観測点(M3 で 4 → 5 観測点に拡張)
- [x] sink.send 経由 partial 候補 push(M2 + M3)
- [x] L1 unit test(M1 + M2)
- [x] L2 integration test(M2 + M3)
- [x] regression scaffolding for Phase 1 14/15(M3、llama-cpp-smoke gated)
- [x] glossary 更新(M4)
- [x] 既存 baseline 0 regression
- [x] proptest invariants(M4)

## Future follow-ups(別 ISSUE 候補、本 PR scope 外)

1. `commit_history` LLM prompt 注入(`ConvertOptions` field 拡張)
2. LLM token-level cancel propagation(`KanjiBackend::convert` signature 拡張、Phase 3-A 本番、spec §13 Open Q 4)
3. real SudachiDict + real LLM の dict-smoke gated end-to-end test(Phase 3-A 本番)
4. `MorphologicalEngine` trait に `Send + Sync` supertrait 追加(workspace cleanup)
5. workspace rustdoc 言語 policy 統一(English / 日本語 mixed の policy clarification)

## Related

- Issue: #120
- Plan: `docs/superpowers/plans/2026-05-02-feature-120-p2d-hybrid-ranker.md` § Milestone 4
- M1〜M3 PRs: #124 / #125 / #126
- Phase 3-A spec §10.1 proptest 要件
- Phase 2 spec §3.3 重み定義

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)