### PR TITLE
P3-B B0f: retract phase 3-A 機能完成 declaration; gate IBus stubs to fail-fast (#146)

### DIFF
--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -184,15 +184,24 @@ fn run_ibus() -> anyhow::Result<()> {
     let engine = kotoha_engine_core::engine::KotohaEngine::new(host_bridge, ranker, learning_store)
         .context("spawn ranker worker thread")?;
 
-    // 10. dispatcher (event loop stub)
+    // 10. dispatcher (event loop stub) — wire up but do NOT silently exit.
+    //
+    // Phase 3-B B0f (ISSUE #146):旧 path は `let _dispatcher = ...; Ok(())` で
+    // event loop が無いまま exit code 0 を返し、systemd の Restart=on-failure
+    // が再起動しない silent failure(spec §9.3 違反)だった。実 event loop
+    // 完成までは fail-loud で起動失敗を user に通知する。
     let _dispatcher = kotoha_engine_ibus::IBusEventDispatcher::new(engine);
 
-    tracing::info!(
+    tracing::error!(
         ranker_backend,
         host_bridge_backend,
-        "kotoha engine wired up; event loop deferred to Phase 3-B B3"
+        "kotoha engine wired up but the IBus event loop is not yet implemented (Phase 3-B B3); \
+         refusing to silently exit"
     );
-    Ok(())
+    anyhow::bail!(
+        "IBus event loop not yet implemented (tracked in Phase 3-B B3 / ISSUE #146); \
+         kotoha-bin cannot serve as an IME yet"
+    );
 }
 
 /// `HybridRanker` を構築する production helper。

--- a/crates/kotoha-engine-ibus/src/proxy.rs
+++ b/crates/kotoha-engine-ibus/src/proxy.rs
@@ -1,26 +1,46 @@
 //! IBus 1.x D-Bus interface proxy 定義(zbus 5.x blocking API 経由)。
 //!
-//! IBus engine が呼び出す host 側 method は `org.freedesktop.IBus.Engine`
-//! interface の subclass virtual method として送出される。実用的に Rust 側で
-//! IBus engine subclass を定義することは難しいため、本 module では engine
-//! object path を保持した上で zbus `Connection` に signal を emit する形を
-//! 取る。signal body の `IBusText` / `IBusLookupTable` 詳細 marshalling は
-//! Phase 3-A 実装段階の L3 manual smoke で empirical に詳細化する
+//! # 現状(Phase 3-B B0f 時点)
+//!
+//! signal body marshalling と emit 機構は **Phase 3-B B2 / B3 で実装する**。
+//! B0f までは 5 method すべて [`zbus::Error::Failure`] を返し fail-loud で
+//! 動く(spec §9.3「silent_failure 禁止」を守るため)。host_bridge 側は
+//! `Err` を `tracing::warn!` で観測する経路を既に持つ
+//! (`crates/kotoha-engine-ibus/src/host_bridge.rs`)。
+//!
+//! 旧版(B0e まで)は `Ok(())` を返して TRACE log 1 行のみ残す **silent
+//! no-op stub** で、production 起動成功 INFO log と組合わさって user に
+//! 「IBus 通信が動いていない」を伝えない構造的 silent failure を作っていた。
+//! 包括 review (2026-05-03) で Critical 1 として検出した(ISSUE #146)。
+//!
+//! 実 signal emit は Phase 3-B B3 で `connection.send_signal` 越しに
+//! `IBusText` / `IBusLookupTable` の D-Bus marshalling を含めて詳細化する
 //! (spec §13 Open Q 9)。
 
 use zbus::blocking::Connection;
 use zbus::Result;
 
+/// 5 method すべてに共通する「未実装である」error message。
+///
+/// caller(`host_bridge.rs`)は本 message を tracing::warn 経由で観測する。
+/// Phase 3-B B3 で実 signal emit に置き換わると本 message は廃止される。
+const NOT_YET_IMPLEMENTED: &str =
+    "IBus signal emit is not yet implemented; tracked in Phase 3-B B3";
+
 /// IBus engine が host(`InputContext`)に発する signal の helper 群。
 ///
-/// 本 PR (M5) では `Connection::session()` で session bus に接続し、object
-/// path を保持するところまでを実装する。signal body 構築 + emit は実装段階で
-/// `connection.send_signal` 越しに詳細化する(spec §13 Open Q 9)。
+/// # 現状
+///
+/// session bus 接続と object path 保持までは本 struct 内で完結するが、
+/// 各 signal emit は B0f 段階で fail-loud(`Err` を返す)。実 emit は
+/// Phase 3-B B3 で実装される。
 pub struct IBusEngineSignals {
-    /// zbus blocking connection(session bus)。
+    /// zbus blocking connection(session bus)。Phase 3-B B3 で
+    /// `connection.send_signal(...)` 越しに使用される。
     #[allow(dead_code)]
     connection: Connection,
     /// engine object path(`/org/freedesktop/IBus/Engine/Kotoha` 等)。
+    /// Phase 3-B B3 で signal の `path` field に使用される。
     #[allow(dead_code)]
     object_path: zbus::zvariant::OwnedObjectPath,
 }
@@ -43,44 +63,67 @@ impl IBusEngineSignals {
 
     /// `UpdatePreeditText(IBusText, u32 cursor_pos, bool visible)` signal emit。
     ///
-    /// IBus 規約上 `IBusText` は `(s a(uuv) v)` 互換の D-Bus type で、
-    /// attribute list と attachment dict を持つ struct。M5 段階では string-only の
-    /// 簡略 marshalling とし、attribute は Phase 3-A 実装段階で詳細化する
-    /// (spec §13 Open Q 9)。
+    /// # Errors
+    ///
+    /// 現状は常に [`zbus::Error::Failure`] を返す(Phase 3-B B3 まで未実装)。
     pub fn update_preedit(&self, text: &str, cursor: u32, visible: bool) -> Result<()> {
-        tracing::trace!(text, cursor, visible, "IBus update_preedit (zbus)");
-        Ok(())
+        tracing::warn!(
+            text_len = text.chars().count(),
+            cursor,
+            visible,
+            "IBus update_preedit not yet wired to D-Bus (Phase 3-B B3)"
+        );
+        Err(zbus::Error::Failure(NOT_YET_IMPLEMENTED.to_string()))
     }
 
     /// `CommitText(IBusText)` signal emit。
+    ///
+    /// # Errors
+    ///
+    /// 現状は常に [`zbus::Error::Failure`] を返す(Phase 3-B B3 まで未実装)。
     pub fn commit_text(&self, text: &str) -> Result<()> {
-        tracing::trace!(text, "IBus commit_text (zbus)");
-        Ok(())
+        tracing::warn!(
+            text_len = text.chars().count(),
+            "IBus commit_text not yet wired to D-Bus (Phase 3-B B3)"
+        );
+        Err(zbus::Error::Failure(NOT_YET_IMPLEMENTED.to_string()))
     }
 
     /// `UpdateLookupTable(IBusLookupTable, bool visible)` signal emit。
+    ///
+    /// # Errors
+    ///
+    /// 現状は常に [`zbus::Error::Failure`] を返す(Phase 3-B B3 まで未実装)。
     pub fn update_lookup_table(
         &self,
         candidates: &[kotoha_core::Candidate],
         visible: bool,
     ) -> Result<()> {
-        tracing::trace!(
+        tracing::warn!(
             count = candidates.len(),
             visible,
-            "IBus update_lookup_table (zbus)"
+            "IBus update_lookup_table not yet wired to D-Bus (Phase 3-B B3)"
         );
-        Ok(())
+        Err(zbus::Error::Failure(NOT_YET_IMPLEMENTED.to_string()))
     }
 
     /// `ShowLookupTable` signal emit。
+    ///
+    /// # Errors
+    ///
+    /// 現状は常に [`zbus::Error::Failure`] を返す(Phase 3-B B3 まで未実装)。
     pub fn show_lookup_table(&self) -> Result<()> {
-        tracing::trace!("IBus show_lookup_table (zbus)");
-        Ok(())
+        tracing::warn!("IBus show_lookup_table not yet wired to D-Bus (Phase 3-B B3)");
+        Err(zbus::Error::Failure(NOT_YET_IMPLEMENTED.to_string()))
     }
 
     /// `HideLookupTable` signal emit。
+    ///
+    /// # Errors
+    ///
+    /// 現状は常に [`zbus::Error::Failure`] を返す(Phase 3-B B3 まで未実装)。
     pub fn hide_lookup_table(&self) -> Result<()> {
-        tracing::trace!("IBus hide_lookup_table (zbus)");
-        Ok(())
+        tracing::warn!("IBus hide_lookup_table not yet wired to D-Bus (Phase 3-B B3)");
+        Err(zbus::Error::Failure(NOT_YET_IMPLEMENTED.to_string()))
     }
 }

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -103,12 +103,14 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 
 ## Test count(実測)
 
-| timing | full workspace |
-|--------|----------------|
-| P2-D 完了時(P3-A 開始前) | 416 |
-| **P3-A M1〜M6 + P3-B B1/B4/B5 完了時(2026-05-03 現在)** | **454** |
+| timing | default features | `--features test-helpers` |
+|--------|------------------|---------------------------|
+| P2-D 完了時(P3-A 開始前) | n/a | 416 |
+| P3-A M1〜M6 + P3-B B1/B4/B5 完了時(B0e merge 直後) | n/a | 459 |
+| **P3-B B0e 完了時(2026-05-03)** | 432 | **473** |
+| **P3-B B0f 完了時(2026-05-03、本 PR)** | 432 | **473**(test 改変ゼロ) |
 
-註:過去の commit message で `446` / `448` と記載した数値は不正確。正規値は `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers` で得た 454。
+註:`cargo test --workspace` (default features) と `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers` で結果が異なる。lefthook pre-push は default features を回す。第 1 回包括 review (B0a-B0e) では test-helpers feature 経由の合計値 (416 → 473) を baseline として参照する。過去の commit message で `446` / `448` / `454` と記載した数値はいずれも不正確で、上表が正規値。
 
 ## L3 manual smoke 結果
 

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -2,15 +2,62 @@
 
 | 項目 | 値 |
 |------|----|
-| ISSUE | #128(自動 close)+ #136(P3-B tracking)+ #140(P3-B B0 必須前提) |
-| 期間 | 2026-05-02 〜(機能完成は P3-B B0 完了時) |
-| Status | **draft 完成 / 機能未完**(下記「再分類後の状態」参照) |
+| ISSUE | #128(自動 close)+ #136(P3-B tracking)+ #140(P3-B B0 / 完了)+ #146(P3-B B0f / 機能完成宣言取り下げ) |
+| 期間 | 2026-05-02 〜(機能完成は P3-B B2 + B3 + L3 manual smoke 完了時に再判定) |
+| Status | **draft 完成 / 機能未完(2026-05-03 再レビューで取り下げ)**(下記「再分類後の状態 v2」参照) |
 | 関連 spec | `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` |
 | 関連 plan | `docs/superpowers/plans/2026-05-02-feature-128-p3a-engine-implementation.md` |
 
-## 再分類後の状態(2026-05-03 包括レビュー後の更新)
+## 再分類後の状態 v2(2026-05-03 第 2 回包括レビュー後)
 
-P3-A の M1〜M6 PR は merge 済 / develop 上に着地済。ただし 2026-05-03 の **包括レビュー(architecture / security / testing / silent-failure 4 視点並列)** で以下の重大ギャップが発覚し、**機能完成宣言を取り下げ、`P3-B B0` を必須前提として後続化** する。
+ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消化(PR #141-#145、test 416 → 473)。直後に **第 2 回包括レビュー(architecture / security / testing / silent-failure 4 dimension 並列再走)** を実施し、**前回見逃した新規 Critical 3 件 + Important 17 件** を検出。最大の問題は以下:
+
+1. **`crates/kotoha-engine-ibus/src/proxy.rs` の 5 method がすべて no-op stub**(`tracing::trace!` + `Ok(())` のみで実 D-Bus signal 送信無し)
+2. **`crates/kotoha-bin/src/main.rs:188` の `let _dispatcher = ...; Ok(())`** で event loop 無く即 exit。INFO log は「kotoha engine wired up」を出すが、IBus daemon に signal は届かず process は exit 0 で正常終了する silent failure(spec §9.3 違反)
+
+上記 2 件は **B0e 段階で「機能完成」と宣言した直後の review で初めて表面化**。`cargo run --bin kotoha` は exit 0 で成功するが、L3 manual smoke を実行した瞬間に「kotoha が 1 keystroke も処理しない」現実が露呈する構造だった。
+
+このため **P3-A 機能完成宣言を取り下げ**(#146 / B0f)、本 WBS の Status を「draft 完成 / 機能未完」に再戻し。機能完成は **B0f + B2 + B3 + L3 manual smoke** 完了時に再判定。
+
+### 第 2 回レビュー検出 Critical(B0f / B2 / B3 で消化)
+
+- **C1 (新)**: `proxy.rs` 5 method の no-op stub(B0f で `Err(zbus::Error::Failure)` 化、B3 で実 signal emit に置換)
+- **C2 (新)**: `main.rs:188` `let _dispatcher; Ok(())` の silent exit(B0f で `anyhow::bail!` に変更、B3 で event loop 実装)
+- **C3 (新)**: hexagonal port 違反 — `kotoha-engine-core` が `kotoha-storage` の trait に直接依存し domain core が adapter 層を import(後続 B0h で driven port 反転)
+- **C4 (新, silent-failure)**: `panic_message` の `Box<dyn Any>` downcast が `&'static str` / `String` のみ対応で `panic_any(anyhow::Error)` 等の payload を消失(後続 B0g で payload + backtrace 拡充)
+- **C5 (新, silent-failure)**: `lookup_table.rs:52` の `_ =>` arm が `non_exhaustive` trap で future variant を WARN 1 行 + no-op fallback に偽装(後続 B0g で exhaustive match 化)
+
+### 第 2 回レビュー検出 Important(後続 B0g / B0h で順次消化)
+
+- I1: `KotohaEngine` SRP 過負荷(5 責務 / `pub(crate)` 14 field 露出)
+- I2: `IBusEventDispatcher<E: IMEEngine>` が engine を own、B3 で `Arc<Mutex<dyn IMEEngine>>` 必須化で破壊的変更不可避
+- I3: `dispatch_rank_request` 同期 blocking が spec §6.1「< 10ms」凍結に違反、加えて Commit 第 2 window (LLM 結果 150ms) が次 keystroke までユーザーに到達しない
+- I4: `HybridRanker` が engine-core 内で dict/kanji backend を巻き込む(crate 分離推奨)
+- I5: Stub fallback が release binary に常時 link、`cfg(debug_assertions)` gate 推奨
+- I6: log credential leak — `hybrid.rs` `kana = %kana_owned` が WARN レベルで `KOTOHA_LOG=info` default 常時出力(B0f / B0g で redact)
+- I7: `HybridRanker` 内 `thread::spawn` の child thread panic が worker.rs catch_unwind 範囲外
+- I8: Engine → IBus 出力に control char / ANSI escape / RTL override / NUL byte sanitization 無し
+- I9: `worker_loop` 自体に top-level catch_unwind が無く永続 IME-disabled risk
+- I10: `silent_ranker_clears_engine_candidates_via_empty_replace` が tautology(theater pattern 再発)
+- I11: spec §5.2 row 8(CommitConverting + Esc/backspace/focus_out)が unit test 0
+- I12: thread::sleep 依存 timing assertion で flaky 温床(`commit_converting_..._on_late_arrival` は 30ms margin only)
+- I13: `worker_recovers_after_ranker_panic` が `second_calls >= 1` のみで half-dead engine を pass 判定
+- I14: MockRanker/MockHostBridge の引数 verification 不在(cursor 値 / kana 値が catch されない)
+- I15: hybrid.rs 全 backend 全滅時 dict-only path で **空 Vec を tracing::error 無しで送信**(spec §9.1 row 3 違反)
+- I16: worker 連続 panic に circuit breaker 無し(error log flood)
+- I17: `dispatcher.rs:41-47` `dispatch_key` が `engine.process_key_event` の panic を catch せず spec §9.1 row 5 違反
+
+### B0f scope(本 ISSUE #146)
+
+機能完成宣言の取り下げ + fail-loud gating の最小範囲:
+
+- proxy.rs 5 method を `Err(zbus::Error::Failure(NOT_YET_IMPLEMENTED))` 化
+- proxy.rs `tracing::trace!(text, ...)` を `text_len = text.chars().count()` に redact(I6 部分対応)
+- main.rs `run_ibus()` を `anyhow::bail!` 化(exit code 1 で起動失敗)
+- 本 WBS の status / 機能完成記述を取り下げ
+- B0g / B0h は別 ISSUE で順次対応
+
+## 再分類後の状態 v1(2026-05-03 第 1 回包括レビュー、ISSUE #140 で消化済)
 
 ### Critical(機能完成 blocker、P3-B B0 で消化)
 
@@ -89,7 +136,10 @@ GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 applicatio
 
 | # | Sub-milestone | 状態 |
 |---|---|---|
-| **B0 (#140)** | **包括レビュー Critical 4 + Important 9 消化(下記 ISSUE 参照)** | **未着手 / 機能完成 blocker** |
-| B2 | IBus signal body marshalling | B0 後着手 |
-| B3 | IBus signal listener loop + event loop | B0 後着手 |
-| B6 | L3 manual smoke | B2/B3 後着手 |
+| ~~B0 (#140)~~ | 第 1 回包括レビュー Critical 4 + Important 9 消化 | **完了**(PR #141-#145、test 416 → 473) |
+| **B0f (#146)** | 機能完成宣言取り下げ + proxy / event loop fail-loud 化 | **進行中**(本 PR) |
+| B0g (TBD ISSUE) | 第 2 回 review C4 / C5 / I7-I17 系の中期消化 | B0f 後着手 |
+| B0h (TBD ISSUE) | hexagonal port 反転(C3) + SRP 分割(I1) + dispatcher Arc<Mutex>(I2) | OSS 公開前必修 |
+| B2 | IBus signal body marshalling | B0f 後着手 |
+| B3 | IBus signal listener loop + event loop | B0f / B2 後着手 |
+| B6 | L3 manual smoke | B2 / B3 後着手 |


### PR DESCRIPTION
## Summary

- Detect: 2nd comprehensive review (2026-05-03, post-B0e) found that the 1st-review-driven B0a-B0e merges had still left two silent failures: `proxy.rs` is a 5-method no-op stub and `main.rs:188` discards the dispatcher and exits 0 without any event loop. `kotoha-bin` therefore appeared to start while serving zero IME functionality (spec §9.3 violation).
- Fix: convert proxy 5 methods to fail-loud `Err(zbus::Error::Failure(NOT_YET_IMPLEMENTED))`, convert `run_ibus()` trailing `Ok(())` to `anyhow::bail!`, retract the "機能完成" declaration in WBS and record the new Critical 3 + Important 17 list from the 2nd review.
- Scope: minimal gating only. B0g / B0h / B2 / B3 cover the remaining work.

## Why this PR exists

The 1st review (which produced B0a-B0e) verified state-machine + worker-thread paths but did not exercise the actual D-Bus signal layer — proxy.rs was 5 `Ok(())` stubs the whole time, and `main.rs` ended its DI sequence with `let _dispatcher = ...; Ok(())`. Both were inherited from M5/M6 PRs (#134/#135). After B0e merged I declared 機能完成 based on the green test count (473 PASS). This PR retracts that declaration; the binary cannot serve a single keystroke until B2 + B3 are done.

## Verification

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (0 warnings)
- [x] `cargo test --workspace` 0 regression
- [x] `KOTOHA_ALLOW_STUB=1 ./target/debug/kotoha` exits with status 1 and a clear error chain naming ISSUE #146 (previously exit 0 with misleading INFO "kotoha engine wired up")
- [x] WBS reflects retracted state with full 2nd-review finding list

## Out of scope (will land in separate ISSUEs)

- B0g: C4 panic_message widening, C5 lookup_table `_`-arm trap, I7-I17 (silent failure / security / testing fixes)
- B0h: C3 hexagonal driven port inversion, I1 SRP split, I2 dispatcher Arc<Mutex>, I3 dispatch_rank_request blocking removal, I4 HybridRanker crate split, I5 stub feature gate
- B2: IBus signal body marshalling
- B3: IBus signal listener loop + event loop body (real resolution of C1+C2)

## Test plan

- [x] Local: `cargo test --workspace` 0 regression
- [x] Local: `KOTOHA_ALLOW_STUB=1 ./target/debug/kotoha` returns exit 1
- [ ] L3 manual smoke deferred until B2 + B3 (per spec §13 Open Q 9)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)