### PR TITLE
feat(engine-ibus): kotoha-engine-ibus crate + IBusHostBridge skeleton (P3-A M4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +294,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +316,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
@@ -261,6 +417,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,12 +474,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
+ "serde",
 ]
 
 [[package]]
@@ -336,6 +514,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -409,6 +608,25 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -500,6 +718,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +779,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kotoha-cli"
 version = "0.1.0"
 dependencies = [
@@ -583,6 +825,17 @@ dependencies = [
  "proptest",
  "thiserror 1.0.69",
  "tracing",
+]
+
+[[package]]
+name = "kotoha-engine-ibus"
+version = "0.1.0"
+dependencies = [
+ "kotoha-core",
+ "kotoha-engine-core",
+ "thiserror 1.0.69",
+ "tracing",
+ "zbus",
 ]
 
 [[package]]
@@ -700,6 +953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +999,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,10 +1044,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -815,6 +1118,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -982,6 +1294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1397,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1438,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1237,6 +1576,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1635,17 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1300,6 +1680,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -1354,6 +1745,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1412,6 +1848,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1515,6 +1960,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,3 +2045,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/kotoha-cli",
     "crates/kotoha-storage",
     "crates/kotoha-engine-core",
+    "crates/kotoha-engine-ibus",
 ]
 
 [workspace.package]
@@ -50,3 +51,11 @@ serial_test = "3"
 # bitflags pinned via P3-A M1 (2026-05-02). KeyModifiers の bitflag 表現に使う。
 # Adopted reason: defacto standard、no_std 対応、P3-A spec §4.1 で明示要請。
 bitflags = "2.6"
+# zbus pinned via P3-A M4 (2026-05-02). IBus 1.x D-Bus binding。
+# Adopted reason: pure-Rust, no GTK dep, defacto std for D-Bus on Rust。
+# Alternatives rejected: ibus-rs (gtk-rs based, heavy and stale),
+# dbus-rs (sync C bindings, complex)。
+# default features (= async-io + p2p + introspection) を使う。tokio runtime を
+# 持ち込まない方針で async-io(smol-based)を選択し、blocking-api を併用して
+# Phase 3-A M3 (std::sync) と同期 path を保つ。
+zbus = "5"

--- a/crates/kotoha-engine-ibus/Cargo.toml
+++ b/crates/kotoha-engine-ibus/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kotoha-engine-ibus"
+description = "Kotoha IME IBus protocol adapter (Phase 3-A spec §3.1)"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
+kotoha-engine-core = { path = "../kotoha-engine-core" }
+kotoha-core = { path = "../kotoha-core" }

--- a/crates/kotoha-engine-ibus/src/host_bridge.rs
+++ b/crates/kotoha-engine-ibus/src/host_bridge.rs
@@ -1,0 +1,61 @@
+//! `IBusHostBridge` — `IMEHostBridge` の IBus 1.x 実装。
+//!
+//! Phase 3-A spec §4.2 / §3.3 全体図に対応する driven port adapter。
+//! 本 PR (M4) では D-Bus call は `tracing::trace!` で stub し、
+//! `Mutex<Vec<Candidate>>` 内部 buffer の coalesce logic を確定させる。
+//! M5 で zbus `Proxy` 経由で IBus engine interface に結線する。
+
+use kotoha_engine_core::{CandidateUpdate, IMEHostBridge};
+
+use crate::lookup_table::LookupTable;
+
+/// IBus 1.x host(`org.freedesktop.IBus.Engine` interface)への呼び出し adapter。
+///
+/// # Construction
+///
+/// M4 段階では `LookupTable` + `tracing::trace!` stub のみ。
+/// M5 で zbus `Connection` / object path を field 追加する。
+///
+/// # Thread safety
+///
+/// `Send + Sync`(spec §4.2)。`LookupTable` 内部 `Mutex` で coalesce、
+/// `tracing` macro は thread-safe。
+#[derive(Debug, Default)]
+pub struct IBusHostBridge {
+    lookup_table: LookupTable,
+}
+
+impl IBusHostBridge {
+    pub fn new() -> Self {
+        Self {
+            lookup_table: LookupTable::new(),
+        }
+    }
+}
+
+impl IMEHostBridge for IBusHostBridge {
+    fn update_preedit(&self, text: &str, cursor: usize, visible: bool) {
+        // M5 で zbus.Proxy::call("UpdatePreeditText", ...) に置換。
+        tracing::trace!(text, cursor, visible, "IBus update_preedit (stub)");
+    }
+
+    fn commit_text(&self, text: &str) {
+        tracing::trace!(text, "IBus commit_text (stub)");
+    }
+
+    fn update_candidates(&self, update: CandidateUpdate) {
+        let merged = self.lookup_table.apply(update);
+        tracing::trace!(
+            count = merged.len(),
+            "IBus update_lookup_table (stub, coalesced)"
+        );
+    }
+
+    fn show_candidate_window(&self) {
+        tracing::trace!("IBus show_lookup_table (stub)");
+    }
+
+    fn hide_candidate_window(&self) {
+        tracing::trace!("IBus hide_lookup_table (stub)");
+    }
+}

