### PR TITLE
refactor: RankerOutput.request_id removal + dispatcher/regression cleanup (P3-B B0e)

### DIFF
--- a/crates/kotoha-engine-core/src/engine/worker.rs
+++ b/crates/kotoha-engine-core/src/engine/worker.rs
@@ -176,12 +176,11 @@ fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> &str {
 /// 指定 window 内に Ranker から届いた `RankerOutput` を `buffer` に集約する。
 /// cancel detect で即時 break。
 ///
-/// `RankerOutput.request_id` は Ranker impl 側の内部 counter であって engine の
-/// `request_id` と一致する保証はない(`Ranker::rank` の trait signature は engine
-/// の id を受け取らない)。従って本 `rx_ranker` channel は **request 毎に新規作成**
-/// される(worker_loop 参照)前提で、ここに来る output はすべて current request の
-/// ものとして受け入れる。stale response の discard は engine 主 thread 側の
-/// `request_id` 照合(spec §7.5)で実施する。
+/// 本 `rx_ranker` channel は **request 毎に新規作成** される(worker_loop 参照)
+/// 前提で、ここに来る output はすべて current request のものとして受け入れる。
+/// `RankerOutput` 自体に id は持たない設計(B0e で `request_id` field を撤去)。
+/// Stale response の discard は engine 主 thread 側の `RankRequest`/`active_request`
+/// ベース id 照合(spec §7.5)で実施する。
 fn drain_window(
     rx_ranker: &mpsc::Receiver<RankerOutput>,
     cancel: &Arc<dyn CancellationToken>,

--- a/crates/kotoha-engine-core/src/ranker/hybrid.rs
+++ b/crates/kotoha-engine-core/src/ranker/hybrid.rs
@@ -5,7 +5,6 @@
 //!
 //! Phase 3-A spec §4.3 で凍結された Ranker trait の concrete impl。
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
@@ -31,11 +30,17 @@ const DEFAULT_TOP_K: usize = 10;
 /// `Arc<dyn LearningCacheReader>` を構築時に DI で受け取る。LLM backend は
 /// M3 で追加し、`Option` 化することで dict-only(M2)動作を保つ。
 ///
-/// # Invariants
+/// # Stale response の discard (Phase 3-B B0e で簡素化)
 ///
-/// - `request_id_seed` は `rank()` 呼び出し毎に単調増加で採番される
-///   (`RankerOutput.request_id` の uniqueness を担保し、engine 主 thread
-///   側で stale response の discard に使う、Phase 3-A spec §7.5)
+/// 以前は `request_id_seed` で内部 counter を維持し `RankerOutput.request_id`
+/// に stamp していたが、`Ranker::rank` の trait signature が engine 側
+/// `request_id` を引数で受けない設計のため、Ranker 側で stamp しても engine 側
+/// で意味のある照合は不可能(B5 で worker レベルの id 照合を撤去した時点で
+/// dead surface 化していた)。`RankerOutput.request_id` field を撤去した
+/// (Important 10、ISSUE #140)。
+///
+/// Stale response の discard は engine 主 thread 側の `RankRequest`/`active_request`
+/// ベース id 照合 + per-request channel 不変条件で十分に成立する(spec §7.5)。
 pub struct HybridRanker {
     sudachi: Arc<dyn MorphologicalEngine + Send + Sync>,
     user_vocab: Arc<dyn UserVocabReader>,
@@ -50,7 +55,6 @@ pub struct HybridRanker {
     /// `Send + Sync` 不要、Phase 1 単 thread CLI 由来の歴史的設計、
     /// kotoha-core spec §5.3)。
     llm: Option<Arc<dyn KanjiBackend + Send + Sync>>,
-    request_id_seed: AtomicU64,
 }
 
 impl HybridRanker {
@@ -77,7 +81,6 @@ impl HybridRanker {
             user_vocab,
             learning_cache,
             llm: None,
-            request_id_seed: AtomicU64::new(0),
         }
     }
 
@@ -96,10 +99,6 @@ impl HybridRanker {
     pub fn with_llm(mut self, llm: Arc<dyn KanjiBackend + Send + Sync>) -> Self {
         self.llm = Some(llm);
         self
-    }
-
-    fn next_request_id(&self) -> u64 {
-        self.request_id_seed.fetch_add(1, Ordering::SeqCst)
     }
 }
 
@@ -142,7 +141,6 @@ impl Ranker for HybridRanker {
         cancel: Arc<dyn CancellationToken>,
         sink: mpsc::Sender<RankerOutput>,
     ) -> Result<(), RankerError> {
-        let request_id = self.next_request_id();
         let kana_owned = kana.to_string();
         // ConversionContext.mode は debug 用 capture(将来 Live mode で LLM skip など
         // mode-dependent behavior を実装する余地)。commit_history 注入は M3 範囲外。
@@ -248,7 +246,6 @@ impl Ranker for HybridRanker {
             // 先に終わる」のは正常 path(engine 側で active request が更新済みのケース、
             // Phase 3-A spec §7.5)。Caller が cleanup 中のため tracing::trace で吸収する。
             if let Err(e) = sink.send(RankerOutput {
-                request_id,
                 update: CandidateUpdate::Replace(merged),
             }) {
                 tracing::trace!(error = ?e, "ranker sink closed before dict send");
@@ -288,7 +285,6 @@ impl Ranker for HybridRanker {
                         DEFAULT_TOP_K,
                     );
                     if let Err(e) = sink.send(RankerOutput {
-                        request_id,
                         update: CandidateUpdate::Replace(combined),
                     }) {
                         tracing::trace!(error = ?e, "ranker sink closed before LLM send");
@@ -356,19 +352,6 @@ mod tests {
             learning_cache.clone() as Arc<dyn LearningCacheReader>,
         );
         (ranker, user_vocab, learning_cache)
-    }
-
-    /// 別 `rank()` 呼び出しで `request_id` が単調増加することを確認(spec §7.5)。
-    #[test]
-    fn request_id_is_monotonically_increasing() {
-        let (ranker, _uv, _lc) = make_ranker(vec![EngineCandidate {
-            surface: "言葉".into(),
-            reading: "ことば".into(),
-            score: -1.0,
-        }]);
-        let id1 = ranker.next_request_id();
-        let id2 = ranker.next_request_id();
-        assert!(id2 > id1, "expected id2 > id1, got id1={id1} id2={id2}");
     }
 
     /// dict-only path: stub engine の候補が sink に到達する。

--- a/crates/kotoha-engine-core/src/ranker/mod.rs
+++ b/crates/kotoha-engine-core/src/ranker/mod.rs
@@ -28,13 +28,22 @@ use crate::cancel::CancellationToken;
 /// - `cancel.is_cancelled() == true` を検出したら以降の `sink.send()` を停止する。
 /// - backend 個別の cancel propagation:
 ///   - SudachiDict / UserVocab / LearningCache: μs オーダーで完結のため cancel
-///     check は不要(完了時に request_id mismatch なら engine 側で discard)。
+///     check は不要。stale response の discard は engine 主 thread 側 `request_id`
+///     照合(spec §7.5)で行う。Ranker 側は engine の `request_id` を知らない設計。
 ///   - LLM: 10 token 毎に `cancel.is_cancelled()` を check、true なら inference 中断。
 ///
 /// # Thread safety
 ///
 /// `Send + Sync` を要求(engine の `RankerWorker` thread と engine 主 thread の
 /// 双方から `Arc<dyn Ranker>` で参照される)。
+///
+/// # Per-request channel invariant (Phase 3-B B0e)
+///
+/// `sink` は **request 毎に新規作成された** mpsc channel である(`RankerWorker`
+/// が `worker_loop` 各 iteration で `(tx_ranker, rx_ranker) = mpsc::channel()`
+/// を生成し、本 `sink` を Ranker に渡す)。本 channel に届く output はすべて
+/// current request のものとして worker が受け取る。Ranker 側は出力を識別する
+/// id を持たない(以前の `RankerOutput.request_id` field は撤去済、I10)。
 pub trait Ranker: Send + Sync {
     /// 候補生成の起動。同期 return、heavy work は impl 内 thread に dispatch。
     ///
@@ -52,12 +61,17 @@ pub trait Ranker: Send + Sync {
 }
 
 /// Ranker から engine への通知 message。
+///
+/// # Phase 3-B B0e (ISSUE #140 / Important 10)
+///
+/// `request_id` field は撤去済。`Ranker::rank` の trait signature が engine
+/// 側 `request_id` を引数で受けない設計のため、Ranker impl 側で stamp しても
+/// engine 側で意味のある照合は不可能だった(B5 で worker レベルの id 照合を
+/// 撤去した時点で `request_id` field は dead surface 化)。
+/// Stale response の discard は engine 主 thread 側の `RankRequest` ベース
+/// id 照合 + per-request channel 不変条件で十分に成立する(spec §7.5)。
 #[derive(Debug, Clone)]
 pub struct RankerOutput {
-    /// engine 主 thread 側で active_request.id と mismatch なら discard する識別子。
-    /// engine が `RankRequest` 発行時に採番した値を Ranker 内部で保持し送出する
-    /// (Phase 3-A spec §7.5)。
-    pub request_id: u64,
     /// 差分通知本体。
     pub update: CandidateUpdate,
 }

--- a/crates/kotoha-engine-core/src/testing.rs
+++ b/crates/kotoha-engine-core/src/testing.rs
@@ -165,11 +165,10 @@ impl Ranker for MockRanker {
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             return Ok(());
         }
-        // request_id は engine 主 thread 採番ではなく、Mock では 0 固定とし、
-        // M3 で `RankerWorker` 経由になった時に worker が `request_id` を
-        // `RankerOutput.request_id` に上書きする設計。
+        // `RankerOutput.request_id` field は B0e (ISSUE #140 / Important 10)で撤去済。
+        // Stale response の discard は engine 主 thread 側で `RankRequest`/`active_request`
+        // ベースの id 照合 + per-request channel 不変条件で成立する(spec §7.5)。
         let _ = sink.send(RankerOutput {
-            request_id: 0,
             update: CandidateUpdate::Replace(self.candidates.clone()),
         });
         Ok(())

--- a/crates/kotoha-engine-core/tests/regression_phase1.rs
+++ b/crates/kotoha-engine-core/tests/regression_phase1.rs
@@ -50,7 +50,19 @@ mod smoke {
 
 /// `llama-cpp-smoke` 無効時の compile-only sanity。本 test は assertion を
 /// 持たず、ファイル全体が default features で compile することのみ観測する。
+///
+/// # B0e (ISSUE #140) `#[ignore]` 化
+///
+/// 包括レビュー(2026-05-03)で「empty body / no assertion で silent test
+/// rot を作る」と指摘された。本 placeholder は実 fixture loader 実装が完了
+/// するまで `#[ignore]` で skip し、`cargo test` の green check が空 body
+/// に騙されないようにする。`cargo test -- --ignored` で明示実行可能(現状は
+/// 通っても何も assert しないため意味のある signal は出ない)。
+///
+/// 後続 ISSUE で実 fixture loader を実装するまでの暫定処置。
 #[test]
+#[ignore = "placeholder: no assertions; will be replaced by HybridRanker-driven \
+            14/15 fixture loader in a follow-up ISSUE"]
 #[cfg(not(feature = "llama-cpp-smoke"))]
 fn regression_test_compiles_without_llama_smoke_feature() {
     // Intentional empty body. The presence of this test under default features

--- a/crates/kotoha-engine-core/tests/state_transitions.rs
+++ b/crates/kotoha-engine-core/tests/state_transitions.rs
@@ -349,7 +349,6 @@ impl kotoha_engine_core::ranker::Ranker for SlowRanker {
                 return;
             }
             let _ = sink.send(kotoha_engine_core::ranker::RankerOutput {
-                request_id: 0,
                 update: kotoha_engine_core::ranker::CandidateUpdate::Replace(cands),
             });
         });

--- a/crates/kotoha-engine-core/tests/worker_coalescing.rs
+++ b/crates/kotoha-engine-core/tests/worker_coalescing.rs
@@ -48,7 +48,6 @@ impl Ranker for CancelObservingRanker {
                 return;
             }
             let _ = sink.send(RankerOutput {
-                request_id: 0,
                 update: CandidateUpdate::Replace(vec![Candidate::new("か", -1.0)]),
             });
         });
@@ -134,7 +133,6 @@ fn worker_recovers_after_ranker_panic() {
             self.second_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let _ = sink.send(RankerOutput {
-                request_id: 0,
                 update: CandidateUpdate::Replace(vec![Candidate::new("あ", -1.0)]),
             });
             Ok(())

--- a/crates/kotoha-engine-ibus/src/dispatcher.rs
+++ b/crates/kotoha-engine-ibus/src/dispatcher.rs
@@ -71,3 +71,116 @@ impl<E: IMEEngine> IBusEventDispatcher<E> {
         &mut self.engine
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Phase 3-B B0e (ISSUE #140 / Important 11): dispatcher の 6 method を
+    //! `MockEngine` 注入で網羅する unit test。
+
+    use super::*;
+    use kotoha_engine_core::ime_engine::IMEEngine;
+    use kotoha_engine_core::key_event::{KeyEvent, KeyEventResult};
+
+    /// dispatcher 単体 test 専用の最小 IMEEngine 実装。
+    ///
+    /// 各 method 呼び出しを名前文字列として `lifecycle` Vec に記録する。
+    /// `process_key_event` の戻り値は `key_result` で制御可能。
+    struct MockEngine {
+        lifecycle: Vec<&'static str>,
+        last_key: Option<KeyEvent>,
+        key_result: KeyEventResult,
+    }
+
+    impl MockEngine {
+        fn new(key_result: KeyEventResult) -> Self {
+            Self {
+                lifecycle: Vec::new(),
+                last_key: None,
+                key_result,
+            }
+        }
+    }
+
+    impl IMEEngine for MockEngine {
+        fn process_key_event(&mut self, key: KeyEvent) -> KeyEventResult {
+            self.lifecycle.push("process_key_event");
+            self.last_key = Some(key);
+            self.key_result
+        }
+        fn focus_in(&mut self) {
+            self.lifecycle.push("focus_in");
+        }
+        fn focus_out(&mut self) {
+            self.lifecycle.push("focus_out");
+        }
+        fn reset(&mut self) {
+            self.lifecycle.push("reset");
+        }
+        fn enable(&mut self) {
+            self.lifecycle.push("enable");
+        }
+        fn disable(&mut self) {
+            self.lifecycle.push("disable");
+        }
+    }
+
+    #[test]
+    fn dispatch_key_consumed_returns_true_and_decodes_state() {
+        let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Consumed));
+        // SHIFT_MASK (1 << 0) | CONTROL_MASK (1 << 2) = 0b101 = 5
+        let consumed = d.dispatch_key(0x6b, 45, 5);
+        assert!(consumed);
+        let ev = d.engine_mut().last_key.expect("key recorded");
+        assert_eq!(ev.keysym, 0x6b);
+        assert_eq!(ev.keycode, 45);
+        assert!(ev
+            .modifiers
+            .contains(kotoha_engine_core::KeyModifiers::SHIFT));
+        assert!(ev
+            .modifiers
+            .contains(kotoha_engine_core::KeyModifiers::CTRL));
+        assert_eq!(d.engine_mut().lifecycle, vec!["process_key_event"]);
+    }
+
+    #[test]
+    fn dispatch_key_forwarded_returns_false() {
+        let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Forwarded));
+        let consumed = d.dispatch_key(0x6b, 0, 0);
+        assert!(!consumed);
+    }
+
+    #[test]
+    fn dispatch_focus_in_invokes_focus_in() {
+        let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Forwarded));
+        d.dispatch_focus_in();
+        assert_eq!(d.engine_mut().lifecycle, vec!["focus_in"]);
+    }
+
+    #[test]
+    fn dispatch_focus_out_invokes_focus_out() {
+        let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Forwarded));
+        d.dispatch_focus_out();
+        assert_eq!(d.engine_mut().lifecycle, vec!["focus_out"]);
+    }
+
+    #[test]
+    fn dispatch_enable_invokes_enable() {
+        let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Forwarded));
+        d.dispatch_enable();
+        assert_eq!(d.engine_mut().lifecycle, vec!["enable"]);
+    }
+
+    #[test]
+    fn dispatch_disable_invokes_disable() {
+        let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Forwarded));
+        d.dispatch_disable();
+        assert_eq!(d.engine_mut().lifecycle, vec!["disable"]);
+    }
+
+    #[test]
+    fn dispatch_reset_invokes_reset() {
+        let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Forwarded));
+        d.dispatch_reset();
+        assert_eq!(d.engine_mut().lifecycle, vec!["reset"]);
+    }
+}

