### PR TITLE
feat(engine-core): IMEEngine/IMEHostBridge + KeyEvent + Mock infra (P3-A M1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
 name = "kotoha-engine-core"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "kotoha-core",
  "kotoha-storage",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 tempfile = "3"
 assert_cmd = "2"
 serial_test = "3"
+# bitflags pinned via P3-A M1 (2026-05-02). KeyModifiers の bitflag 表現に使う。
+# Adopted reason: defacto standard、no_std 対応、P3-A spec §4.1 で明示要請。
+bitflags = "2.6"

--- a/crates/kotoha-engine-core/Cargo.toml
+++ b/crates/kotoha-engine-core/Cargo.toml
@@ -18,6 +18,9 @@ authors.workspace = true
 #   (`HybridRanker` の sudachi backend port)。
 thiserror = { workspace = true }
 tracing = { workspace = true }
+# `bitflags` pinned via P3-A M1 (2026-05-02): `KeyModifiers` の bitflag 表現
+# (Phase 3-A spec §4.1)。
+bitflags = { workspace = true }
 kotoha-core = { path = "../kotoha-core", features = ["dict"] }
 kotoha-storage = { path = "../kotoha-storage" }
 

--- a/crates/kotoha-engine-core/src/host_bridge.rs
+++ b/crates/kotoha-engine-core/src/host_bridge.rs
@@ -1,0 +1,47 @@
+//! `IMEHostBridge` driven port — engine から host(adapter)への呼び出し API。
+//!
+//! Phase 3-A spec §4.2 で凍結。`Send + Sync` を要求するのは engine 主 thread と
+//! `RankerWorker` thread の双方から `Box<dyn IMEHostBridge>` を経由して呼ばれる
+//! ため(spec §4.2 Send + Sync 節)。
+
+use crate::CandidateUpdate;
+
+/// engine から IME host(adapter)への呼び出し API。
+///
+/// # Implementor 要件
+///
+/// - `Send + Sync` を満たす(spec §4.2、複数 thread 利用)
+/// - 内部 D-Bus call の thread-safety は impl 側責務(IBus 1.x adapter は
+///   `Mutex<Vec<Candidate>>` 内部 buffer で coalesce)
+pub trait IMEHostBridge: Send + Sync {
+    /// preedit text を更新する。
+    ///
+    /// # Postconditions
+    ///
+    /// - host の preedit display が `text` / `cursor` / `visible` で書き換わる
+    /// - `visible == false` の場合は preedit 非表示扱い(空文字列でも host 側で
+    ///   表示無し化)
+    fn update_preedit(&self, text: &str, cursor: usize, visible: bool);
+
+    /// `text` を application に確定送信する。
+    ///
+    /// # Postconditions
+    ///
+    /// - host が application(focused window)に `text` を文字列として注入する
+    fn commit_text(&self, text: &str);
+
+    /// 候補 list の差分を反映する。
+    ///
+    /// # Postconditions
+    ///
+    /// - IBus 1.x adapter は `Replace` / `Append` / `Remove` / `Clear` を
+    ///   internal buffer mutate + `update_lookup_table` 1 回で集約する
+    ///   (spec §4.2 mapping 表)
+    fn update_candidates(&self, update: CandidateUpdate);
+
+    /// 候補 window を表示する。
+    fn show_candidate_window(&self);
+
+    /// 候補 window を非表示にする。
+    fn hide_candidate_window(&self);
+}

--- a/crates/kotoha-engine-core/src/ime_engine.rs
+++ b/crates/kotoha-engine-core/src/ime_engine.rs
@@ -1,0 +1,60 @@
+//! `IMEEngine` driving port — host(adapter)から engine への呼び出し API。
+//!
+//! Phase 3-A spec §4.1 で凍結。`Send` のみ要求(`Sync` は不要、event loop は
+//! 単一 thread から engine を呼ぶ前提、内部並行性は `RankerWorker` thread と
+//! channel で扱う、spec §4.1 Send + ! Sync 節)。
+
+use crate::key_event::{KeyEvent, KeyEventResult};
+
+/// IME host(adapter)から engine に呼び出される API。
+///
+/// # Lifecycle
+///
+/// 1. host が `enable()` を呼ぶ → engine は active 状態
+/// 2. `focus_in()` でフォーカス取得通知
+/// 3. `process_key_event()` で keystroke を渡す(0 回以上)
+/// 4. `focus_out()` でフォーカス喪失通知
+/// 5. `disable()` で engine inactive へ
+///
+/// # Invariants
+///
+/// - `enable()` 前 / `disable()` 後の `process_key_event()` は no-op + `Forwarded` 返却
+/// - `focus_out()` 後は engine 状態が必ず Idle(active_request cancel + preedit clear)
+pub trait IMEEngine: Send {
+    /// 1 keystroke を処理し、消費 / forward を返す。
+    ///
+    /// # Preconditions
+    ///
+    /// - engine が `enable()` 後 / `disable()` 前
+    /// - `focus_in()` 後 / `focus_out()` 前
+    ///
+    /// # Postconditions
+    ///
+    /// - `Consumed` を返した場合、[`crate::host_bridge::IMEHostBridge::update_preedit`] /
+    ///   `update_candidates` / `commit_text` のいずれかが engine 内部で
+    ///   呼び出された(0 回以上)
+    /// - panic-free を保証(panic は top-level catch_unwind で reset 経由、
+    ///   spec §9.1)
+    fn process_key_event(&mut self, key: KeyEvent) -> KeyEventResult;
+
+    /// application フォーカス取得通知(host から)。
+    fn focus_in(&mut self);
+
+    /// application フォーカス喪失通知(host から)。
+    ///
+    /// # Postconditions
+    ///
+    /// - active_request の cancel_token を fire
+    /// - preedit / commit_history / 候補 window を clear
+    /// - engine 状態 → Idle
+    fn focus_out(&mut self);
+
+    /// engine 内部状態を強制 reset(host からの強制 reset、`focus_out` と同等)。
+    fn reset(&mut self);
+
+    /// engine を active 状態に遷移させる(host が IME を有効化)。
+    fn enable(&mut self);
+
+    /// engine を inactive 状態に遷移させる(host が IME を無効化)。
+    fn disable(&mut self);
+}

--- a/crates/kotoha-engine-core/src/key_event.rs
+++ b/crates/kotoha-engine-core/src/key_event.rs
@@ -1,0 +1,90 @@
+//! `KeyEvent` / `KeyEventResult` / `KeyModifiers` — host から engine への
+//! keystroke 入力 + engine から host への consume/forward 判断。
+//!
+//! Phase 3-A spec §4.1 で凍結。bitflags 表現は IBus IBusModifierType と同型で、
+//! adapter 層で 1:1 mapping される(spec §13 Open Q 8 で完全 mapping は実装段階対応)。
+
+use bitflags::bitflags;
+
+/// 1 keystroke の表現。host adapter が IBus / fcitx5 等の event から構築して
+/// [`crate::ime_engine::IMEEngine::process_key_event`] に渡す。
+///
+/// # Invariants
+///
+/// - `keysym` は X11 keysym(`XK_*`)を u32 で保持する。spec §13 Open Q 8 で
+///   full mapping を adapter 段階で確定する。
+/// - `keycode` は physical keycode(layout 非依存判定用、Phase 3-A 初期は
+///   未使用、forward-compat のため field 確保)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyEvent {
+    /// X11 keysym(IBus が KeyPress event で渡す sym と同一の u32 値)。
+    pub keysym: u32,
+    /// 物理 keycode(layout 非依存判定用、Phase 3-A 初期は未使用)。
+    pub keycode: u32,
+    /// modifier 状態(Shift / Ctrl / Alt / Super)。
+    pub modifiers: KeyModifiers,
+}
+
+bitflags! {
+    /// Keystroke 同伴 modifier。Phase 3-A 初期は IBus IBusModifierType の
+    /// 主要 4 種のみ(spec §13 Open Q 8 で残余は実装段階対応)。
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct KeyModifiers: u32 {
+        const SHIFT = 1 << 0;
+        const CTRL  = 1 << 1;
+        const ALT   = 1 << 2;
+        const SUPER = 1 << 3;
+    }
+}
+
+/// [`crate::ime_engine::IMEEngine::process_key_event`] の戻り値。
+///
+/// # Invariants
+///
+/// - `Consumed`:engine が keystroke を吸収。host は application に key を渡してはならない。
+/// - `Forwarded`:engine は不処理。host は application に key を渡してよい。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyEventResult {
+    Consumed,
+    Forwarded,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// spec §4.1: KeyModifiers の bitflag 合成
+    #[test]
+    fn modifiers_combine_via_bitor() {
+        let m = KeyModifiers::SHIFT | KeyModifiers::CTRL;
+        assert!(m.contains(KeyModifiers::SHIFT));
+        assert!(m.contains(KeyModifiers::CTRL));
+        assert!(!m.contains(KeyModifiers::ALT));
+    }
+
+    /// spec §4.1: empty modifier は no flag
+    #[test]
+    fn modifiers_empty_has_no_flags() {
+        let m = KeyModifiers::empty();
+        assert!(!m.contains(KeyModifiers::SHIFT));
+        assert!(!m.contains(KeyModifiers::CTRL));
+    }
+
+    /// spec §4.1: KeyEvent は Copy(adapter 層で頻繁に複製される)
+    #[test]
+    fn key_event_is_copy() {
+        let ev = KeyEvent {
+            keysym: 0x6b, // 'k'
+            keycode: 45,
+            modifiers: KeyModifiers::empty(),
+        };
+        let ev2 = ev;
+        assert_eq!(ev, ev2);
+    }
+
+    /// spec §4.1: KeyEventResult variants
+    #[test]
+    fn key_event_result_distinct_variants() {
+        assert_ne!(KeyEventResult::Consumed, KeyEventResult::Forwarded);
+    }
+}

