### PR TITLE
feat(engine-core): async path + worker empty Replace (P3-B B0d)

### DIFF
--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -198,6 +198,27 @@ impl KotohaEngine {
         self.drain_events_blocking(max_wait, request_id);
     }
 
+    /// spec §5.2 row 7 (CommitConverting + RankerOutput → CandidatesShown) の
+    /// 反映 helper。`Candidates` event を apply_candidate_update した直後に
+    /// 呼び、CommitConverting 中で候補非空なら CandidatesShown へ遷移して
+    /// `update_candidates` を host に発行する。
+    fn maybe_promote_commit_to_candidates_shown(&mut self) {
+        if self.state == EngineState::CommitConverting && !self.candidates.is_empty() {
+            self.host
+                .update_candidates(CandidateUpdate::Replace(self.candidates.clone()));
+            self.state = EngineState::CandidatesShown;
+        }
+    }
+
+    /// worker 死亡 / WorkerError 発生時の共通 Idle 復帰処理。
+    fn degrade_to_idle(&mut self) {
+        self.active_request = None;
+        self.candidates.clear();
+        self.highlight_idx = 0;
+        self.host.hide_candidate_window();
+        self.state = EngineState::Idle;
+    }
+
     /// `rx_event` から最大 `max_wait` まで待ち、第 1 Candidates(target_id 一致)を
     /// engine state に反映して return する。
     ///
@@ -207,6 +228,8 @@ impl KotohaEngine {
     /// - `RecvTimeoutError::Timeout` は normal path で return。
     /// - `RecvTimeoutError::Disconnected` は worker thread 死亡を意味し、spec §9.1 row 2
     ///   に従い engine 状態を Idle に戻し host を閉じて return。
+    /// - `Candidates` で CommitConverting 中なら `CandidatesShown` 遷移を併発する
+    ///   (spec §5.2 row 7、Phase 3-B B0d Critical 4 async path 修正)。
     pub(crate) fn drain_events_blocking(&mut self, max_wait: Duration, target_id: u64) {
         let deadline = Instant::now() + max_wait;
         while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
@@ -216,16 +239,13 @@ impl KotohaEngine {
                         continue;
                     }
                     self.apply_candidate_update(update);
+                    self.maybe_promote_commit_to_candidates_shown();
                     return;
                 }
                 Ok(event::EngineEvent::WorkerError { request_id, error }) => {
                     tracing::error!(request_id, error, "ranker worker error");
                     if request_id == target_id {
-                        self.active_request = None;
-                        self.candidates.clear();
-                        self.highlight_idx = 0;
-                        self.host.hide_candidate_window();
-                        self.state = EngineState::Idle;
+                        self.degrade_to_idle();
                         return;
                     }
                 }
@@ -235,11 +255,7 @@ impl KotohaEngine {
                         target_id,
                         "ranker worker channel disconnected; engine degrading to Idle"
                     );
-                    self.active_request = None;
-                    self.candidates.clear();
-                    self.highlight_idx = 0;
-                    self.host.hide_candidate_window();
-                    self.state = EngineState::Idle;
+                    self.degrade_to_idle();
                     return;
                 }
             }
@@ -248,10 +264,12 @@ impl KotohaEngine {
 
     /// `rx_event` に蓄積されている event を非 blocking で全 drain する
     /// (`process_key_event` 先頭で呼び出し、Commit mode second window で
-    /// 到着した LLM 結果等を反映する)。
+    /// 到着した LLM 結果等 + 遅延 dict 候補を反映する)。
     ///
     /// `try_recv` が `Disconnected` を返した場合は worker 死亡で、
     /// `drain_events_blocking` と同等の Idle 復帰処理を行う。
+    /// `Candidates` で CommitConverting 中なら `CandidatesShown` へ遷移する
+    /// (spec §5.2 row 7)。
     pub(crate) fn drain_pending_events(&mut self) {
         let active_id = self.active_request.as_ref().map(|h| h.id);
         loop {
@@ -261,15 +279,12 @@ impl KotohaEngine {
                         continue; // mismatch discard
                     }
                     self.apply_candidate_update(update);
+                    self.maybe_promote_commit_to_candidates_shown();
                 }
                 Ok(event::EngineEvent::WorkerError { request_id, error }) => {
                     tracing::error!(request_id, error, "ranker worker error");
                     if active_id == Some(request_id) {
-                        self.active_request = None;
-                        self.candidates.clear();
-                        self.highlight_idx = 0;
-                        self.host.hide_candidate_window();
-                        self.state = EngineState::Idle;
+                        self.degrade_to_idle();
                     }
                 }
                 Err(mpsc::TryRecvError::Empty) => return,
@@ -278,11 +293,7 @@ impl KotohaEngine {
                         ?active_id,
                         "ranker worker channel disconnected; engine degrading to Idle"
                     );
-                    self.active_request = None;
-                    self.candidates.clear();
-                    self.highlight_idx = 0;
-                    self.host.hide_candidate_window();
-                    self.state = EngineState::Idle;
+                    self.degrade_to_idle();
                     return;
                 }
             }