--- a/crates/kotoha-engine-ibus/src/lib.rs
+++ b/crates/kotoha-engine-ibus/src/lib.rs
@@ -1,0 +1,25 @@
+//! `kotoha-engine-ibus`: IBus 1.x protocol adapter for Kotoha engine.
+//!
+//! 本 crate は Phase 3-A spec §3.1 の adapter layer に対応する。
+//! [`kotoha_engine_core::IMEHostBridge`] を [`IBusHostBridge`] で impl し、
+//! IBus engine 側の D-Bus signal/method を `kotoha_engine_core::IMEEngine`
+//! method 呼び出しに変換する dispatcher を提供する。
+//!
+//! # Module 構成
+//!
+//! - [`host_bridge::IBusHostBridge`] — `IMEHostBridge` の IBus 実装(driven port)
+//! - [`lookup_table::LookupTable`] — `Mutex<Vec<Candidate>>` 内部 buffer + IBus mapping
+//! - `dispatcher::IBusEventDispatcher` — D-Bus event 受信 + `IMEEngine` 呼び出し(M5 で追加)
+//! - `keysym` — IBus keysym → `KeyEvent` 変換 helper(M5 で追加)
+//!
+//! # Boundary 原則
+//!
+//! 本 crate は IBus 固有の D-Bus interface に依存して良いが、`kotoha-engine-core`
+//! は host 非依存のため、core 側に IBus 識別子を漏らさない(spec §3.1 / Adaptive
+//! boundary-first 原則)。
+
+pub mod host_bridge;
+pub mod lookup_table;
+
+pub use host_bridge::IBusHostBridge;
+pub use lookup_table::LookupTable;