--- a/crates/kotoha-engine-core/src/lib.rs
+++ b/crates/kotoha-engine-core/src/lib.rs
@@ -12,15 +12,26 @@
 //! - [`ranker::CandidateUpdate`] — 候補差分通知 enum
 //! - [`cancel::CancellationToken`] — cancel signal trait
 //! - [`cancel::StdCancellationToken`] — std::sync ベース impl
+//! - [`ime_engine::IMEEngine`] — driving port(host → engine)
+//! - [`host_bridge::IMEHostBridge`] — driven port(engine → host)
+//! - [`key_event::KeyEvent`] / [`key_event::KeyEventResult`] / [`key_event::KeyModifiers`]
 //!
-//! 本 crate は Phase 3-A engine 本体(`KotohaEngine` 状態機械、`IMEEngine` /
-//! `IMEHostBridge` trait、`RankerWorker`)を含まない。それらは Phase 3-A 本番
-//! 実装段階で本 crate に追加される。
+//! 本 crate は Phase 3-A engine 本体(`KotohaEngine` 状態機械、`RankerWorker`)を
+//! Milestone 2 / 3 で追加する。
 
 pub mod cancel;
+pub mod host_bridge;
+pub mod ime_engine;
+pub mod key_event;
 pub mod ranker;
 