--- a/crates/kotoha-engine-ibus/tests/ibus_host_bridge.rs
+++ b/crates/kotoha-engine-ibus/tests/ibus_host_bridge.rs
@@ -3,19 +3,24 @@
 //! 完全な mock IBus daemon は spec §10.1 / Open Q 9 で実装段階に詰める。
 //! 本 PR は **接続 only** の smoke を入れ、PR レビューで sequence assert
 //! の詳細化を Phase 3-A 本番実装段階に deferral する。
+//!
+//! # B0e (ISSUE #140 / Important review feedback)
+//!
+//! 旧版は `Err(e)` で全 path を skip しており assertion ゼロだった。本 fix で:
+//!
+//! - session bus が無い場合は `#[ignore]` で skip(green check で誤誘導しない)
+//! - session bus が在る場合は `result.is_ok()` を assert
+//! - session bus 在 + 接続失敗(IBus daemon 未起動等)時は明示 panic で fail surface
 
 #[test]
-fn host_bridge_constructs_with_dummy_path() {
-    // session bus が無い CI 環境では skip(`DBUS_SESSION_BUS_ADDRESS` 未設定時)。
-    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err() {
-        eprintln!("skipping: no session bus available");
-        return;
-    }
+#[ignore = "requires DBUS_SESSION_BUS_ADDRESS; run with `cargo test -- --ignored`"]
+fn host_bridge_constructs_with_session_bus() {
+    let _addr = std::env::var("DBUS_SESSION_BUS_ADDRESS")
+        .expect("DBUS_SESSION_BUS_ADDRESS required for this test");
     let result = kotoha_engine_ibus::IBusHostBridge::new("/org/freedesktop/IBus/Engine/Kotoha");
-    // 構築できれば PASS、call 詳細は Phase 3-A 実装段階で詰める。
-    // session bus へ接続できない場合(daemon 未起動等)は Err でも skip。
-    match result {
-        Ok(_) => (),
-        Err(e) => eprintln!("session bus connect failed (skipping): {e}"),
-    }
+    assert!(
+        result.is_ok(),
+        "IBusHostBridge::new should succeed on a healthy session bus: {:?}",
+        result.err()
+    );
 }


### PR DESCRIPTION
## Summary

包括レビュー Important 10 (RankerOutput.request_id dead field) + Important 11 (IBusEventDispatcher 単体 test 0) + silent test rot 2 件 (regression_phase1 / ibus_host_bridge) を消化。**P3-B B0 の最終 cleanup PR**。

## I10 RankerOutput.request_id 撤去

`Ranker::rank` trait signature が engine 側 `request_id` を受けない設計のため、Ranker impl 側の `RankerOutput.request_id` field は誰にも読まれない dead surface だった。撤去。

- `RankerOutput` から field 削除
- `HybridRanker.request_id_seed` AtomicU64 + `next_request_id` 削除
- 全 test の `request_id: 0` field 撤去
- doc comment を per-request channel 不変条件 + engine main-thread id 照合で stale discard が成立することを明示

## I11 IBusEventDispatcher 6 method unit test

`MockEngine` 注入で `dispatch_*` 全 method を assert(consumed/forwarded 切替 + state mask decode + lifecycle invoke 順)。

## silent test rot 解消

- `regression_phase1.rs` の empty-body placeholder を `#[ignore]` 化
- `ibus_host_bridge.rs`: assertion ゼロ test を削除し `host_bridge_constructs_with_session_bus` (#[ignore] + `assert!(result.is_ok())`) に置換

## Test plan

- [x] lefthook pre-push 全 stage PASS
- [x] dispatcher: 0 → 6 unit tests
- [x] full workspace: 469 → 473 (+4), 0 regression
- [x] gitleaks clean
- [x] HybridRanker engine_wrap_hybrid + worker_coalescing 既存 test 全 PASS (id 撤去後の regression なし、per-request channel 不変条件で機能継続)

## P3-B B0 完成宣言

本 PR で B0 範囲の Critical 4 + Important 9 全消化。次は B2 (IBus signal body marshalling) / B3 (signal listener loop) に進める状態。

Refs #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)