--- a/crates/kotoha-engine-core/src/engine/transitions.rs
+++ b/crates/kotoha-engine-core/src/engine/transitions.rs
@@ -136,20 +136,38 @@ fn handle_backspace(engine: &mut KotohaEngine) -> KeyEventResult {
     }
 }
 
-/// Space path — commit-mode 開始(spec §5.2)。
+/// Space path — commit-mode 開始(spec §5.2 row 4 + row 7)。
+///
+/// spec §5.2 strict: `LiveConverting + space → CommitConverting`(候補未到着の中間状態)、
+/// `CommitConverting + RankerOutput → CandidatesShown`(候補到着で遷移)の 2 段。
+///
+/// Phase 3-B B0d (ISSUE #140 / Critical 4 async path 修正):
+/// 1. state を即 `CommitConverting` に遷移し、`show_candidate_window` で
+///    user に「変換中」フィードバックを出す(内容は到着待ち)。
+/// 2. `dispatch_rank_request` 内 blocking で第 1 batch を待つ(同期 Mock 経路 + 速い
+///    実 Ranker は ここで populate される)。
+/// 3. 候補が間に合えば即 `CandidatesShown` に追加遷移。間に合わない場合は
+///    `CommitConverting` で抜け、後続 `process_key_event` 先頭の
+///    [`KotohaEngine::drain_pending_events`] が候補到着時に `CandidatesShown` 遷移を行う。
 fn handle_space(engine: &mut KotohaEngine) -> KeyEventResult {
     match engine.state {
         EngineState::Idle => KeyEventResult::Forwarded,
         EngineState::LiveConverting | EngineState::CommitConverting => {
             engine.cancel_active();
+            // spec §5.2 row 4: 即 CommitConverting + show_candidate_window
+            engine.candidates.clear();
+            engine.highlight_idx = 0;
+            engine.state = EngineState::CommitConverting;
+            engine.host.show_candidate_window();
+
             engine.dispatch_rank_request(ConversionMode::Commit);
-            if engine.candidates.is_empty() {
-                engine.state = EngineState::CommitConverting;
-            } else {
+
+            // 候補が dispatch 内 drain で間に合っていれば row 7 遷移を即適用。
+            // 間に合っていなければ後続 keystroke の drain_pending_events で対応。
+            if !engine.candidates.is_empty() {
                 engine
                     .host
                     .update_candidates(CandidateUpdate::Replace(engine.candidates.clone()));
-                engine.host.show_candidate_window();
                 engine.state = EngineState::CandidatesShown;
             }
             KeyEventResult::Consumed

--- a/crates/kotoha-engine-core/src/engine/worker.rs
+++ b/crates/kotoha-engine-core/src/engine/worker.rs
@@ -119,8 +119,10 @@ fn worker_loop(rx_request: mpsc::Receiver<RankRequest>, tx_event: mpsc::Sender<E
         let mut buffer: Vec<Candidate> = Vec::new();
         drain_window(&rx_ranker, &cancel, window, &mut buffer);
 
+        // Phase 3-B B0d (Important 8): cancel されていなければ buffer が空でも
+        // Replace を送る。engine 側は前回 dispatch の stale 候補を本 Replace で
+        // 確実に clear できる。spec §9.3「変換失敗で前回候補が画面に残る」を防ぐ。
         if !cancel.is_cancelled()
-            && !buffer.is_empty()
             && try_send_event(
                 &tx_event,
                 EngineEvent::Candidates {

--- a/crates/kotoha-engine-core/tests/state_transitions.rs
+++ b/crates/kotoha-engine-core/tests/state_transitions.rs
@@ -319,6 +319,123 @@ fn live_consecutive_typing_extends_preedit() {
     assert_eq!(eng.state_for_test(), EngineState::LiveConverting);
 }
 
+// ------------------------------------------------------------------
+// Phase 3-B B0d (ISSUE #140): Critical 4 async path 修正の検証
+// ------------------------------------------------------------------
+// spec §5.2 row 4: LiveConverting + space → CommitConverting
+// spec §5.2 row 7: CommitConverting + RankerOutput → CandidatesShown
+// 同期 MockRanker では中間状態 CommitConverting が観測不能なため、遅延 Ranker
+// (SlowRanker)を使って中間状態を捕捉する。
+
+/// 指定 delay 後に固定候補を sink.send する Ranker。
+struct SlowRanker {
+    delay: std::time::Duration,
+    candidates: Vec<Candidate>,
+}
+
+impl kotoha_engine_core::ranker::Ranker for SlowRanker {
+    fn rank(
+        &self,
+        _kana: &str,
+        _ctx: &kotoha_engine_core::ranker::ConversionContext,
+        cancel: std::sync::Arc<dyn kotoha_engine_core::cancel::CancellationToken>,
+        sink: std::sync::mpsc::Sender<kotoha_engine_core::ranker::RankerOutput>,
+    ) -> Result<(), kotoha_engine_core::ranker::RankerError> {
+        let delay = self.delay;
+        let cands = self.candidates.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(delay);
+            if cancel.is_cancelled() {
+                return;
+            }
+            let _ = sink.send(kotoha_engine_core::ranker::RankerOutput {
+                request_id: 0,
+                update: kotoha_engine_core::ranker::CandidateUpdate::Replace(cands),
+            });
+        });
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct StubWriterB0d;
+impl kotoha_storage::learning_cache::LearningCacheWriter for StubWriterB0d {
+    fn record_choice(
+        &self,
+        _kana_input: &str,
+        _chosen_kanji: &str,
+    ) -> Result<(), kotoha_storage::error::StorageError> {
+        Ok(())
+    }
+    fn evict_lru(&self, _max_entries: usize) -> Result<usize, kotoha_storage::error::StorageError> {
+        Ok(0)
+    }
+}
+
+fn build_engine_with_slow_ranker(
+    delay_ms: u64,
+    candidates: Vec<Candidate>,
+) -> (KotohaEngine, MockHostBridge) {
+    let host = MockHostBridge::new();
+    let host_clone = host.clone();
+    let ranker = std::sync::Arc::new(SlowRanker {
+        delay: std::time::Duration::from_millis(delay_ms),
+        candidates,
+    });
+    let writer = std::sync::Arc::new(StubWriterB0d);
+    let mut eng = KotohaEngine::new(Box::new(host_clone), ranker, writer).expect("engine spawn");
+    eng.enable();
+    eng.focus_in();
+    (eng, host)
+}
+
+/// spec §5.2 row 4 strict: LiveConverting + space で Ranker が遅延すると state は
+/// `CommitConverting` で抜ける(候補未到着の中間状態が観測される)。
+/// spec §5.2 strict 適合の対 test。
+#[test]
+fn live_space_with_slow_ranker_stays_at_commit_converting() {
+    // delay を Commit window 35ms より長くして、dispatch 内 drain で候補が
+    // 間に合わないようにする。
+    let (mut eng, host) = build_engine_with_slow_ranker(80, vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_special(keysyms::SPACE));
+    // 第 1 batch がまだ届いていない → state == CommitConverting
+    assert_eq!(eng.state_for_test(), EngineState::CommitConverting);
+    // show_candidate_window は spec §5.2 row 4 通り即発行されている
+    assert!(host
+        .operations()
+        .iter()
+        .any(|o| matches!(o, HostOperation::ShowCandidateWindow)));
+}
+
+/// spec §5.2 row 7: CommitConverting で RankerOutput が遅れて到着すると、
+/// 後続 process_key_event の drain_pending_events で `CandidatesShown` へ遷移する。
+#[test]
+fn commit_converting_transitions_to_candidates_shown_on_late_arrival() {
+    let (mut eng, host) = build_engine_with_slow_ranker(50, vec![Candidate::new("か", -1.0)]);
+    eng.process_key_event(key_char('k'));
+    eng.process_key_event(key_char('a'));
+    eng.process_key_event(key_special(keysyms::SPACE));
+    assert_eq!(eng.state_for_test(), EngineState::CommitConverting);
+    // 候補到着まで sleep
+    std::thread::sleep(std::time::Duration::from_millis(80));
+    host.clear();
+    // 後続キーで drain_pending_events が走り、row 7 の遷移が起きる。
+    // navigation key は CommitConverting では処理しないが、process_key_event
+    // 入口で drain_pending_events が走る点を利用する。
+    eng.process_key_event(key_special(keysyms::DOWN));
+    assert_eq!(eng.state_for_test(), EngineState::CandidatesShown);
+    assert!(host
+        .operations()
+        .iter()
+        .any(|o| matches!(o, HostOperation::UpdateCandidates(_))));
+}
+
+// ------------------------------------------------------------------
+// 既存 §5.2 transitions 続き
+// ------------------------------------------------------------------
+
 /// spec §5.2 row 1 negative: Idle + 大文字(現状 ASCII graphic として扱う)
 /// が既存 path で Consumed になることを観測。Phase 6 input mode で再評価。
 #[test]

--- a/crates/kotoha-engine-core/tests/worker_coalescing.rs
+++ b/crates/kotoha-engine-core/tests/worker_coalescing.rs
@@ -295,3 +295,51 @@ fn key_special_for_cancel(keysym: u32) -> KeyEvent {
         modifiers: KeyModifiers::empty(),
     }
 }
+
+// ------------------------------------------------------------------
+// Phase 3-B B0d (Important 8): worker 空 buffer 時の Replace 送信
+// ------------------------------------------------------------------
+
+/// `Ranker::rank` が 1 回も `sink.send` せず Ok 復帰する場合、worker は空 Replace を
+/// engine に送る(spec §9.3「変換失敗で前回候補が画面に残る」を防ぐ)。本 test は
+/// 「typing で候補表示」→「next typing で別 reading の SilentRanker が走り
+/// 候補が clear される」end-to-end shape で verify する。
+#[test]
+fn silent_ranker_clears_engine_candidates_via_empty_replace() {
+    use kotoha_engine_core::engine::KotohaEngine;
+    use kotoha_engine_core::ime_engine::IMEEngine;
+
+    /// `rank` で何も送らずに Ok 復帰する Ranker。
+    struct SilentRanker;
+    impl Ranker for SilentRanker {
+        fn rank(
+            &self,
+            _kana: &str,
+            _ctx: &ConversionContext,
+            _cancel: Arc<dyn CancellationToken>,
+            _sink: std::sync::mpsc::Sender<RankerOutput>,
+        ) -> Result<(), RankerError> {
+            Ok(())
+        }
+    }
+
+    let host = Box::new(MockHostBridge::new());
+    let writer = Arc::new(StubWriter);
+    let mut eng = KotohaEngine::new(host, Arc::new(SilentRanker), writer).expect("engine spawn");
+    eng.enable();
+    eng.focus_in();
+
+    // 'a' typing で SilentRanker が走る → worker から空 Replace が来て engine の
+    // candidates は空のまま、state は LiveConverting(preedit 「あ」)で安定する。
+    eng.process_key_event(key('a'));
+    assert_eq!(eng.candidate_count_for_test(), 0);
+    assert_eq!(eng.preedit_for_test(), "あ");
+
+    // 待機して worker の処理を確実に消化する。
+    sleep(Duration::from_millis(20));
+    eng.process_key_event(key('i'));
+    // 第 2 keystroke 入口の drain_pending_events で前 request の空 Replace が
+    // 適用済み(engine 側の candidates は既に空)。新 SilentRanker request も
+    // 同じ Empty Replace を返す → candidates 空のまま。
+    assert_eq!(eng.candidate_count_for_test(), 0);
+}


### PR DESCRIPTION
## Summary

包括レビュー Critical 4 (spec §7 async モデル崩壊) + Important 8 (worker 空 buffer 区別不能) を消化。spec §5.2 row 4/7 の strict 解釈に従い、Commit mode で **「候補未到着の中間状態 CommitConverting」** が観測可能になり、遅れて到着した候補が後続 keystroke で `CandidatesShown` に遷移するように修正。

## C4 async path correction

- `handle_space`: 即 `CommitConverting` + `show_candidate_window` (row 4) → drain 内で間に合えば row 7 即適用、間に合わなければ後続 process_key_event の drain_pending_events が transition
- `drain_events_blocking` / `drain_pending_events`: `maybe_promote_commit_to_candidates_shown()` helper で row 7 遷移を統合
- 共通 cleanup を `degrade_to_idle()` helper に抽出 (4 site の重複排除)

## I8 worker empty Replace

- `worker_loop`: cancel されていなければ buffer 空でも `Replace(empty)` 送信
- spec §9.3「変換失敗で前回候補が画面に残る」を防ぐ
- engine 側は既存 `apply_candidate_update::Replace` で空 Vec assign により stale clear

## 新規 test (3 件)

- `live_space_with_slow_ranker_stays_at_commit_converting` (row 4 strict)
- `commit_converting_transitions_to_candidates_shown_on_late_arrival` (row 7)
- `silent_ranker_clears_engine_candidates_via_empty_replace` (Important 8)

## Test plan

- [x] lefthook pre-push 全 stage PASS
- [x] state_transitions: 16 → 18 (+2)
- [x] worker_coalescing: 8 → 9 (+1)
- [x] full workspace: 466 → 469 (+3), 0 regression
- [x] gitleaks clean
- [x] 既存 cancel triggers 7 case + state_transitions 16 case 全 PASS (worker 動作変更の regression なし)

## Out of scope (B0e)

- I10 RankerOutput.request_id dead field 撤去
- I11 IBusEventDispatcher 単体 test
- I12 L2-core sequence assertion
- regression_phase1 #[ignore] / ibus_host_bridge assertion

Refs #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)