### PR TITLE
test: missing state transitions + cancel triggers (P3-B B0c)

### DIFF
--- a/crates/kotoha-engine-core/tests/state_transitions.rs
+++ b/crates/kotoha-engine-core/tests/state_transitions.rs
@@ -87,9 +87,15 @@ fn idle_typing_transitions_to_live() {
         .any(|o| matches!(o, HostOperation::ShowCandidateWindow)));
 }
 
-/// spec §5.2: LiveConverting + space → CandidatesShown
+/// spec §5.2 row 4: LiveConverting + space。即応 Ranker(MockRanker は同期 send)で
+/// dispatch_rank_request 内で候補が間に合えば最終 state = CandidatesShown。
+///
+/// なお spec §5.2 の正解 target は `CommitConverting`(候補未到着の中間状態)。
+/// 同期 Mock では中間状態が観測不能なため、対の遅延 Ranker test
+/// (`live_space_with_slow_ranker_stays_at_commit_converting`)で
+/// CommitConverting branch を assert する。
 #[test]
-fn live_space_transitions_to_candidates_shown() {
+fn live_space_with_fast_ranker_transitions_to_candidates_shown() {
     let (mut eng, _host, _w) = build_engine(vec![Candidate::new("琴葉", -1.0)]);
     eng.process_key_event(key_char('k'));
     eng.process_key_event(key_char('a'));
@@ -200,4 +206,133 @@ fn candidates_navigation_moves_highlight() {
     eng.process_key_event(key_special(keysyms::DOWN));
     // wrap around
     assert_eq!(eng.highlight_idx_for_test(), 0);
+}
+
+// ------------------------------------------------------------------
+// Phase 3-B B0c (ISSUE #140): missing spec §5.2 transition rows
+// ------------------------------------------------------------------
+
+/// spec §5.2 row 5: LiveConverting + Esc → Idle (preedit + 候補 全 clear)
+#[test]
+fn live_escape_clears_to_idle() {
+    let (mut eng, host, _w) = build_engine(vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    let r = eng.process_key_event(key_special(keysyms::ESCAPE));
+    assert_eq!(r, KeyEventResult::Consumed);
+    assert_eq!(eng.state_for_test(), EngineState::Idle);
+    assert!(eng.preedit_for_test().is_empty());
+    let ops = host.operations();
+    assert!(ops
+        .iter()
+        .any(|o| matches!(o, HostOperation::HideCandidateWindow)));
+    assert!(ops.iter().any(|o| matches!(
+        o,
+        HostOperation::UpdatePreedit { text, visible, .. }
+            if text.is_empty() && !*visible
+    )));
+}
+
+/// spec §5.2 row 3 non-empty path: LiveConverting + backspace → LiveConverting
+/// (kana が複数残るときは preedit 1 char 縮 + Live 再起動)
+#[test]
+fn live_backspace_keeps_live_when_preedit_remains() {
+    let (mut eng, _host, _w) = build_engine(vec![Candidate::new("かい", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_char('i'));
+    assert_eq!(eng.preedit_for_test(), "かい");
+    eng.process_key_event(key_special(keysyms::BACKSPACE));
+    assert_eq!(eng.state_for_test(), EngineState::LiveConverting);
+    assert_eq!(eng.preedit_for_test(), "か");
+}
+
+/// spec §5.2 row 11: CandidatesShown + 通常 typing → LiveConverting
+/// (候補ウィンドウ閉、新 preedit + Live RankRequest 再起動)
+#[test]
+fn candidates_typing_resumes_live() {
+    let (mut eng, host, _w) = build_engine(vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_special(keysyms::SPACE));
+    assert_eq!(eng.state_for_test(), EngineState::CandidatesShown);
+    host.clear();
+    // typing 「i」を再開
+    eng.process_key_event(key_char('i'));
+    assert_eq!(eng.state_for_test(), EngineState::LiveConverting);
+    let ops = host.operations();
+    assert!(ops
+        .iter()
+        .any(|o| matches!(o, HostOperation::HideCandidateWindow)));
+}
+
+/// spec §5.2 row 13: CandidatesShown + backspace → LiveConverting
+/// (候補ウィンドウ閉、preedit 1 char 縮、Live 再起動)
+#[test]
+fn candidates_backspace_returns_to_live() {
+    let (mut eng, host, _w) = build_engine(vec![Candidate::new("かい", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_char('i'));
+    eng.process_key_event(key_special(keysyms::SPACE));
+    assert_eq!(eng.state_for_test(), EngineState::CandidatesShown);
+    host.clear();
+    eng.process_key_event(key_special(keysyms::BACKSPACE));
+    assert_eq!(eng.state_for_test(), EngineState::LiveConverting);
+    assert_eq!(eng.preedit_for_test(), "か");
+    let ops = host.operations();
+    assert!(ops
+        .iter()
+        .any(|o| matches!(o, HostOperation::HideCandidateWindow)));
+}
+
+/// spec §5.2 row 14: CandidatesShown + focus_out → Idle (全 clear)
+#[test]
+fn candidates_focus_out_clears() {
+    let (mut eng, host, _w) = build_engine(vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_special(keysyms::SPACE));
+    assert_eq!(eng.state_for_test(), EngineState::CandidatesShown);
+    host.clear();
+    eng.focus_out();
+    assert_eq!(eng.state_for_test(), EngineState::Idle);
+    assert!(eng.preedit_for_test().is_empty());
+    assert_eq!(eng.candidate_count_for_test(), 0);
+    let ops = host.operations();
+    assert!(ops
+        .iter()
+        .any(|o| matches!(o, HostOperation::HideCandidateWindow)));
+}
+
+/// spec §5.2 row 2 explicit: LiveConverting + 連続通常 char → LiveConverting
+/// (preedit 伸長 + Live RankRequest 再発行)
+#[test]
+fn live_consecutive_typing_extends_preedit() {
+    let (mut eng, _host, _w) = build_engine(vec![Candidate::new("かい", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    assert_eq!(eng.preedit_for_test(), "か");
+    assert_eq!(eng.state_for_test(), EngineState::LiveConverting);
+    eng.process_key_event(key_char('i'));
+    assert_eq!(eng.preedit_for_test(), "かい");
+    assert_eq!(eng.state_for_test(), EngineState::LiveConverting);
+}
+
+/// spec §5.2 row 1 negative: Idle + 大文字(現状 ASCII graphic として扱う)
+/// が既存 path で Consumed になることを観測。Phase 6 input mode で再評価。
+#[test]
+fn idle_uppercase_is_consumed_via_typing_path() {
+    // 'A' (0x41) は ASCII graphic + ASCII uppercase のため
+    // handle_typing が char::from_u32 で受け入れ、ローマ字 trie で
+    // 該当 entry が無いため pending は invalid 扱いで dropped。
+    // 現状 spec では大文字の挙動は §13 Open Q 8 で「実装段階対応」。
+    // 本 test は「panic-free + Forwarded ではなく Consumed として吸収する」
+    // 現状 behavior を lock する(spec 確定後 expectations を更新)。
+    let (mut eng, _host, _w) = build_engine(vec![]);
+    let r = eng.process_key_event(key_char('A'));
+    assert_eq!(r, KeyEventResult::Consumed);
+    // 大文字単独では ローマ字 entry に hit しないため preedit は空のまま Idle 維持
+    assert!(eng.preedit_for_test().is_empty());
+    assert_eq!(eng.state_for_test(), EngineState::Idle);
 }

--- a/crates/kotoha-engine-core/tests/worker_coalescing.rs
+++ b/crates/kotoha-engine-core/tests/worker_coalescing.rs
@@ -194,3 +194,104 @@ fn focus_out_cancels_active_request() {
         cancel_count.load(Ordering::SeqCst)
     );
 }
+
+// ------------------------------------------------------------------
+// Phase 3-B B0c (ISSUE #140): missing spec §8.1 cancel triggers
+// ------------------------------------------------------------------
+
+/// 共通 helper:CancelObservingRanker + StubWriter で engine 構築
+fn build_engine_for_cancel_test(delay_ms: u64) -> (KotohaEngine, Arc<AtomicU64>) {
+    let cancel_count = Arc::new(AtomicU64::new(0));
+    let ranker = Arc::new(CancelObservingRanker {
+        cancel_observed: cancel_count.clone(),
+        delay: Duration::from_millis(delay_ms),
+    });
+    let host = Box::new(MockHostBridge::new());
+    let writer = Arc::new(StubWriter);
+    let mut eng = KotohaEngine::new(host, ranker, writer).expect("engine spawn");
+    eng.enable();
+    eng.focus_in();
+    (eng, cancel_count)
+}
+
+/// spec §8.1 trigger 4: `Esc` key on LiveConverting で cancel 観測
+#[test]
+fn escape_on_live_cancels_active_request() {
+    let (mut eng, cancel_count) = build_engine_for_cancel_test(40);
+
+    eng.process_key_event(key('a'));
+    eng.process_key_event(key_special_for_cancel(
+        kotoha_engine_core::engine::transitions::keysyms::ESCAPE,
+    ));
+
+    sleep(Duration::from_millis(100));
+    assert!(
+        cancel_count.load(Ordering::SeqCst) >= 1,
+        "expected Esc to cancel active request, got {}",
+        cancel_count.load(Ordering::SeqCst)
+    );
+}
+
+/// spec §8.1 trigger 5: `IMEEngine::reset()` で cancel 観測
+#[test]
+fn reset_cancels_active_request() {
+    use kotoha_engine_core::ime_engine::IMEEngine as _;
+    let (mut eng, cancel_count) = build_engine_for_cancel_test(40);
+
+    eng.process_key_event(key('a'));
+    eng.reset();
+
+    sleep(Duration::from_millis(100));
+    assert!(
+        cancel_count.load(Ordering::SeqCst) >= 1,
+        "expected reset() to cancel active request, got {}",
+        cancel_count.load(Ordering::SeqCst)
+    );
+}
+
+/// spec §8.1 trigger 3: 連続 space(別 RankRequest 開始)で先 request の cancel
+#[test]
+fn consecutive_space_cancels_previous_request() {
+    let (mut eng, cancel_count) = build_engine_for_cancel_test(40);
+
+    eng.process_key_event(key('a'));
+    eng.process_key_event(key_special_for_cancel(
+        kotoha_engine_core::engine::transitions::keysyms::SPACE,
+    ));
+    eng.process_key_event(key_special_for_cancel(
+        kotoha_engine_core::engine::transitions::keysyms::SPACE,
+    ));
+
+    sleep(Duration::from_millis(100));
+    assert!(
+        cancel_count.load(Ordering::SeqCst) >= 1,
+        "expected consecutive space to cancel previous request, got {}",
+        cancel_count.load(Ordering::SeqCst)
+    );
+}
+
+/// spec §8.1 trigger 2 (backspace path): backspace で preedit を空にする際の cancel
+#[test]
+fn backspace_to_idle_cancels_active_request() {
+    let (mut eng, cancel_count) = build_engine_for_cancel_test(40);
+
+    eng.process_key_event(key('a'));
+    eng.process_key_event(key_special_for_cancel(
+        kotoha_engine_core::engine::transitions::keysyms::BACKSPACE,
+    ));
+
+    sleep(Duration::from_millis(100));
+    assert!(
+        cancel_count.load(Ordering::SeqCst) >= 1,
+        "expected backspace-to-idle to cancel active request, got {}",
+        cancel_count.load(Ordering::SeqCst)
+    );
+}
+
+fn key_special_for_cancel(keysym: u32) -> KeyEvent {
+    KeyEvent {
+        keysym,
+        keycode: 0,
+        modifiers: KeyModifiers::empty(),
+    }
+}


### PR DESCRIPTION
## Summary

包括レビュー Critical 3 (spec §10.2 全 row 網羅未達) + Important 5 (spec §8.1 cancel 5 trigger のうち 3 不足) を消化する test-only PR。

## C3 spec §5.2 全 row 網羅 (7 row 追加 + theater fix)

`state_transitions.rs` に 7 case 追加(row 2/3non-empty/5/11/13/14/Open Q 8 大文字)+ `live_space_transitions_to_candidates_shown` を `..._with_fast_ranker_...` に rename し、CommitConverting 中間状態の対 test は B0d で別途追加することを doc comment 化。

## I5 spec §8.1 cancel 全 trigger 網羅 (4 不足分)

`worker_coalescing.rs` に 4 case 追加(Esc / reset / 連続 space / backspace-to-idle)+ `build_engine_for_cancel_test` helper で重複排除。

## Test plan

- [x] lefthook pre-push 全 stage PASS
- [x] state_transitions: 9 → 16 (+7)
- [x] worker_coalescing: 3 → 7 (+4)
- [x] full workspace: 455 → 466 (+11), 0 regression
- [x] gitleaks clean

## Out of scope (B0d で消化)

- CommitConverting + RankerOutput → CandidatesShown 遷移 + C4 async path
- I8 / I11 / I12 / regression cleanup
- I10 RankerOutput.request_id 撤去 (B0e)

Refs #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)