### PR TITLE
feat: KeyModifiers full IBus mapping + RELEASE event handling (P3-B B4)

### DIFF
--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -251,6 +251,14 @@ impl IMEEngine for KotohaEngine {
         if !self.enabled || !self.focused {
             return KeyEventResult::Forwarded;
         }
+        // RELEASE event は engine が処理しない(IBus は press/release 双方を渡すため、
+        // press path のみで状態遷移を駆動する。Phase 3-B B4)。
+        if key
+            .modifiers
+            .contains(crate::key_event::KeyModifiers::RELEASE)
+        {
+            return KeyEventResult::Forwarded;
+        }
         // Commit mode second window などで遅延到着した event を最初に取り込む。
         self.drain_pending_events();
         transitions::dispatch_key(self, key)

--- a/crates/kotoha-engine-core/src/key_event.rs
+++ b/crates/kotoha-engine-core/src/key_event.rs
@@ -26,14 +26,26 @@ pub struct KeyEvent {
 }
 
 bitflags! {
-    /// Keystroke 同伴 modifier。Phase 3-A 初期は IBus IBusModifierType の
-    /// 主要 4 種のみ(spec §13 Open Q 8 で残余は実装段階対応)。
+    /// Keystroke 同伴 modifier。IBus `IBusModifierType` の主要 flag を網羅する
+    /// (Phase 3-B B4、ISSUE #136、spec §13 Open Q 8 解決)。bit 位置は IBus 由来
+    /// ではなく自前序数で持ち、IBus → 本 enum mapping は host adapter 層で行う。
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct KeyModifiers: u32 {
-        const SHIFT = 1 << 0;
-        const CTRL  = 1 << 1;
-        const ALT   = 1 << 2;
-        const SUPER = 1 << 3;
+        const SHIFT   = 1 << 0;
+        const LOCK    = 1 << 1;  // Caps Lock
+        const CTRL    = 1 << 2;
+        const ALT     = 1 << 3;  // Mod1 (Alt)
+        const MOD2    = 1 << 4;  // Num Lock(典型)
+        const MOD3    = 1 << 5;
+        const MOD4    = 1 << 6;
+        const MOD5    = 1 << 7;
+        const SUPER   = 1 << 8;
+        const HYPER   = 1 << 9;
+        const META    = 1 << 10;
+        /// IBus `IBUS_RELEASE_MASK` 相当。`process_key_event` 受領側は本 flag が
+        /// 立っている event を **release event** として識別し、典型的には
+        /// `KeyEventResult::Forwarded` に短絡する。
+        const RELEASE = 1 << 11;
     }
 }
 

--- a/crates/kotoha-engine-core/tests/state_transitions.rs
+++ b/crates/kotoha-engine-core/tests/state_transitions.rs
@@ -161,6 +161,30 @@ fn idle_backspace_is_forwarded() {
     assert_eq!(eng.state_for_test(), EngineState::Idle);
 }
 
+/// Phase 3-B B4: RELEASE flag 付き event は engine 不処理 (Forwarded、状態変化なし)
+#[test]
+fn release_event_is_forwarded_without_state_change() {
+    let (mut eng, host, _w) = build_engine(vec![Candidate::new("か", -1.0)]);
+    // 通常 press で「か」を入れる
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    let state_before = eng.state_for_test();
+    let preedit_before = eng.preedit_for_test();
+    host.clear();
+    // RELEASE event を投入
+    let release = KeyEvent {
+        keysym: 'a' as u32,
+        keycode: 0,
+        modifiers: KeyModifiers::RELEASE,
+    };
+    let r = eng.process_key_event(release);
+    assert_eq!(r, KeyEventResult::Forwarded);
+    assert_eq!(eng.state_for_test(), state_before);
+    assert_eq!(eng.preedit_for_test(), preedit_before);
+    // host にも何も呼ばれていない
+    assert!(host.operations().is_empty());
+}
+
 /// spec §5.2: CandidatesShown + ↓ → highlight_idx 移動 (Ranker 再起動なし)
 #[test]
 fn candidates_navigation_moves_highlight() {

--- a/crates/kotoha-engine-ibus/src/keysym.rs
+++ b/crates/kotoha-engine-ibus/src/keysym.rs
@@ -1,21 +1,30 @@
 //! IBus keysym(X11 keysym 互換)→ `KeyEvent` 変換 helper。
 //!
-//! IBus は KeyPress signal で `(keysym: u32, keycode: u32, state: u32)` を渡す。
-//! `state` は `IBusModifierType` flag bitfield。本 module は state を
+//! IBus は KeyPress / KeyRelease signal で `(keysym: u32, keycode: u32, state: u32)`
+//! を渡す。`state` は `IBusModifierType` flag bitfield。本 module は state を
 //! `KeyModifiers` に変換する。
 
 use kotoha_engine_core::{KeyEvent, KeyModifiers};
 
-/// IBusModifierType の主要 flag(spec §13 Open Q 8 で完全 mapping は
-/// 後続 task)。
+/// `IBusModifierType` の主要 flag(spec §13 Open Q 8、Phase 3-B B4 で網羅)。
+///
+/// 参照:`ibus/ibus/ibustypes.h` の `IBusModifierType` enum
 mod ibus_state {
     pub const SHIFT_MASK: u32 = 1 << 0;
+    pub const LOCK_MASK: u32 = 1 << 1; // Caps Lock
     pub const CONTROL_MASK: u32 = 1 << 2;
     pub const MOD1_MASK: u32 = 1 << 3; // Alt
+    pub const MOD2_MASK: u32 = 1 << 4; // Num Lock(典型)
+    pub const MOD3_MASK: u32 = 1 << 5;
+    pub const MOD4_MASK: u32 = 1 << 6;
+    pub const MOD5_MASK: u32 = 1 << 7;
     pub const SUPER_MASK: u32 = 1 << 26;
+    pub const HYPER_MASK: u32 = 1 << 27;
+    pub const META_MASK: u32 = 1 << 28;
+    pub const RELEASE_MASK: u32 = 1 << 30;
 }
 
-/// IBus KeyPress signal の生 args から `KeyEvent` を構築する。
+/// IBus KeyPress / KeyRelease signal の生 args から `KeyEvent` を構築する。
 ///
 /// # Preconditions
 ///
@@ -23,11 +32,16 @@ mod ibus_state {
 ///
 /// # Postconditions
 ///
-/// - 主要 4 flag(Shift / Ctrl / Alt / Super)が `KeyModifiers` に mapping される
+/// - 戻り値の `modifiers` は IBus state flag を `KeyModifiers` に 1:1 mapping した結果
+/// - `RELEASE_MASK` が set されている場合は `KeyModifiers::RELEASE` を立てる
+///   (engine 側で release event を Forwarded に短絡する判断材料)
 pub fn from_ibus(keysym: u32, keycode: u32, state: u32) -> KeyEvent {
     let mut modifiers = KeyModifiers::empty();
     if state & ibus_state::SHIFT_MASK != 0 {
         modifiers |= KeyModifiers::SHIFT;
+    }
+    if state & ibus_state::LOCK_MASK != 0 {
+        modifiers |= KeyModifiers::LOCK;
     }
     if state & ibus_state::CONTROL_MASK != 0 {
         modifiers |= KeyModifiers::CTRL;
@@ -35,8 +49,29 @@ pub fn from_ibus(keysym: u32, keycode: u32, state: u32) -> KeyEvent {
     if state & ibus_state::MOD1_MASK != 0 {
         modifiers |= KeyModifiers::ALT;
     }
+    if state & ibus_state::MOD2_MASK != 0 {
+        modifiers |= KeyModifiers::MOD2;
+    }
+    if state & ibus_state::MOD3_MASK != 0 {
+        modifiers |= KeyModifiers::MOD3;
+    }
+    if state & ibus_state::MOD4_MASK != 0 {
+        modifiers |= KeyModifiers::MOD4;
+    }
+    if state & ibus_state::MOD5_MASK != 0 {
+        modifiers |= KeyModifiers::MOD5;
+    }
     if state & ibus_state::SUPER_MASK != 0 {
         modifiers |= KeyModifiers::SUPER;
+    }
+    if state & ibus_state::HYPER_MASK != 0 {
+        modifiers |= KeyModifiers::HYPER;
+    }
+    if state & ibus_state::META_MASK != 0 {
+        modifiers |= KeyModifiers::META;
+    }
+    if state & ibus_state::RELEASE_MASK != 0 {
+        modifiers |= KeyModifiers::RELEASE;
     }
     KeyEvent {
         keysym,
@@ -71,5 +106,73 @@ mod tests {
         let ev = from_ibus(0x6b, 45, 0);
         assert_eq!(ev.keysym, 0x6b);
         assert_eq!(ev.keycode, 45);
+    }
+
+    /// Caps Lock は LOCK flag に
+    #[test]
+    fn maps_caps_lock() {
+        let ev = from_ibus(0x6b, 45, ibus_state::LOCK_MASK);
+        assert!(ev.modifiers.contains(KeyModifiers::LOCK));
+    }
+
+    /// Num Lock(典型 MOD2)は MOD2 flag に
+    #[test]
+    fn maps_mod2_num_lock() {
+        let ev = from_ibus(0x6b, 45, ibus_state::MOD2_MASK);
+        assert!(ev.modifiers.contains(KeyModifiers::MOD2));
+    }
+
+    /// Super, Hyper, Meta の高位 bit
+    #[test]
+    fn maps_super_hyper_meta() {
+        let ev = from_ibus(
+            0x6b,
+            45,
+            ibus_state::SUPER_MASK | ibus_state::HYPER_MASK | ibus_state::META_MASK,
+        );
+        assert!(ev.modifiers.contains(KeyModifiers::SUPER));
+        assert!(ev.modifiers.contains(KeyModifiers::HYPER));
+        assert!(ev.modifiers.contains(KeyModifiers::META));
+    }
+
+    /// RELEASE_MASK は KeyModifiers::RELEASE に mapping(engine 側 Forwarded 判断材料)
+    #[test]
+    fn maps_release_mask() {
+        let ev = from_ibus(0x6b, 45, ibus_state::RELEASE_MASK);
+        assert!(ev.modifiers.contains(KeyModifiers::RELEASE));
+    }
+
+    /// 全 flag 同時 set でも漏れなく mapping される
+    #[test]
+    fn maps_all_flags_simultaneously() {
+        let state = ibus_state::SHIFT_MASK
+            | ibus_state::LOCK_MASK
+            | ibus_state::CONTROL_MASK
+            | ibus_state::MOD1_MASK
+            | ibus_state::MOD2_MASK
+            | ibus_state::MOD3_MASK
+            | ibus_state::MOD4_MASK
+            | ibus_state::MOD5_MASK
+            | ibus_state::SUPER_MASK
+            | ibus_state::HYPER_MASK
+            | ibus_state::META_MASK
+            | ibus_state::RELEASE_MASK;
+        let ev = from_ibus(0x6b, 45, state);
+        for m in [
+            KeyModifiers::SHIFT,
+            KeyModifiers::LOCK,
+            KeyModifiers::CTRL,
+            KeyModifiers::ALT,
+            KeyModifiers::MOD2,
+            KeyModifiers::MOD3,
+            KeyModifiers::MOD4,
+            KeyModifiers::MOD5,
+            KeyModifiers::SUPER,
+            KeyModifiers::HYPER,
+            KeyModifiers::META,
+            KeyModifiers::RELEASE,
+        ] {
+            assert!(ev.modifiers.contains(m), "missing flag: {m:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase 3-A spec §13 Open Q 8 を解決。`KeyModifiers` を SHIFT/LOCK/CTRL/ALT/MOD2-MOD5/SUPER/HYPER/META/RELEASE の 12 flag に拡張し、IBus IBusModifierType の主要 flag を全て mapping。合わせて IBus が key press / release 双方を engine に渡す前提で、`KotohaEngine::process_key_event` で RELEASE event を `Forwarded` に短絡する。

- core: `KeyModifiers` 12 flag(LOCK/MOD2..MOD5/HYPER/META/RELEASE 追加)
- ibus adapter: `keysym::from_ibus` 完全 mapping
- engine: RELEASE event を Forwarded 短絡(状態遷移なし)

## Test plan

- [x] lefthook pre-push 全 stage PASS
- [x] keysym 8 PASS (+5 new: LOCK / MOD2 / SUPER+HYPER+META / RELEASE / 全 flag)
- [x] state_transitions 9 PASS (+1 RELEASE forwarded)
- [x] full workspace 446 → 452 PASS, 0 regression
- [x] gitleaks clean

Refs #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)