### PR TITLE
feat: catch_unwind + worker recovery + tx_request cleanup (P3-B B0b)

### DIFF
--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -8,18 +8,27 @@
 //! 4. `Database::open` で SQLite 接続
 //! 5. `SqliteUserVocabStore` / `SqliteLearningCacheStore` 構築
 //! 6. `MorphologicalEngine` を SudachiDict-core から構築
-//!    (env var `KOTOHA_SYSTEM_DICT_PATH`、未設定時は `StubRanker` fallback)
+//!    (env var `KOTOHA_SYSTEM_DICT_PATH` 必須、`KOTOHA_ALLOW_STUB=1` 時のみ
+//!    `StubRanker` fallback 許可)
 //! 7. `HybridRanker::new(sudachi, user_vocab, learning)` を構築
 //!    (LLM 統合は Phase 3-B B2+ で詳細化、現段階では dict-only)
 //! 8. `IBusHostBridge::new(object_path)` で session bus 接続
-//!    (失敗時は `StubHostBridge` fallback)
-//! 9. `KotohaEngine::new(host, ranker, learning_writer)`
+//!    (`KOTOHA_ALLOW_STUB=1` 時のみ `StubHostBridge` fallback 許可)
+//! 9. `KotohaEngine::new(host, ranker, learning_writer)` (Result)
 //! 10. `IBusEventDispatcher::new(engine)` で event loop 起動 stub
 //!
 //! 実 D-Bus event loop(`zbus::blocking::MessageStream` 経由の signal
 //! receive + dispatch)は Phase 3-B B3 / spec §13 Open Q 9 で詳細化する。
+//!
+//! # Panic recovery (spec §9.1 row 5)
+//!
+//! `main` は `std::panic::catch_unwind` で `run()` 全体を包み、unwind
+//! 観測時は `tracing::error!` + exit code 75 (EX_TEMPFAIL) で terminate
+//! する。これにより systemd 等が restart loop に入れる。
 
+use std::panic::{self, AssertUnwindSafe};
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::sync::mpsc;
 use std::sync::Arc;
 
@@ -31,9 +40,48 @@ mod host_detect;
 const ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
 const KOTOHA_LOG_ENV: &str = "KOTOHA_LOG";
 const KOTOHA_SYSTEM_DICT_PATH_ENV: &str = "KOTOHA_SYSTEM_DICT_PATH";
+const KOTOHA_ALLOW_STUB_ENV: &str = "KOTOHA_ALLOW_STUB";
 
-fn main() -> anyhow::Result<()> {
+/// `EX_TEMPFAIL`(systemd / sysexits.h):再起動が妥当な一時失敗。
+const EXIT_TEMPFAIL: u8 = 75;
+/// 一般エラー。spec §9.1 で具体 exit code は未指定のため、anyhow 由来の
+/// 起動失敗は通常の 1 を返す。
+const EXIT_FAILURE: u8 = 1;
+
+fn main() -> ExitCode {
     init_tracing();
+
+    // spec §9.1 row 5: top-level catch_unwind。`AssertUnwindSafe` は
+    // `run()` 内部で borrow / mutex を panic 越しに抱える設計でないことを
+    // 引き受ける明示。
+    let result = panic::catch_unwind(AssertUnwindSafe(run));
+
+    match result {
+        Ok(Ok(())) => ExitCode::SUCCESS,
+        Ok(Err(e)) => {
+            tracing::error!(error = ?e, "kotoha-bin failed");
+            ExitCode::from(EXIT_FAILURE)
+        }
+        Err(panic_payload) => {
+            let msg = panic_message(&panic_payload);
+            tracing::error!(panic = msg, "kotoha-bin caught top-level panic");
+            ExitCode::from(EXIT_TEMPFAIL)
+        }
+    }
+}
+
+/// `catch_unwind` payload から表示用 message を取り出す best-effort helper。
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> &str {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "(non-string panic payload)"
+    }
+}
+
+fn run() -> anyhow::Result<()> {
     let host = host_detect::detect();
     tracing::info!(?host, "kotoha-bin starting");
 
@@ -44,8 +92,32 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn init_tracing() {
-    let filter = EnvFilter::try_from_env(KOTOHA_LOG_ENV).unwrap_or_else(|_| EnvFilter::new("info"));
+    // 未設定時は静かに `info` default。設定済 + parse 失敗時のみ eprintln! で
+    // warning を出す(`try_from_env` は両者を `Err` で返すため、env::var で
+    // 先に存在判定する)。
+    let filter = match std::env::var(KOTOHA_LOG_ENV) {
+        Ok(directive) => match EnvFilter::try_new(&directive) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!(
+                    "warning: invalid {KOTOHA_LOG_ENV}={directive:?} ({e}); falling back to info"
+                );
+                EnvFilter::new("info")
+            }
+        },
+        Err(_) => EnvFilter::new("info"),
+    };
     tracing_subscriber::fmt().with_env_filter(filter).init();