--- a/crates/kotoha-engine-ibus/src/lookup_table.rs
+++ b/crates/kotoha-engine-ibus/src/lookup_table.rs
@@ -1,0 +1,121 @@
+//! `LookupTable` — IBus 1.x の `update_lookup_table` 全置換制約に対応する
+//! `Mutex<Vec<Candidate>>` 内部 buffer。
+//!
+//! Phase 3-A spec §4.2 mapping 表に従い、`CandidateUpdate::Append` /
+//! `Remove` / `Clear` を internal buffer mutate + `Replace` 相当の全置換
+//! call に変換する。
+
+use std::sync::Mutex;
+
+use kotoha_core::Candidate;
+use kotoha_engine_core::CandidateUpdate;
+
+/// IBus 用 lookup table buffer。`Mutex` poison は
+/// `unwrap_or_else(PoisonError::into_inner)` で取扱う(PR #111 規約)。
+#[derive(Debug, Default)]
+pub struct LookupTable {
+    candidates: Mutex<Vec<Candidate>>,
+}
+
+impl LookupTable {
+    pub fn new() -> Self {
+        Self {
+            candidates: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// `CandidateUpdate` を内部 buffer に適用する。
+    ///
+    /// # Postconditions
+    ///
+    /// - 戻り値は IBus に send すべき全置換 candidate Vec(visible 判定とは別 flag)
+    /// - `Clear` は空 Vec を返す
+    pub fn apply(&self, update: CandidateUpdate) -> Vec<Candidate> {
+        let mut guard = self
+            .candidates
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match update {
+            CandidateUpdate::Replace(c) => *guard = c,
+            CandidateUpdate::Append(c) => guard.extend(c),
+            CandidateUpdate::Remove(r) => {
+                let len = guard.len();
+                let start = r.start.min(len);
+                let end = r.end.min(len);
+                if start < end {
+                    guard.drain(start..end);
+                }
+            }
+            CandidateUpdate::Clear => guard.clear(),
+            // `CandidateUpdate` は non_exhaustive(spec §4.2、Phase 5 で variant 追加余地)。
+            // 未知 variant が来た場合は IBus 側から見ると no-op で扱い、tracing で観測する。
+            other => tracing::warn!(?other, "unknown CandidateUpdate variant; treating as no-op"),
+        }
+        guard.clone()
+    }
+
+    /// 内部 buffer を直接 clear する(focus_out 等で host 側から強制 reset)。
+    pub fn clear(&self) {
+        self.candidates
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// spec §4.2 mapping: Replace で全置換
+    #[test]
+    fn replace_fully_replaces_buffer() {
+        let t = LookupTable::new();
+        let r1 = t.apply(CandidateUpdate::Replace(vec![Candidate::new("a", 0.0)]));
+        assert_eq!(r1.len(), 1);
+        let r2 = t.apply(CandidateUpdate::Replace(vec![Candidate::new("b", 0.0)]));
+        assert_eq!(r2.len(), 1);
+        assert_eq!(r2[0].surface, "b");
+    }
+
+    /// spec §4.2 mapping: Append で末尾追加
+    #[test]
+    fn append_extends_buffer() {
+        let t = LookupTable::new();
+        t.apply(CandidateUpdate::Replace(vec![Candidate::new("a", 0.0)]));
+        let r = t.apply(CandidateUpdate::Append(vec![Candidate::new("b", 0.0)]));
+        assert_eq!(r.len(), 2);
+    }
+
+    /// spec §4.2 mapping: Remove で範囲削除
+    #[test]
+    fn remove_drops_range() {
+        let t = LookupTable::new();
+        t.apply(CandidateUpdate::Replace(vec![
+            Candidate::new("a", 0.0),
+            Candidate::new("b", 0.0),
+            Candidate::new("c", 0.0),
+        ]));
+        let r = t.apply(CandidateUpdate::Remove(1..3));
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].surface, "a");
+    }
+
+    /// spec §4.2 mapping: Clear で空化
+    #[test]
+    fn clear_empties_buffer() {
+        let t = LookupTable::new();
+        t.apply(CandidateUpdate::Replace(vec![Candidate::new("a", 0.0)]));
+        let r = t.apply(CandidateUpdate::Clear);
+        assert!(r.is_empty());
+    }
+
+    /// 範囲 out-of-bounds は clamp(panic 禁止)
+    #[test]
+    fn remove_out_of_bounds_clamps() {
+        let t = LookupTable::new();
+        t.apply(CandidateUpdate::Replace(vec![Candidate::new("a", 0.0)]));
+        let r = t.apply(CandidateUpdate::Remove(5..10));
+        assert_eq!(r.len(), 1); // 変化なし
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3-A spec §3.1 で凍結された adapter layer の新 crate を追加。本 PR (M4) では `IMEHostBridge` の IBus 1.x 実装 skeleton + `LookupTable` 内部 buffer (Mutex<Vec<Candidate>>) を確定させ、D-Bus binding は M5 で zbus 経由で接続する。

- 新 crate `kotoha-engine-ibus`
- `LookupTable`: spec §4.2 mapping (Replace/Append/Remove/Clear + non-exhaustive 対応)
- `IBusHostBridge`: `IMEHostBridge` impl skeleton (D-Bus call は M5 で zbus 経由実装)
- `zbus = "5"` workspace dep 追加 (default features = async-io + blocking-api)

## Test plan

- [x] lefthook pre-push 全 stage PASS
- [x] lookup_table 5 unit test PASS
- [x] gitleaks clean
- [x] full workspace 0 regression

## Notes

- zbus は default features (async-io + p2p) を使用。GTK/dbus-rs を避け pure-Rust で構築。
- `Mutex` poison は `unwrap_or_else(PoisonError::into_inner)` (PR #111 規約)。

Refs #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)