### PR TITLE
feat(bin): kotoha-bin + L2 integration + glossary + ADRs (P3-A M6 wrap-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kotoha-bin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "kotoha-core",
+ "kotoha-engine-core",
+ "kotoha-engine-ibus",
+ "kotoha-storage",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kotoha-cli"
 version = "0.1.0"
 dependencies = [
@@ -938,6 +951,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +997,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1434,6 +1465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1684,35 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/kotoha-storage",
     "crates/kotoha-engine-core",
     "crates/kotoha-engine-ibus",
+    "crates/kotoha-bin",
 ]
 
 [workspace.package]

--- a/crates/kotoha-bin/Cargo.toml
+++ b/crates/kotoha-bin/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "kotoha-bin"
+description = "Kotoha IME entry binary (Phase 3-A spec §3.1)"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "kotoha"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+kotoha-engine-core = { path = "../kotoha-engine-core" }
+kotoha-engine-ibus = { path = "../kotoha-engine-ibus" }
+kotoha-storage = { path = "../kotoha-storage" }
+kotoha-core = { path = "../kotoha-core" }

--- a/crates/kotoha-bin/src/host_detect.rs
+++ b/crates/kotoha-bin/src/host_detect.rs
@@ -1,0 +1,15 @@
+//! Host detection logic — Phase 3-A 初期は IBus 固定。
+//!
+//! Phase 4 fcitx5 adapter 増設時に env var(`XDG_CURRENT_DESKTOP` /
+//! `IM_MODULE` 等)+ D-Bus name 確認で分岐する(spec §3.2 / §13 Open Q 8)。
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectedHost {
+    IBus,
+    // Phase 4: Fcitx5,
+}
+
+/// 現在 host を検出する。Phase 3-A 初期は常に `IBus` を返す。
+pub fn detect() -> DetectedHost {
+    DetectedHost::IBus
+}

--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -1,0 +1,126 @@
+//! Kotoha IME entry binary。
+//!
+//! Phase 3-A spec §3.3 全体図の DI sequence を実装する:
+//!
+//! 1. tracing init(env var `KOTOHA_LOG`、default `info`)
+//! 2. host detect(P3-A: IBus 固定)
+//! 3. DB 配置 path 解決(`kotoha-storage::path::resolve_data_dir`)
+//! 4. `Database::open` で SQLite 接続
+//! 5. `SqliteUserVocabStore` / `SqliteLearningCacheStore` 構築
+//! 6. `MorphologicalEngine` / LLM backend 構築(本 PR は Stub で wiring 確立)
+//! 7. `HybridRanker::new(...).with_llm(llm)`
+//! 8. `IBusHostBridge::new(object_path)` で session bus 接続
+//! 9. `KotohaEngine::new(host, ranker, learning_writer)`
+//! 10. `IBusEventDispatcher::new(engine)` で event loop 起動 stub
+//!
+//! 実 D-Bus event loop(`zbus::blocking::MessageStream` 経由の signal
+//! receive + dispatch)は spec §13 Open Q 9 通り Phase 3-A 実装段階で
+//! empirical に詳細化する。本 binary は **DI sequence + tracing log で
+//! 起動確認可能な状態** を成果物とする。
+
+use std::sync::mpsc;
+use std::sync::Arc;
+
+use anyhow::Context;
+use tracing_subscriber::EnvFilter;
+
+mod host_detect;
+
+const ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
+const KOTOHA_LOG_ENV: &str = "KOTOHA_LOG";
+
+fn main() -> anyhow::Result<()> {
+    init_tracing();
+    let host = host_detect::detect();
+    tracing::info!(?host, "kotoha-bin starting");
+
+    match host {
+        host_detect::DetectedHost::IBus => run_ibus()?,
+    }
+    Ok(())
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_env(KOTOHA_LOG_ENV).unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+}
+
+fn run_ibus() -> anyhow::Result<()> {
+    // 3. DB 配置 path
+    let db_path = kotoha_storage::path::resolve_data_dir().context("resolve kotoha.db path")?;
+    tracing::info!(path = %db_path.display(), "opening database");
+
+    // 4. DB open
+    let db = kotoha_storage::database::Database::open(&db_path).context("open kotoha.db")?;
+
+    // 5. stores
+    let _user_vocab_store = Arc::new(kotoha_storage::user_vocab::SqliteUserVocabStore::new(
+        db.clone(),
+    ));
+    let learning_store =
+        Arc::new(kotoha_storage::learning_cache::SqliteLearningCacheStore::new(db.clone()));
+
+    // 6 + 7. Ranker (P3-A M6 では DI sequence 確立に focus、
+    // production の MorphologicalEngine / LLM 統合は L3 manual smoke 段階で
+    // 詰める。本段階では `StubRanker` を暫定で構築)。
+    let ranker: Arc<dyn kotoha_engine_core::Ranker> = Arc::new(StubRanker);
+
+    // 8. host bridge: session bus 接続。失敗時は stub に fallback して engine
+    // 自体は起動可能にする(L3 manual smoke 段階で実 IBus 接続を検証)。
+    let host_bridge: Box<dyn kotoha_engine_core::IMEHostBridge> =
+        match kotoha_engine_ibus::IBusHostBridge::new(ENGINE_OBJECT_PATH) {
+            Ok(b) => Box::new(b),
+            Err(e) => {
+                tracing::warn!(error = %e, "IBus session bus connect failed; using stub host_bridge");
+                Box::new(StubHostBridge)
+            }
+        };
+
+    // 9. engine
+    let engine = kotoha_engine_core::engine::KotohaEngine::new(host_bridge, ranker, learning_store);
+
+    // 10. dispatcher (event loop stub)
+    let _dispatcher = kotoha_engine_ibus::IBusEventDispatcher::new(engine);
+
+    tracing::info!("kotoha engine wired up; event loop deferred to Phase 3-A L3 manual smoke");
+    Ok(())
+}
+
+/// 暫定 stub ranker(P3-A M6 段階)。
+///
+/// Phase 3-A 実装段階で実 `HybridRanker::new(SudachiAdapter, ...)` に置換される。
+/// 本 stub は `rank()` 内で何も送らず、空候補で完結する Ranker として動く。
+struct StubRanker;
+
+impl kotoha_engine_core::Ranker for StubRanker {
+    fn rank(
+        &self,
+        _kana: &str,
+        _ctx: &kotoha_engine_core::ConversionContext,
+        _cancel: Arc<dyn kotoha_engine_core::CancellationToken>,
+        _sink: mpsc::Sender<kotoha_engine_core::RankerOutput>,
+    ) -> Result<(), kotoha_engine_core::RankerError> {
+        Ok(())
+    }
+}
+
+/// 暫定 stub host bridge(session bus 接続失敗時の fallback)。
+struct StubHostBridge;
+
+impl kotoha_engine_core::IMEHostBridge for StubHostBridge {
+    fn update_preedit(&self, text: &str, cursor: usize, visible: bool) {
+        tracing::trace!(text, cursor, visible, "stub update_preedit");
+    }
+    fn commit_text(&self, text: &str) {
+        tracing::trace!(text, "stub commit_text");
+    }
+    fn update_candidates(&self, _update: kotoha_engine_core::CandidateUpdate) {
+        tracing::trace!("stub update_candidates");
+    }
+    fn show_candidate_window(&self) {
+        tracing::trace!("stub show_candidate_window");
+    }
+    fn hide_candidate_window(&self) {
+        tracing::trace!("stub hide_candidate_window");
+    }
+}

--- a/crates/kotoha-engine-core/tests/integration_l2_core.rs
+++ b/crates/kotoha-engine-core/tests/integration_l2_core.rs
@@ -1,0 +1,119 @@
+//! L2-core integration test: KotohaEngine 4 代表シナリオ(spec §10.3)。
+//!
+//! - typing → space → commit (Enter)
+//! - backspace
+//! - focus_out
+//! - Esc on candidates
+
+#![cfg(feature = "test-helpers")]
+
+use std::sync::Arc;
+
+use kotoha_core::Candidate;
+use kotoha_engine_core::engine::transitions::keysyms;
+use kotoha_engine_core::engine::KotohaEngine;
+use kotoha_engine_core::ime_engine::IMEEngine;
+use kotoha_engine_core::key_event::{KeyEvent, KeyModifiers};
+use kotoha_engine_core::testing::{HostOperation, MockHostBridge, MockRanker};
+
+#[derive(Default)]
+struct StubWriter;
+impl kotoha_storage::learning_cache::LearningCacheWriter for StubWriter {
+    fn record_choice(
+        &self,
+        _kana: &str,
+        _kanji: &str,
+    ) -> Result<(), kotoha_storage::error::StorageError> {
+        Ok(())
+    }
+    fn evict_lru(&self, _max_entries: usize) -> Result<usize, kotoha_storage::error::StorageError> {
+        Ok(0)
+    }
+}
+
+fn key_char(c: char) -> KeyEvent {
+    KeyEvent {
+        keysym: c as u32,
+        keycode: 0,
+        modifiers: KeyModifiers::empty(),
+    }
+}
+
+fn key_special(keysym: u32) -> KeyEvent {
+    KeyEvent {
+        keysym,
+        keycode: 0,
+        modifiers: KeyModifiers::empty(),
+    }
+}
+
+fn build(candidates: Vec<Candidate>) -> (KotohaEngine, MockHostBridge) {
+    let host = MockHostBridge::new();
+    let host_clone = host.clone();
+    let ranker = Arc::new(MockRanker::new(candidates));
+    let writer = Arc::new(StubWriter);
+    let mut eng = KotohaEngine::new(Box::new(host_clone), ranker, writer);
+    eng.enable();
+    eng.focus_in();
+    (eng, host)
+}
+
+/// Scenario A: typing「kotoha」(7 chars)→ space → top 候補 Enter で commit_text 観測
+#[test]
+fn scenario_typing_space_enter() {
+    let (mut eng, host) = build(vec![Candidate::new("琴葉", -1.0)]);
+    for c in "kotoha".chars() {
+        eng.process_key_event(key_char(c));
+    }
+    eng.process_key_event(key_special(keysyms::SPACE));
+    eng.process_key_event(key_special(keysyms::RETURN));
+    let ops = host.operations();
+    assert!(
+        ops.iter()
+            .any(|o| matches!(o, HostOperation::CommitText(s) if s == "琴葉")),
+        "expected CommitText('琴葉') in {ops:?}"
+    );
+}
+
+/// Scenario B: typing → backspace で preedit shrink、再 typing で kana 出力が継続する
+#[test]
+fn scenario_typing_backspace_typing() {
+    let (mut eng, _host) = build(vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_special(keysyms::BACKSPACE));
+    eng.process_key_event(key_char('a'));
+    // preedit が空→「あ」に変化(『か』→『』→『あ』)
+    assert_eq!(eng.preedit_for_test(), "あ");
+}
+
+/// Scenario C: focus_out で全 clear + state Idle
+#[test]
+fn scenario_focus_out_clears() {
+    let (mut eng, host) = build(vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_special(keysyms::SPACE));
+    eng.focus_out();
+    let ops = host.operations();
+    assert!(ops
+        .iter()
+        .any(|o| matches!(o, HostOperation::HideCandidateWindow)));
+    assert!(eng.preedit_for_test().is_empty());
+}
+
+/// Scenario D: CandidatesShown で Esc → preedit kana 維持で LiveConverting に戻る
+#[test]
+fn scenario_esc_on_candidates_back_to_live() {
+    let (mut eng, host) = build(vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_special(keysyms::SPACE));
+    host.clear();
+    eng.process_key_event(key_special(keysyms::ESCAPE));
+    assert_eq!(eng.preedit_for_test(), "か");
+    let ops = host.operations();
+    assert!(ops
+        .iter()
+        .any(|o| matches!(o, HostOperation::HideCandidateWindow)));
+}

--- a/docs/adr/0017-ibus-engine-api-surface-and-async-modality.md
+++ b/docs/adr/0017-ibus-engine-api-surface-and-async-modality.md
@@ -1,0 +1,41 @@
+# ADR 0017: IBus engine API surface and async modality
+
+## Status
+
+Accepted (2026-05-02)
+
+## Context
+
+Phase 3-A IBus engine 実装で、core engine layer (`kotoha-engine-core`) が host 層
+(IBus / fcitx5 / 将来) に対してどの粒度で API を出すべきか、また async runtime
+(tokio) を core 側で要求するかを決める必要があった。
+
+## Decision
+
+- **2 trait port 構成**: driving port `IMEEngine`(host → engine)と
+  driven port `IMEHostBridge`(engine → host)の 2 trait に分離する。
+  `IMEEngine` は `Send` のみ要求(event loop 単一 thread 前提)、
+  `IMEHostBridge` は `Send + Sync` 要求(engine 主 thread と `RankerWorker`
+  thread の双方から呼ばれる)。
+- **Async runtime 非依存**: core 層は tokio 等の async runtime に直接依存しない。
+  channel-based plumbing は `std::sync::mpsc` + dedicated `std::thread` で構築する。
+  `CancellationToken` は自作 trait + `StdCancellationToken` impl とし、Phase 5/6 で
+  tokio runtime を導入する場合は別 crate で `TokioCancellationToken` adapter を
+  提供する。
+
+## Consequences
+
+- IBus / fcitx5 / 将来の input-method protocol は adapter crate
+  (`kotoha-engine-ibus` / `kotoha-engine-fcitx5`)の追加 / 差し替えだけで
+  対応可能(boundary-first 原則)。
+- core 単独 unit test が host adapter 不要(`MockHostBridge` 注入)で実現可能。
+- async runtime を要求する Phase 5 機能(beam search 並列化等)は adapter 層 /
+  別 crate で対応し、core は std 経路を維持する。
+- 副作用として、blocking API 中心の zbus 5.x 経路を選び、tokio 依存を避けた
+  (P3-A M5 の zbus dep `default features` 採用根拠)。
+
+## References
+
+- Phase 3-A spec `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` §3 / §4
+- ADR 0011: kanji backend trait design(trait ベース DI の前例)
+- Adaptive boundary-first 原則(`feedback_adaptive_boundary_first.md`)

--- a/docs/adr/0018-ranker-invocation-contract.md
+++ b/docs/adr/0018-ranker-invocation-contract.md
@@ -1,0 +1,43 @@
+# ADR 0018: Ranker invocation contract
+
+## Status
+
+Accepted (2026-05-02)
+
+## Context
+
+Phase 3-A engine が `Ranker::rank()` を呼ぶ contract と、その背景の
+`RankerWorker` thread / coalescing / cancel propagation 規約を確定する必要があった。
+
+## Decision
+
+- **同期 `rank()` + 内部 thread dispatch**: `Ranker::rank()` は同期に return し、
+  heavy lifting は impl 内部で thread / async に dispatch する。engine 主 thread は
+  blocking しない。`mpsc::Sender<RankerOutput>` は impl 側に move される。
+- **Coalescing window**: typing 中(`Live`)は 7ms primary、space 後(`Commit`)は
+  30ms primary + 150ms secondary の 2 段 window で候補を集約する。値の細部は
+  Phase 3-A 実装段階で empirical 調整する(spec §13 Open Q 2、ADR 改訂不要)。
+- **request_id mismatch discard**: engine 採番の単調増加 64-bit ID で stale
+  response を識別し、worker レベル(fast path)+ engine 主 thread レベル
+  (safety net)の両側で discard する(layered defense、spec §7.5)。
+- **Cancel propagation**: `CancellationToken` を `Arc<dyn>` で 5 trigger
+  (focus_out / preedit edit / 連続 space / Esc / `IMEEngine::reset`)から fire し、
+  backend 別 latency は SudachiDict 即 / UserVocab 即 / LearningCache 即 / LLM
+  10 token check を許容する(spec §8.2)。
+
+## Consequences
+
+- `HybridRanker` impl はその内部で更に下位 thread / async を起動する自由度を持つ
+  (P2-D で `std::thread::spawn` ベースの parallel backend dispatch を採用)。
+- coalescing 値は実装段階で empirical に確定(spec §13 Open Q 2)、本 ADR は
+  「2 段 window 構造」を凍結し、定数値の調整は ADR 改訂不要とする。
+- LLM cancel 漏れ token は計算 cost が無駄になるが UX 影響なしとして許容する。
+- Phase 3-A engine の coalescing window 細部は `LIVE_WINDOW` / `COMMIT_WINDOW`
+  / `COMMIT_SECOND_WINDOW` constants(`crates/kotoha-engine-core/src/engine/worker.rs`)
+  を tweak することで調整可能。
+
+## References
+
+- Phase 3-A spec `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` §4.3 / §7 / §8
+- ADR 0011: KanjiBackend の sync API 前例(下位 async 持ち込みなし)
+- ADR 0017: 2 trait port + async runtime 非依存(本 ADR は §7 / §8 規約を補完)

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -1,0 +1,65 @@
+# Phase 3-A IBus engine integration — implementation log
+
+| 項目 | 値 |
+|------|----|
+| ISSUE | #128 |
+| 期間 | 2026-05-02 〜(L3 manual smoke 完了時に更新) |
+| 関連 spec | `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` |
+| 関連 plan | `docs/superpowers/plans/2026-05-02-feature-128-p3a-engine-implementation.md` |
+
+## Milestone 結果
+
+| # | Milestone | PR | branch |
+|---|---|---|---|
+| M1 | engine-core types + traits + Mock infra | #130 | `feature/128-p3a-m1-traits-and-mocks` |
+| M2 | KotohaEngine 状態機械 (synchronous Ranker) | #131 | `feature/128-p3a-m2-state-machine` |
+| M3 | RankerWorker + coalescing + cancel propagation | #132 | `feature/128-p3a-m3-ranker-worker` |
+| M4 | kotoha-engine-ibus skeleton + IBusHostBridge | #133 | `feature/128-p3a-m4-ibus-host-bridge` |
+| M5 | IBusEventDispatcher + zbus binding | #134 | `feature/128-p3a-m5-ibus-dispatcher` |
+| M6 | kotoha-bin + L2 + glossary + ADRs | (本 PR) | `feature/128-p3a-m6-bin-and-tests` |
+
+## Test count
+
+| timing | engine-core unit | engine-core integration | engine-ibus | full workspace |
+|--------|------------------|-------------------------|-------------|----------------|
+| baseline (P2-D 直後) | 17 | 27 | — | 416 |
+| M1 後 | 21 | 27 | — | 420 |
+| M2 後 | 24 | 35 | — | 431 |
+| M3 後 | 24 | 37 | — | 433 |
+| M4 後 | 24 | 37 | 5 | 438 |
+| M5 後 | 24 | 37 | 9 | 442 |
+| M6 後(本 PR) | 24 | 41 (+ L2-core 4) | 9 | 446 |
+
+## L3 manual smoke 結果
+
+GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 application で典型変換を確認する。本 PR では skeleton として枠を確保し、実機検証は Phase 3-A 実装段階で詳細化する。
+
+- [ ] Firefox URL bar / textarea で 5 件
+- [ ] GNOME Text Editor で 3 件
+- [ ] VS Code editor で 2 件
+- [ ] flicker observation(spec §13 Open Q 3)
+
+## 残 Open Questions(spec §13 由来)
+
+| # | 暫定値 | 実装段階での確定 method | 結果 |
+|---|--------|------------------------|------|
+| 1 | commit_history 200 chars | 100 / 200 / 400 で AB test | TBD |
+| 2 | coalescing Live 7ms / Commit 30ms | IBus host 描画 frame rate と実機 measure | TBD |
+| 3 | IBus update_lookup_table flicker | 連続 update 観察 | TBD |
+| 4 | LLM cancel 10 token check | metrics 観測 | TBD |
+| 7 | typing 中 LLM invocation | empirical 観測 | TBD |
+| 8 | KeyModifiers full mapping | IBus IBusModifierType 全列挙 | TBD |
+| 9 | adapter Mutex<Vec<Candidate>> 競合 | multi-thread 化必要時に再評価 | TBD |
+| 9 (D-Bus body) | `IBusText` / `IBusLookupTable` marshalling | L3 manual smoke で `connection.send_signal` body 確定 | TBD |
+
+## 主要 deferral 事項
+
+本 P3-A 実装で確立されたが Phase 3-A 実装段階の L3 manual smoke で詳細化する事項:
+
+- `IBusEngineSignals` の signal body 完全 marshalling(`IBusText` struct
+  D-Bus type の正確 serialize)
+- `IBusEventDispatcher` の D-Bus signal listener loop(`zbus::blocking::MessageStream`
+  経由の signal receive)
+- `kotoha-bin` の production `MorphologicalEngine` / LLM backend 統合
+  (本 PR は StubRanker で wiring のみ確立)
+- Phase 1 14/15 regression engine wrap test の本格実装

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -379,6 +379,36 @@
 - **対応する identifier**: `kotoha_engine_core::ranker::HybridRanker`(`crates/kotoha-engine-core/src/ranker/hybrid.rs`)
 - **備考**: LLM backend は `Option<Arc<dyn KanjiBackend>>` で None なら dict-only で動作。Live mode は best-effort、Commit mode は LLM 完了まで待機する設計だが、token-level cancel propagation(spec §13 Open Q 4)は Phase 3-A 本番実装で対応する。
 
+### KotohaEngine
+
+- **定義**: Phase 3-A spec §5 で凍結された core engine 状態機械。`IMEEngine` driving port を impl し、`Idle` / `LiveConverting` / `CommitConverting` / `CandidatesShown` 4 状態を遷移する。`RankerWorker` 背景 thread + cancel propagation 5 trigger を内部で扱い、`IMEHostBridge` driven port 経由で host 層に preedit / 候補 / commit を出力する。
+- **初出**: P3-A Milestone 2(2026-05-02、ISSUE #128 / branch `feature/128-p3a-m2-state-machine`)
+- **対応する identifier**: `kotoha_engine_core::engine::KotohaEngine`(`crates/kotoha-engine-core/src/engine/mod.rs`)
+
+### IMEEngine
+
+- **定義**: Phase 3-A spec §4.1 で凍結された driving port trait。host adapter(IBus / fcitx5)が engine に対して呼び出す API surface(`process_key_event` / `focus_in/out` / `enable/disable` / `reset`)。`Send` のみ要求、`Sync` は不要(event loop 単一 thread 前提)。
+- **初出**: P3-A Milestone 1(2026-05-02、ISSUE #128 / branch `feature/128-p3a-m1-traits-and-mocks`)
+- **対応する identifier**: `kotoha_engine_core::ime_engine::IMEEngine`(`crates/kotoha-engine-core/src/ime_engine.rs`)
+
+### IMEHostBridge
+
+- **定義**: Phase 3-A spec §4.2 で凍結された driven port trait。engine が host adapter に対して呼び出す API surface(`update_preedit` / `commit_text` / `update_candidates` / `show_candidate_window` / `hide_candidate_window`)。`Send + Sync` を要求(engine 主 thread + `RankerWorker` thread の双方から呼ばれる)。
+- **初出**: P3-A Milestone 1(2026-05-02、ISSUE #128 / branch `feature/128-p3a-m1-traits-and-mocks`)
+- **対応する identifier**: `kotoha_engine_core::host_bridge::IMEHostBridge`(`crates/kotoha-engine-core/src/host_bridge.rs`)
+
+### RankerWorker
+
+- **定義**: Phase 3-A spec §7 の dedicated background thread。engine 主 thread から `RankRequest` を mpsc channel で受領し、`Ranker::rank` を呼び出して coalescing window(Live 7ms / Commit 30ms + second 150ms)で候補を集約後、`EngineEvent::Candidates` で engine 主 thread に push する。spec §7.5 request_id mismatch discard で stale response を除去する。
+- **初出**: P3-A Milestone 3(2026-05-02、ISSUE #128 / branch `feature/128-p3a-m3-ranker-worker`)
+- **対応する identifier**: `kotoha_engine_core::engine::worker`(`crates/kotoha-engine-core/src/engine/worker.rs`)
+
+### Coalescing window
+
+- **定義**: Phase 3-A spec §7.3 の動的 buffer 集約 window。Live mode は typing 応答性優先で 5-10ms、Commit mode は LLM 結果待機で 30ms + second 150ms。spec §13 Open Q 2 で実装段階に IBus host 描画 frame rate 計測と合わせて empirical 確定する。
+- **初出**: P3-A Milestone 3(2026-05-02、ISSUE #128 / branch `feature/128-p3a-m3-ranker-worker`)
+- **対応する identifier**: `LIVE_WINDOW` / `COMMIT_WINDOW` / `COMMIT_SECOND_WINDOW` constants(`crates/kotoha-engine-core/src/engine/worker.rs`)
+
 ## 5. LLM 推論とプロンプト
 
 ### PromptTemplate


### PR DESCRIPTION
## Summary

Phase 3-A 全 milestone を完成させる wrap-up PR。entry binary `kotoha` で 9-step DI sequence を確立し、L2-core integration test 4 シナリオ + glossary 5 entry + ADR 0017/0018 + WBS 実装ログ skeleton を同梱する。**Closes #128.**

- 新 crate `kotoha-bin` (binary `kotoha`): tracing init + host detect + DI sequence
- L2-core 4 シナリオ:typing→space→Enter / typing→backspace→typing / focus_out / Esc on candidates
- glossary 5 entry: KotohaEngine / IMEEngine / IMEHostBridge / RankerWorker / Coalescing window
- ADR 0017 (engine API surface and async modality)
- ADR 0018 (Ranker invocation contract)
- WBS 実装ログ (M1-M6 PR/branch summary + L3 smoke 受け入れ枠)

## Test plan

- [x] lefthook pre-push 全 stage PASS
- [x] full workspace 446 PASS (baseline 416 → +30, 0 regression)
- [x] `cargo build --workspace` 全 crate (kotoha-bin 含む) build 成功
- [x] gitleaks clean

## Test count breakdown

| Layer | count |
|---|---|
| engine-core unit | 24 |
| engine-core integration | 41 |
| engine-ibus | 9 |
| その他既存 | 372 |
| **total** | **446** |

## Deferred to L3 manual smoke phase

本 PR で wiring + skeleton を確立し、以下は Phase 3-A 実装段階の L3 manual smoke で詳細化する(spec §13 Open Q 9):

- IBus D-Bus signal body (`IBusText` / `IBusLookupTable`) の完全 marshalling
- `IBusEventDispatcher` の `zbus::blocking::MessageStream` 経由 signal listener loop
- `kotoha-bin` の production `MorphologicalEngine` / 実 LLM 統合(現在は StubRanker)
- Phase 1 14/15 regression engine wrap test の本格実装

## References

- Spec: `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-feature-128-p3a-engine-implementation.md` Milestone 6
- M1-M5 PRs: #130, #131, #132, #133, #134

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)