+#[cfg(feature = "test-helpers")]
+pub mod testing;
+
 pub use cancel::{CancellationToken, StdCancellationToken};
+pub use host_bridge::IMEHostBridge;
+pub use ime_engine::IMEEngine;
+pub use key_event::{KeyEvent, KeyEventResult, KeyModifiers};
 pub use ranker::{
     CandidateUpdate, ConversionContext, ConversionMode, HybridRanker, Ranker, RankerError,
     RankerOutput,

--- a/crates/kotoha-engine-core/src/testing.rs
+++ b/crates/kotoha-engine-core/src/testing.rs
@@ -1,0 +1,177 @@
+//! Test infra: `MockHostBridge` / `MockRanker` for L1 unit test DI.
+//!
+//! `test-helpers` feature gate 下で公開する。本 module は production binary に
+//! 含まれない(P2-D `MockLearningCacheStore` と同 pattern、spec §10.5)。
+
+#![cfg(feature = "test-helpers")]
+
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+
+use kotoha_core::Candidate;
+
+use crate::cancel::CancellationToken;
+use crate::host_bridge::IMEHostBridge;
+use crate::ranker::{CandidateUpdate, ConversionContext, Ranker, RankerError, RankerOutput};
+
+/// `IMEHostBridge` への呼び出しを `Vec<HostOperation>` に記録する mock。
+///
+/// L1 unit test で engine の状態遷移ごとに host call sequence を assert する
+/// (spec §10.2 / §10.5)。
+#[derive(Debug, Clone, Default)]
+pub struct MockHostBridge {
+    operations: Arc<Mutex<Vec<HostOperation>>>,
+}
+
+/// `MockHostBridge` が記録する 1 操作。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostOperation {
+    UpdatePreedit {
+        text: String,
+        cursor: usize,
+        visible: bool,
+    },
+    CommitText(String),
+    UpdateCandidates(MockCandidateUpdate),
+    ShowCandidateWindow,
+    HideCandidateWindow,
+}
+
+/// `CandidateUpdate` の test 比較用 simplified clone。`Range` の `Eq` 実装が
+/// 不安定のため自前 enum を用意する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MockCandidateUpdate {
+    Replace(Vec<String>),
+    Append(Vec<String>),
+    Remove { start: usize, end: usize },
+    Clear,
+}
+
+impl From<&CandidateUpdate> for MockCandidateUpdate {
+    fn from(u: &CandidateUpdate) -> Self {
+        match u {
+            CandidateUpdate::Replace(c) => {
+                MockCandidateUpdate::Replace(c.iter().map(|x| x.surface.clone()).collect())
+            }
+            CandidateUpdate::Append(c) => {
+                MockCandidateUpdate::Append(c.iter().map(|x| x.surface.clone()).collect())
+            }
+            CandidateUpdate::Remove(r) => MockCandidateUpdate::Remove {
+                start: r.start,
+                end: r.end,
+            },
+            CandidateUpdate::Clear => MockCandidateUpdate::Clear,
+        }
+    }
+}
+
+impl MockHostBridge {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 記録された全 operation の clone を返す。
+    pub fn operations(&self) -> Vec<HostOperation> {
+        self.operations
+            .lock()
+            .expect("MockHostBridge mutex poisoned")
+            .clone()
+    }
+
+    /// 記録を全 clear する。複数シナリオの分離 assert に使う。
+    pub fn clear(&self) {
+        self.operations
+            .lock()
+            .expect("MockHostBridge mutex poisoned")
+            .clear();
+    }
+
+    fn push(&self, op: HostOperation) {
+        self.operations
+            .lock()
+            .expect("MockHostBridge mutex poisoned")
+            .push(op);
+    }
+}
+
+impl IMEHostBridge for MockHostBridge {
+    fn update_preedit(&self, text: &str, cursor: usize, visible: bool) {
+        self.push(HostOperation::UpdatePreedit {
+            text: text.to_string(),
+            cursor,
+            visible,
+        });
+    }
+
+    fn commit_text(&self, text: &str) {
+        self.push(HostOperation::CommitText(text.to_string()));
+    }
+
+    fn update_candidates(&self, update: CandidateUpdate) {
+        self.push(HostOperation::UpdateCandidates((&update).into()));
+    }
+
+    fn show_candidate_window(&self) {
+        self.push(HostOperation::ShowCandidateWindow);
+    }
+
+    fn hide_candidate_window(&self) {
+        self.push(HostOperation::HideCandidateWindow);
+    }
+}
+
+/// `Ranker` の mock impl。固定候補を即時 sink.send + cancel observer。
+///
+/// L1 unit test で engine が rank を呼ぶ回数 / cancel 検出を assert する
+/// (spec §10.2 / §10.5)。
+#[derive(Debug)]
+pub struct MockRanker {
+    candidates: Vec<Candidate>,
+    rank_calls: Arc<std::sync::atomic::AtomicU64>,
+    cancel_observed: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl MockRanker {
+    pub fn new(candidates: Vec<Candidate>) -> Self {
+        Self {
+            candidates,
+            rank_calls: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            cancel_observed: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        }
+    }
+
+    pub fn rank_calls(&self) -> u64 {
+        self.rank_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    pub fn cancel_observed(&self) -> u64 {
+        self.cancel_observed
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl Ranker for MockRanker {
+    fn rank(
+        &self,
+        _kana: &str,
+        _ctx: &ConversionContext,
+        cancel: Arc<dyn CancellationToken>,
+        sink: mpsc::Sender<RankerOutput>,
+    ) -> Result<(), RankerError> {
+        self.rank_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if cancel.is_cancelled() {
+            self.cancel_observed
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            return Ok(());
+        }
+        // request_id は engine 主 thread 採番ではなく、Mock では 0 固定とし、
+        // M3 で `RankerWorker` 経由になった時に worker が `request_id` を
+        // `RankerOutput.request_id` に上書きする設計。
+        let _ = sink.send(RankerOutput {
+            request_id: 0,
+            update: CandidateUpdate::Replace(self.candidates.clone()),
+        });
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3-A spec §4.1 / §4.2 で凍結された driving port + driven port trait を追加。後続 M2 (KotohaEngine 状態機械) / M3 (RankerWorker) / M4-M5 (IBus adapter) / M6 (binary) の base layer を確立する。

- `KeyEvent` / `KeyEventResult` / `KeyModifiers` (bitflags 2.x)
- `IMEEngine` driving port trait (`Send`, ! Sync)
- `IMEHostBridge` driven port trait (`Send + Sync`)
- `MockHostBridge` / `MockRanker` (test-helpers feature gate)

## Test plan

- [x] lefthook pre-push (build / clippy / fmt / test 全 stage PASS)
- [x] engine-core unit 17 → 21 (+4 KeyEvent tests), 0 regression
- [x] full workspace test (--features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers) 416 → 420 PASS

## References

- Spec: `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` §4.1 / §4.2 / §10.5
- Plan: `docs/superpowers/plans/2026-05-02-feature-128-p3a-engine-implementation.md` Milestone 1

Refs #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)