+}
+
+/// `KOTOHA_ALLOW_STUB` env var が `1` / `true` / `yes` のいずれかを指す場合 true。
+/// それ以外(未設定 / `0` 等)は false で、production 起動時は stub fallback を
+/// 拒否(spec §9.3「空候補返却で終わる」を防ぐ)。
+fn stub_fallback_allowed() -> bool {
+    matches!(
+        std::env::var(KOTOHA_ALLOW_STUB_ENV).as_deref(),
+        Ok("1" | "true" | "yes")
+    )
 }
 
 fn run_ibus() -> anyhow::Result<()> {
@@ -64,40 +136,62 @@ fn run_ibus() -> anyhow::Result<()> {
         Arc::new(kotoha_storage::learning_cache::SqliteLearningCacheStore::new(db.clone()));
 
     // 6 + 7. Ranker: SudachiDict-core を env var 経由で読み、HybridRanker を構築する。
-    // dict path 未設定 / load 失敗 / その他事故では StubRanker fallback で起動を続行
-    // (development / CI 環境での起動可能性を担保、production は env var 設定必須)。
-    let ranker: Arc<dyn kotoha_engine_core::Ranker> = match build_hybrid_ranker(
-        user_vocab_store.clone(),
-        learning_store.clone(),
-    ) {
-        Ok(r) => {
-            tracing::info!("HybridRanker constructed (dict-only path; LLM is Phase 3-B B2+)");
-            r
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to construct HybridRanker; falling back to StubRanker");
-            Arc::new(StubRanker)
-        }
-    };
-
-    // 8. host bridge: session bus 接続。失敗時は stub に fallback して engine
-    // 自体は起動可能にする(L3 manual smoke 段階で実 IBus 接続を検証)。
-    let host_bridge: Box<dyn kotoha_engine_core::IMEHostBridge> =
-        match kotoha_engine_ibus::IBusHostBridge::new(ENGINE_OBJECT_PATH) {
-            Ok(b) => Box::new(b),
+    let allow_stub = stub_fallback_allowed();
+    let (ranker, ranker_backend): (Arc<dyn kotoha_engine_core::Ranker>, &'static str) =
+        match build_hybrid_ranker(user_vocab_store.clone(), learning_store.clone()) {
+            Ok(r) => {
+                tracing::info!("HybridRanker constructed (dict-only path; LLM is Phase 3-B B2+)");
+                (r, "HybridRanker")
+            }
+            Err(e) if allow_stub => {
+                tracing::error!(
+                    error = ?e,
+                    "failed to construct HybridRanker; falling back to StubRanker (KOTOHA_ALLOW_STUB=1)"
+                );
+                (Arc::new(StubRanker), "StubRanker")
+            }
             Err(e) => {
-                tracing::warn!(error = %e, "IBus session bus connect failed; using stub host_bridge");
-                Box::new(StubHostBridge)
+                return Err(e).with_context(|| {
+                    format!(
+                        "HybridRanker construction failed and {KOTOHA_ALLOW_STUB_ENV} is not set; \
+                         set {KOTOHA_SYSTEM_DICT_PATH_ENV} or {KOTOHA_ALLOW_STUB_ENV}=1 for development"
+                    )
+                });
             }
         };
 
-    // 9. engine
-    let engine = kotoha_engine_core::engine::KotohaEngine::new(host_bridge, ranker, learning_store);
+    // 8. host bridge: session bus 接続。
+    let (host_bridge, host_bridge_backend): (
+        Box<dyn kotoha_engine_core::IMEHostBridge>,
+        &'static str,
+    ) = match kotoha_engine_ibus::IBusHostBridge::new(ENGINE_OBJECT_PATH) {
+        Ok(b) => (Box::new(b), "IBusHostBridge"),
+        Err(e) if allow_stub => {
+            tracing::error!(
+                error = ?e,
+                "IBus session bus connect failed; using StubHostBridge (KOTOHA_ALLOW_STUB=1)"
+            );
+            (Box::new(StubHostBridge), "StubHostBridge")
+        }
+        Err(e) => {
+            return Err(anyhow::Error::new(e)).with_context(|| {
+                format!("IBusHostBridge connect failed and {KOTOHA_ALLOW_STUB_ENV} is not set")
+            });
+        }
+    };
+
+    // 9. engine(spec §9.1 row 5: spawn 失敗は Result 経由 propagate)
+    let engine = kotoha_engine_core::engine::KotohaEngine::new(host_bridge, ranker, learning_store)
+        .context("spawn ranker worker thread")?;
 
     // 10. dispatcher (event loop stub)
     let _dispatcher = kotoha_engine_ibus::IBusEventDispatcher::new(engine);
 
-    tracing::info!("kotoha engine wired up; event loop deferred to Phase 3-B B3");
+    tracing::info!(
+        ranker_backend,
+        host_bridge_backend,
+        "kotoha engine wired up; event loop deferred to Phase 3-B B3"
+    );
     Ok(())
 }
 
@@ -121,7 +215,7 @@ fn build_hybrid_ranker(
     Ok(Arc::new(ranker))
 }
 
-/// 暫定 stub ranker(env var 未設定 / Sudachi load 失敗時の fallback)。
+/// 暫定 stub ranker(`KOTOHA_ALLOW_STUB=1` 時のみ fallback として利用)。
 struct StubRanker;
 
 impl kotoha_engine_core::Ranker for StubRanker {
@@ -136,7 +230,7 @@ impl kotoha_engine_core::Ranker for StubRanker {
     }
 }
 
-/// 暫定 stub host bridge(session bus 接続失敗時の fallback)。
+/// 暫定 stub host bridge(`KOTOHA_ALLOW_STUB=1` 時のみ fallback として利用)。
 struct StubHostBridge;
 
 impl kotoha_engine_core::IMEHostBridge for StubHostBridge {

--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -7,6 +7,7 @@
 //! spec §5.2 の状態遷移 table を `process_key_event` 内の dispatch helper
 //! ([`transitions::dispatch_key`])で網羅する。
 
+use std::io;
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -94,13 +95,21 @@ impl KotohaEngine {
     /// - `state == EngineState::Idle`
     /// - `enabled == false`(host が `enable()` を呼ぶまで no-op + `Forwarded`)
     /// - `focused == false`
+    ///
+    /// # Errors
+    ///
+    /// - [`io::Error`] — `RankerWorker` 用 OS thread の spawn が失敗した場合
+    ///   (thread resource 枯渇等)。spec §9.1 row 5 に従い、起動失敗は呼び出し側
+    ///   (`kotoha-bin`)で `Err` 経由 propagate し process を中断させる。以前の
+    ///   実装は `.expect()` で panic していたが、process-wide panic は
+    ///   `catch_unwind` 経路に乗らないため非推奨。
     pub fn new(
         host: Box<dyn IMEHostBridge>,
         ranker: Arc<dyn Ranker>,
         learning_writer: Arc<dyn kotoha_storage::learning_cache::LearningCacheWriter>,
-    ) -> Self {
-        let (tx_request, rx_event, worker_handle) = worker::spawn_worker();
-        Self {
+    ) -> io::Result<Self> {
+        let (tx_request, rx_event, worker_handle) = worker::spawn_worker()?;
+        Ok(Self {
             state: EngineState::Idle,
             host,
             ranker,
@@ -118,7 +127,7 @@ impl KotohaEngine {
             tx_request,
             rx_event,
             worker_handle: Some(worker_handle),
-        }
+        })
     }
 
     /// 次 request_id を採番する(64-bit 単調増加、spec §7.5)。
@@ -163,7 +172,19 @@ impl KotohaEngine {
             ranker: self.ranker.clone(),
         };
         if self.tx_request.send(req).is_err() {
-            tracing::error!("ranker worker channel closed; engine will degrade");
+            // worker thread が死亡している。spec §9.1 row 2 に従い、
+            // engine 状態を Idle に戻して候補ウィンドウを閉じ、stale な
+            // active_request を残さない(後続 keystroke の cancel_active が
+            // phantom request を握って残響しないようにする)。
+            tracing::error!(
+                request_id,
+                "ranker worker channel closed; engine degrading to Idle"
+            );
+            self.active_request = None;
+            self.candidates.clear();
+            self.highlight_idx = 0;
+            self.host.hide_candidate_window();
+            self.state = EngineState::Idle;
             return;
         }
 
@@ -178,8 +199,14 @@ impl KotohaEngine {
     }
 
     /// `rx_event` から最大 `max_wait` まで待ち、第 1 Candidates(target_id 一致)を
-    /// engine state に反映して return する。WorkerError は `tracing::error!` を
-    /// 残し loop 継続。recv 失敗 / mismatch は無視 + skip。
+    /// engine state に反映して return する。
+    ///
+    /// - WorkerError target_id 一致時は spec §9.1 row 2 に従い `host.hide_candidate_window()`
+    ///   + state Idle に戻し、`tracing::error!` を残して return。
+    /// - WorkerError target_id 不一致時は loop 継続(別 request の error)。
+    /// - `RecvTimeoutError::Timeout` は normal path で return。
+    /// - `RecvTimeoutError::Disconnected` は worker thread 死亡を意味し、spec §9.1 row 2
+    ///   に従い engine 状態を Idle に戻し host を閉じて return。
     pub(crate) fn drain_events_blocking(&mut self, max_wait: Duration, target_id: u64) {
         let deadline = Instant::now() + max_wait;
         while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
@@ -193,8 +220,28 @@ impl KotohaEngine {
                 }
                 Ok(event::EngineEvent::WorkerError { request_id, error }) => {
                     tracing::error!(request_id, error, "ranker worker error");
+                    if request_id == target_id {
+                        self.active_request = None;
+                        self.candidates.clear();
+                        self.highlight_idx = 0;
+                        self.host.hide_candidate_window();
+                        self.state = EngineState::Idle;
+                        return;
+                    }
                 }
-                Err(_) => return,
+                Err(mpsc::RecvTimeoutError::Timeout) => return,
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    tracing::error!(
+                        target_id,
+                        "ranker worker channel disconnected; engine degrading to Idle"
+                    );
+                    self.active_request = None;
+                    self.candidates.clear();
+                    self.highlight_idx = 0;
+                    self.host.hide_candidate_window();
+                    self.state = EngineState::Idle;
+                    return;
+                }
             }
         }
     }
@@ -202,18 +249,41 @@ impl KotohaEngine {
     /// `rx_event` に蓄積されている event を非 blocking で全 drain する
     /// (`process_key_event` 先頭で呼び出し、Commit mode second window で
     /// 到着した LLM 結果等を反映する)。
+    ///
+    /// `try_recv` が `Disconnected` を返した場合は worker 死亡で、
+    /// `drain_events_blocking` と同等の Idle 復帰処理を行う。
     pub(crate) fn drain_pending_events(&mut self) {
         let active_id = self.active_request.as_ref().map(|h| h.id);
-        while let Ok(ev) = self.rx_event.try_recv() {
-            match ev {
-                event::EngineEvent::Candidates { request_id, update } => {
+        loop {
+            match self.rx_event.try_recv() {
+                Ok(event::EngineEvent::Candidates { request_id, update }) => {
                     if active_id != Some(request_id) {
                         continue; // mismatch discard
                     }
                     self.apply_candidate_update(update);
                 }
-                event::EngineEvent::WorkerError { request_id, error } => {
+                Ok(event::EngineEvent::WorkerError { request_id, error }) => {
                     tracing::error!(request_id, error, "ranker worker error");
+                    if active_id == Some(request_id) {
+                        self.active_request = None;
+                        self.candidates.clear();
+                        self.highlight_idx = 0;
+                        self.host.hide_candidate_window();
+                        self.state = EngineState::Idle;
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => return,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    tracing::error!(
+                        ?active_id,
+                        "ranker worker channel disconnected; engine degrading to Idle"
+                    );
+                    self.active_request = None;
+                    self.candidates.clear();
+                    self.highlight_idx = 0;
+                    self.host.hide_candidate_window();
+                    self.state = EngineState::Idle;
+                    return;
                 }
             }
         }

--- a/crates/kotoha-engine-core/src/engine/worker.rs
+++ b/crates/kotoha-engine-core/src/engine/worker.rs
@@ -8,6 +8,8 @@
 //! - Live: 7ms (5-10ms range の中央値、実装段階 empirical 確定)
 //! - Commit: 30ms (LLM 結果待機、second window 150ms で追加 push 受信)
 
+use std::io;
+use std::panic::{self, AssertUnwindSafe};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::sync::Arc;
 use std::thread;
@@ -38,18 +40,34 @@ pub const COMMIT_SECOND_WINDOW: Duration = Duration::from_millis(150);
 ///
 /// - `tx_request` が drop されると worker は loop を抜けて return
 /// - `JoinHandle` は engine 側 `Drop` impl で best-effort join
-pub(crate) fn spawn_worker() -> (
+///
+/// # Errors
+///
+/// - [`io::Error`] — OS が thread spawn を拒否した場合(thread resource 枯渇等)。
+///   呼び出し側([`super::KotohaEngine::new`])で `Result` 経由 propagate し、
+///   process 起動を中断させる(spec §9.1 row 5)。
+pub(crate) fn spawn_worker() -> io::Result<(
     mpsc::Sender<RankRequest>,
     mpsc::Receiver<EngineEvent>,
     thread::JoinHandle<()>,
-) {
+)> {
     let (tx_request, rx_request) = mpsc::channel::<RankRequest>();
     let (tx_event, rx_event) = mpsc::channel::<EngineEvent>();
     let handle = thread::Builder::new()
         .name("kotoha-ranker-worker".into())
-        .spawn(move || worker_loop(rx_request, tx_event))
-        .expect("spawn ranker worker thread");
-    (tx_request, rx_event, handle)
+        .spawn(move || worker_loop(rx_request, tx_event))?;
+    Ok((tx_request, rx_event, handle))
+}
+
+/// engine 主 thread の receiver が drop された場合に worker_loop を即時終了させる
+/// helper。`tx_event.send` が `Err` を返したら debug log を残して `true` を返す。
+/// 呼び出し側は `if try_send_event(...) { return; }` の pattern で抜ける。
+fn try_send_event(tx_event: &mpsc::Sender<EngineEvent>, ev: EngineEvent, request_id: u64) -> bool {
+    if tx_event.send(ev).is_err() {
+        tracing::debug!(request_id, "engine receiver dropped; worker exiting");
+        return true;
+    }
+    false
 }
 
 fn worker_loop(rx_request: mpsc::Receiver<RankRequest>, tx_event: mpsc::Sender<EngineEvent>) {
@@ -59,14 +77,37 @@ fn worker_loop(rx_request: mpsc::Receiver<RankRequest>, tx_event: mpsc::Sender<E
         let cancel = req.cancel_dyn();
 
         let (tx_ranker, rx_ranker) = mpsc::channel::<RankerOutput>();
-        let rank_result = req
-            .ranker
-            .rank(&req.kana, &req.ctx, cancel.clone(), tx_ranker);
-        if let Err(e) = rank_result {
-            let _ = tx_event.send(EngineEvent::WorkerError {
+
+        // spec §9.1 row 2: Ranker::rank の panic を catch し WorkerError として
+        // 報告。worker thread 自体は loop continue で生存させる(セッション全断
+        // を避ける)。`AssertUnwindSafe` は Ranker / kana / ctx / cancel / sink
+        // が panic 越しに不変であることを caller(本 module)が引き受ける明示。
+        let kana = req.kana.clone();
+        let ctx = req.ctx.clone();
+        let ranker = req.ranker.clone();
+        let cancel_for_call = cancel.clone();
+        let rank_result = panic::catch_unwind(AssertUnwindSafe(move || {
+            ranker.rank(&kana, &ctx, cancel_for_call, tx_ranker)
+        }));
+
+        let rank_outcome = match rank_result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(format!("ranker error: {e}")),
+            Err(panic_payload) => {
+                let msg = panic_message(&panic_payload);
+                tracing::error!(request_id, panic = msg, "ranker panicked");
+                Err(format!("ranker panicked: {msg}"))
+            }
+        };
+
+        if let Err(error) = rank_outcome {
+            if try_send_event(
+                &tx_event,
+                EngineEvent::WorkerError { request_id, error },
                 request_id,
-                error: format!("{e}"),
-            });
+            ) {
+                return;
+            }
             continue;
         }
 
@@ -78,11 +119,18 @@ fn worker_loop(rx_request: mpsc::Receiver<RankRequest>, tx_event: mpsc::Sender<E
         let mut buffer: Vec<Candidate> = Vec::new();
         drain_window(&rx_ranker, &cancel, window, &mut buffer);
 
-        if !cancel.is_cancelled() && !buffer.is_empty() {
-            let _ = tx_event.send(EngineEvent::Candidates {
+        if !cancel.is_cancelled()
+            && !buffer.is_empty()
+            && try_send_event(
+                &tx_event,
+                EngineEvent::Candidates {
+                    request_id,
+                    update: CandidateUpdate::Replace(buffer.clone()),
+                },
                 request_id,
-                update: CandidateUpdate::Replace(buffer.clone()),
-            });
+            )
+        {
+            return;
         }
 
         // 2nd window for Commit mode: LLM 後続結果
@@ -96,12 +144,30 @@ fn worker_loop(rx_request: mpsc::Receiver<RankRequest>, tx_event: mpsc::Sender<E
             );
             if !cancel.is_cancelled() && !second_buffer.is_empty() {
                 buffer.extend(second_buffer);
-                let _ = tx_event.send(EngineEvent::Candidates {
+                let send_failed = try_send_event(
+                    &tx_event,
+                    EngineEvent::Candidates {
+                        request_id,
+                        update: CandidateUpdate::Replace(buffer),
+                    },
                     request_id,
-                    update: CandidateUpdate::Replace(buffer),
-                });
+                );
+                if send_failed {
+                    return;
+                }
             }
         }
+    }
+}
+
+/// `catch_unwind` payload から表示用 message を取り出す best-effort helper。
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> &str {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "(non-string panic payload)"
     }
 }
 

--- a/crates/kotoha-engine-core/tests/engine_wrap_hybrid.rs
+++ b/crates/kotoha-engine-core/tests/engine_wrap_hybrid.rs
@@ -80,7 +80,8 @@ fn build_engine_with_real_hybrid_ranker(
         user_vocab,
         learning_cache.clone(),
     ));
-    let mut eng = KotohaEngine::new(Box::new(host_clone), ranker, learning_cache.clone());
+    let mut eng = KotohaEngine::new(Box::new(host_clone), ranker, learning_cache.clone())
+        .expect("engine spawn");
     eng.enable();
     eng.focus_in();
     (eng, host, learning_cache)

--- a/crates/kotoha-engine-core/tests/integration_l2_core.rs
+++ b/crates/kotoha-engine-core/tests/integration_l2_core.rs
@@ -52,7 +52,7 @@ fn build(candidates: Vec<Candidate>) -> (KotohaEngine, MockHostBridge) {
     let host_clone = host.clone();
     let ranker = Arc::new(MockRanker::new(candidates));
     let writer = Arc::new(StubWriter);
-    let mut eng = KotohaEngine::new(Box::new(host_clone), ranker, writer);
+    let mut eng = KotohaEngine::new(Box::new(host_clone), ranker, writer).expect("engine spawn");
     eng.enable();
     eng.focus_in();
     (eng, host)

--- a/crates/kotoha-engine-core/tests/state_transitions.rs
+++ b/crates/kotoha-engine-core/tests/state_transitions.rs
@@ -61,7 +61,8 @@ fn build_engine(
     let host_clone = host.clone();
     let ranker = Arc::new(MockRanker::new(candidates));
     let writer = Arc::new(MockLearningWriter::default());
-    let mut eng = KotohaEngine::new(Box::new(host_clone), ranker, writer.clone());
+    let mut eng =
+        KotohaEngine::new(Box::new(host_clone), ranker, writer.clone()).expect("engine spawn");
     eng.enable();
     eng.focus_in();
     (eng, host, writer)

--- a/crates/kotoha-engine-core/tests/worker_coalescing.rs
+++ b/crates/kotoha-engine-core/tests/worker_coalescing.rs
@@ -89,7 +89,7 @@ fn consecutive_typing_cancels_previous_rank_request() {
     });
     let host = Box::new(MockHostBridge::new());
     let writer = Arc::new(StubWriter);
-    let mut eng = KotohaEngine::new(host, ranker, writer);
+    let mut eng = KotohaEngine::new(host, ranker, writer).expect("engine spawn");
     eng.enable();
     eng.focus_in();
 
@@ -106,6 +106,69 @@ fn consecutive_typing_cancels_previous_rank_request() {
     );
 }
 
+/// spec §9.1 row 2: `Ranker::rank` が panic しても worker thread は生存し、
+/// engine は次 keystroke を引き続き処理できる(catch_unwind による recovery)。
+#[test]
+fn worker_recovers_after_ranker_panic() {
+    use std::sync::atomic::{AtomicBool, AtomicU64};
+
+    /// 第 1 回 rank で panic、第 2 回以降は正常 send する Ranker。
+    struct FlakyRanker {
+        first_call: AtomicBool,
+        second_calls: Arc<AtomicU64>,
+    }
+    impl Ranker for FlakyRanker {
+        fn rank(
+            &self,
+            _kana: &str,
+            _ctx: &ConversionContext,
+            _cancel: Arc<dyn CancellationToken>,
+            sink: std::sync::mpsc::Sender<RankerOutput>,
+        ) -> Result<(), RankerError> {
+            if self
+                .first_call
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                panic!("intentional ranker panic for catch_unwind regression");
+            }
+            self.second_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let _ = sink.send(RankerOutput {
+                request_id: 0,
+                update: CandidateUpdate::Replace(vec![Candidate::new("あ", -1.0)]),
+            });
+            Ok(())
+        }
+    }
+
+    let second_calls = Arc::new(AtomicU64::new(0));
+    let ranker = Arc::new(FlakyRanker {
+        first_call: AtomicBool::new(true),
+        second_calls: second_calls.clone(),
+    });
+    let host = Box::new(MockHostBridge::new());
+    let writer = Arc::new(StubWriter);
+    let mut eng = KotohaEngine::new(host, ranker, writer).expect("engine spawn");
+    eng.enable();
+    eng.focus_in();
+
+    // 第 1 回 keystroke:Ranker が panic するが、worker は WorkerError を engine に
+    // 送って継続。engine 主 thread はそれを観測して Idle 復帰する(spec §9.1 row 2)。
+    eng.process_key_event(key('a'));
+
+    // 第 2 回 keystroke:worker が生存していれば 2 度目の rank が走り
+    // second_calls がインクリメントされる。
+    eng.process_key_event(key('i'));
+
+    // worker thread の処理を待つ。
+    sleep(Duration::from_millis(50));
+    assert!(
+        second_calls.load(std::sync::atomic::Ordering::SeqCst) >= 1,
+        "worker should have survived first-call panic and serviced second key, got {}",
+        second_calls.load(std::sync::atomic::Ordering::SeqCst)
+    );
+}
+
 /// spec §5.2: `focus_out` で `active_request` の cancel_token が fire される。
 #[test]
 fn focus_out_cancels_active_request() {
@@ -116,7 +179,7 @@ fn focus_out_cancels_active_request() {
     });
     let host = Box::new(MockHostBridge::new());
     let writer = Arc::new(StubWriter);
-    let mut eng = KotohaEngine::new(host, ranker, writer);
+    let mut eng = KotohaEngine::new(host, ranker, writer).expect("engine spawn");
     eng.enable();
     eng.focus_in();
 


### PR DESCRIPTION
## Summary

包括レビュー Critical 1 (spec §9.1 catch_unwind 未実装) + Important 5 (worker observation) / 7 (worker spawn panic) / 9 (tx_request 失敗 stale state) を消化する PR。Phase 3-B B0 の core security & availability 改善。

## What changed

- **C1 catch_unwind**:`kotoha-bin` top-level + worker thread 内 `Ranker::rank` 周りの 2 段 catch_unwind。worker は panic 後も生存、kotoha-bin は exit 75 で systemd restart loop 対応
- **C2 stub fallback gating**:`KOTOHA_ALLOW_STUB=1` 未設定時は production silent IME-disabled を防止して `anyhow::bail!` 化
- **I6 worker tx_event observation**:`let _ = tx_event.send` を `try_send_event` helper に統一、send 失敗時は `tracing::debug!` + worker_loop return
- **I7 worker spawn Result API**:`KotohaEngine::new` を `io::Result<Self>` に変更、process-wide panic 経路を排除
- **I9 tx_request.send 失敗時 cleanup**:active_request 解除 + candidates clear + host hide + state Idle で full cleanup
- **I13 error chain**:全 ERROR/WARN ログを `error = ?e` に変更、anyhow Caused-by chain 全展開
- **`drain_events_blocking` / `drain_pending_events`**:Disconnected を Timeout/Empty と区別し worker 死亡時の Idle graceful degradation
- **WorkerError target_id match**:engine 主 thread 側で host hide + state Idle に復帰
- **regression test**:`worker_recovers_after_ranker_panic` で FlakyRanker による catch_unwind recovery を直接 assert

## Self-review

- [x] lefthook pre-push 全 stage PASS
- [x] cargo clippy --all-targets --features test-helpers -- -D warnings PASS
- [x] full workspace 454 → 455 (+1 panic recovery test)、0 regression
- [x] gitleaks clean
- [x] E2E smoke 3 mode 確認:default(exit 1)/ KOTOHA_ALLOW_STUB=1(degraded mode INFO 構造化)/ HybridRanker production
- [x] `KotohaEngine::new` Result 化に伴う 4 test + kotoha-bin 全 call site 更新
- [x] doc comment lazy continuation clippy 修正(`# Errors` 前に空行)
- [x] collapsible-if clippy 修正(worker.rs)

## Out of scope (B0c-B0f に持ち越し)

- C3 spec §10.2 全 row 網羅(state_transitions に 7 case 追加)
- C4 spec §7 async モデル修正(Commit 2nd window LLM 候補配信)
- I5 cancel 4 trigger 追加 test
- I8 worker 空 buffer 時の Replace 送信
- I10 RankerOutput.request_id dead field 撤去
- I11 IBusEventDispatcher 単体テスト
- I12 L2-core sequence assertion

## References

- ISSUE #140 (P3-B B0 tracking)
- Spec §9.1 / §9.3
- WBS docs/wbs/2026-05-02-phase3a-implementation.md

Refs #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)