### PR TITLE
P3-B B0g-a: silent-failure residuals (panic_message + lookup_table + worker circuit breaker + hybrid empty-fallback + dispatcher panic catch) (#148)

### DIFF
--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -113,7 +113,15 @@ fn install_panic_hook() {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         // tracing への構造化転送(systemd journal / log aggregator 想定)
+        //
+        // self-review #1:同一 panic に対して本 hook と `catch_unwind` 経路の
+        // 両方で `tracing::error!` が出る(unwind 開始前 / 後で 2 回)。後段
+        // 集計で重複扱いするため `source = "panic_hook"` で識別子を付与する。
+        // catch_unwind 経路側は別 message なので grep で区別可能だが、本 field
+        // を併用すると alert duplication 抑制が容易。
         tracing::error!(
+            source = "panic_hook",
+            thread = ?std::thread::current().name(),
             location = ?info.location(),
             payload = %info,
             "panic hook captured panic"

--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -50,6 +50,7 @@ const EXIT_FAILURE: u8 = 1;
 
 fn main() -> ExitCode {
     init_tracing();
+    install_panic_hook();
 
     // spec §9.1 row 5: top-level catch_unwind。`AssertUnwindSafe` は
     // `run()` 内部で borrow / mutex を panic 越しに抱える設計でないことを
@@ -64,21 +65,62 @@ fn main() -> ExitCode {
         }
         Err(panic_payload) => {
             let msg = panic_message(&panic_payload);
-            tracing::error!(panic = msg, "kotoha-bin caught top-level panic");
+            tracing::error!(panic = %msg, "kotoha-bin caught top-level panic");
             ExitCode::from(EXIT_TEMPFAIL)
         }
     }
 }
 
-/// `catch_unwind` payload から表示用 message を取り出す best-effort helper。
-fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> &str {
+/// `catch_unwind` payload から表示用 message を best-effort で抽出する。
+///
+/// B0g #148 / 第 2 回 review C4: 旧 impl は `&'static str` / `String` のみ
+/// downcast していたため、`panic_any(anyhow::Error)` 等の payload が
+/// `(non-string panic payload)` で消失していた。本版では:
+///
+/// - `&'static str` / `String` を最優先で抽出
+/// - `anyhow::Error` 経由の `panic_any` を debug 形式で展開
+/// - いずれにも該当しない場合は payload type 名(`std::any::Any::type_id`
+///   の Debug 表現)を含めて返す
+///
+/// 加えて、本関数で payload を取り損ねた場合でも `install_panic_hook` で
+/// 登録された hook が **panic 発生時の location + backtrace を `tracing::error!`
+/// に残す**(本関数の前段で観測される)ため、root cause 探索が継続可能。
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
-        s
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.as_str()
-    } else {
-        "(non-string panic payload)"
+        return (*s).to_string();
     }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    if let Some(e) = payload.downcast_ref::<anyhow::Error>() {
+        return format!("anyhow: {e:?}");
+    }
+    format!(
+        "(non-string panic payload, type_id={:?})",
+        (**payload).type_id()
+    )
+}
+
+/// process global panic hook。`tracing` が初期化された後に呼ぶこと。
+///
+/// B0g #148 / C4: hook を登録することで、`catch_unwind` の payload type に
+/// 依存せず **panic location + payload 表示** が確実に `tracing::error!` に
+/// 流れる。`catch_unwind` 経由の `tracing::error!(panic = ..., ...)` と
+/// 重複するが、hook の方が source file / line number を持つため debug 価値
+/// が高い。
+fn install_panic_hook() {
+    // Default hook も呼んで stderr 上の human-readable backtrace を残す。
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // tracing への構造化転送(systemd journal / log aggregator 想定)
+        tracing::error!(
+            location = ?info.location(),
+            payload = %info,
+            "panic hook captured panic"
+        );
+        // stderr へ default の human-readable trace も流す
+        default_hook(info);
+    }));
 }
 
 fn run() -> anyhow::Result<()> {

--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -176,15 +176,23 @@ impl KotohaEngine {
             // engine 状態を Idle に戻して候補ウィンドウを閉じ、stale な
             // active_request を残さない(後続 keystroke の cancel_active が
             // phantom request を握って残響しないようにする)。
+            //
+            // B0g #148 / I16: worker は連続 panic 上限到達で exit する circuit
+            // breaker を持つ。本 path に到達したら、engine 全体を IME-disabled
+            // に倒して keystroke ごとの ERROR log flood を停止し、user が
+            // 「IME が無効化された」を察知できるようにする(spec §9.3
+            // 「IME-disabled mode を user に通知」)。
             tracing::error!(
                 request_id,
-                "ranker worker channel closed; engine degrading to Idle"
+                "ranker worker channel closed; engine going to IME-disabled (consecutive panic threshold reached \
+                 or worker exited unexpectedly)"
             );
             self.active_request = None;
             self.candidates.clear();
             self.highlight_idx = 0;
             self.host.hide_candidate_window();
             self.state = EngineState::Idle;
+            self.enabled = false;
             return;
         }
 
@@ -427,5 +435,12 @@ impl KotohaEngine {
     /// Test-only inspector: 現在 state を返す。
     pub fn state_for_test(&self) -> EngineState {
         self.state
+    }
+    /// Test-only inspector: 現在 enabled flag を返す。
+    ///
+    /// B0g #148 / I16 で「worker 連続 panic → engine が IME-disabled に degrade」
+    /// を assert するための accessor。
+    pub fn enabled_for_test(&self) -> bool {
+        self.enabled
     }
 }

--- a/crates/kotoha-engine-core/src/engine/transitions.rs
+++ b/crates/kotoha-engine-core/src/engine/transitions.rs
@@ -76,6 +76,14 @@ fn handle_typing(engine: &mut KotohaEngine, key: KeyEvent) -> KeyEventResult {
     if !engine.current_preedit.is_empty() {
         engine.cancel_active();
         engine.dispatch_rank_request(ConversionMode::Live);
+        // B0g #148 / I16:dispatch_rank_request が worker channel disconnect を
+        // 観測すると `enabled = false` + `state = Idle` に degrade する。本 path
+        // では state を LiveConverting に上書きせず、IME-disabled 状態を維持する
+        // (上書きすると次 keystroke で再度 dispatch を試み ERROR log flood に
+        // 戻る)。
+        if !engine.enabled {
+            return KeyEventResult::Consumed;
+        }
         if !engine.candidates.is_empty() {
             engine
                 .host

--- a/crates/kotoha-engine-core/src/engine/worker.rs
+++ b/crates/kotoha-engine-core/src/engine/worker.rs
@@ -29,6 +29,22 @@ pub const COMMIT_WINDOW: Duration = Duration::from_millis(30);
 /// Commit mode の second window(LLM 後続結果待機、暫定 150ms)。
 pub const COMMIT_SECOND_WINDOW: Duration = Duration::from_millis(150);
 
+/// 連続 panic 上限。Ranker.rank panic と worker body panic を統合 counter で
+/// 監視し、上限到達で worker exit する circuit breaker。
+///
+/// B0g #148 / 第 2 回 review I9 + I16:
+/// - I9 (worker body panic): `apply_to_buffer` / `drain_window` の自前 code が
+///   panic した場合、旧実装は worker thread 死亡 → engine 側永続 IME-disabled。
+/// - I16 (deterministic Ranker panic): `Ranker::rank` が同一入力で繰り返し
+///   panic する場合(例: Mutex poison cascade)、旧実装は keystroke 毎に
+///   ERROR log flood + degrade_to_idle ループで user に signal が届かない。
+///
+/// 本 const は両系統の panic を 1 counter で見て、5 連続で worker thread を
+/// exit させる。exit 後は engine 主 thread が `tx_request.send` の Err を
+/// 観測し、enabled = false に degrade(spec §9.3「IME-disabled mode を
+/// user に通知」)。
+const MAX_CONSECUTIVE_PANICS: u32 = 5;
+
 /// `RankerWorker` を spawn する。
 ///
 /// # Returns
@@ -70,107 +86,196 @@ fn try_send_event(tx_event: &mpsc::Sender<EngineEvent>, ev: EngineEvent, request
     false
 }
 
+/// 1 iteration の処理結果。`worker_loop` の連続 panic counter 制御に使う。
+enum IterationOutcome {
+    /// Ranker.rank も worker body も panic せず通常終了。counter reset 対象。
+    Clean,
+    /// Ranker.rank が panic し WorkerError event を送信済。counter increment 対象
+    /// (deterministic Ranker panic を I16 として検出する)。
+    RankerPanicked,
+    /// `tx_event.send` が Err を返した(engine 主 thread 側 receiver drop)。
+    /// 即時 worker exit する。
+    EngineDisconnected,
+}
+
 fn worker_loop(rx_request: mpsc::Receiver<RankRequest>, tx_event: mpsc::Sender<EngineEvent>) {
+    let mut consecutive_panics: u32 = 0;
     while let Ok(req) = rx_request.recv() {
         let request_id = req.request_id;
-        let mode = req.ctx.mode;
-        let cancel = req.cancel_dyn();
 
-        let (tx_ranker, rx_ranker) = mpsc::channel::<RankerOutput>();
+        // B0g #148 / I9: worker body 全体を catch_unwind で wrap。
+        // `apply_to_buffer` / `drain_window` 等の自前 code が panic しても
+        // worker thread が即死せず、connections / consecutive_panics 越しに
+        // 段階的 degrade させる。
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| handle_one_request(req, &tx_event)));
 
-        // spec §9.1 row 2: Ranker::rank の panic を catch し WorkerError として
-        // 報告。worker thread 自体は loop continue で生存させる(セッション全断
-        // を避ける)。`AssertUnwindSafe` は Ranker / kana / ctx / cancel / sink
-        // が panic 越しに不変であることを caller(本 module)が引き受ける明示。
-        let kana = req.kana.clone();
-        let ctx = req.ctx.clone();
-        let ranker = req.ranker.clone();
-        let cancel_for_call = cancel.clone();
-        let rank_result = panic::catch_unwind(AssertUnwindSafe(move || {
-            ranker.rank(&kana, &ctx, cancel_for_call, tx_ranker)
-        }));
-
-        let rank_outcome = match rank_result {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(e)) => Err(format!("ranker error: {e}")),
-            Err(panic_payload) => {
-                let msg = panic_message(&panic_payload);
-                tracing::error!(request_id, panic = msg, "ranker panicked");
-                Err(format!("ranker panicked: {msg}"))
-            }
-        };
-
-        if let Err(error) = rank_outcome {
-            if try_send_event(
-                &tx_event,
-                EngineEvent::WorkerError { request_id, error },
-                request_id,
-            ) {
-                return;
-            }
-            continue;
-        }
-
-        // 1st window: dict 候補集約
-        let window = match mode {
-            ConversionMode::Live => LIVE_WINDOW,
-            ConversionMode::Commit => COMMIT_WINDOW,
-        };
-        let mut buffer: Vec<Candidate> = Vec::new();
-        drain_window(&rx_ranker, &cancel, window, &mut buffer);
-
-        // Phase 3-B B0d (Important 8): cancel されていなければ buffer が空でも
-        // Replace を送る。engine 側は前回 dispatch の stale 候補を本 Replace で
-        // 確実に clear できる。spec §9.3「変換失敗で前回候補が画面に残る」を防ぐ。
-        if !cancel.is_cancelled()
-            && try_send_event(
-                &tx_event,
-                EngineEvent::Candidates {
+        let panicked = match outcome {
+            Ok(IterationOutcome::Clean) => false,
+            Ok(IterationOutcome::RankerPanicked) => true,
+            Ok(IterationOutcome::EngineDisconnected) => return,
+            Err(payload) => {
+                let msg = panic_message(&payload);
+                tracing::error!(
                     request_id,
-                    update: CandidateUpdate::Replace(buffer.clone()),
-                },
-                request_id,
-            )
-        {
-            return;
-        }
-
-        // 2nd window for Commit mode: LLM 後続結果
-        if mode == ConversionMode::Commit && !cancel.is_cancelled() {
-            let mut second_buffer: Vec<Candidate> = Vec::new();
-            drain_window(
-                &rx_ranker,
-                &cancel,
-                COMMIT_SECOND_WINDOW,
-                &mut second_buffer,
-            );
-            if !cancel.is_cancelled() && !second_buffer.is_empty() {
-                buffer.extend(second_buffer);
-                let send_failed = try_send_event(
+                    panic = %msg,
+                    "worker_loop body panicked outside Ranker::rank"
+                );
+                if try_send_event(
                     &tx_event,
-                    EngineEvent::Candidates {
+                    EngineEvent::WorkerError {
                         request_id,
-                        update: CandidateUpdate::Replace(buffer),
+                        error: format!("worker body panicked: {msg}"),
                     },
                     request_id,
-                );
-                if send_failed {
+                ) {
                     return;
                 }
+                true
             }
+        };
+
+        if panicked {
+            consecutive_panics += 1;
+            if consecutive_panics >= MAX_CONSECUTIVE_PANICS {
+                tracing::error!(
+                    consecutive_panics,
+                    "ranker worker thread exiting after {MAX_CONSECUTIVE_PANICS} consecutive panics; \
+                     engine main thread will observe channel disconnect on next dispatch"
+                );
+                return;
+            }
+        } else {
+            consecutive_panics = 0;
         }
     }
 }
 
-/// `catch_unwind` payload から表示用 message を取り出す best-effort helper。
-fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> &str {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        s
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.as_str()
-    } else {
-        "(non-string panic payload)"
+/// 1 件の `RankRequest` を処理する。`worker_loop` から call される。
+///
+/// # Returns
+///
+/// - [`IterationOutcome::Clean`] — 通常終了
+/// - [`IterationOutcome::RankerPanicked`] — Ranker.rank が panic し WorkerError 送信済
+/// - [`IterationOutcome::EngineDisconnected`] — engine 主 thread の receiver drop
+///
+/// 本関数自体が panic した場合は `worker_loop` の outer catch_unwind が拾い、
+/// I9 として連続 panic counter に加算される。
+fn handle_one_request(req: RankRequest, tx_event: &mpsc::Sender<EngineEvent>) -> IterationOutcome {
+    let request_id = req.request_id;
+    let mode = req.ctx.mode;
+    let cancel = req.cancel_dyn();
+
+    let (tx_ranker, rx_ranker) = mpsc::channel::<RankerOutput>();
+
+    // spec §9.1 row 2: Ranker::rank の panic を catch し WorkerError として
+    // 報告。worker thread 自体は loop continue で生存させる。`AssertUnwindSafe`
+    // は Ranker / kana / ctx / cancel / sink が panic 越しに不変である
+    // ことを caller(本 module)が引き受ける明示。
+    let kana = req.kana.clone();
+    let ctx = req.ctx.clone();
+    let ranker = req.ranker.clone();
+    let cancel_for_call = cancel.clone();
+    let rank_result = panic::catch_unwind(AssertUnwindSafe(move || {
+        ranker.rank(&kana, &ctx, cancel_for_call, tx_ranker)
+    }));
+
+    let (rank_outcome, ranker_panicked) = match rank_result {
+        Ok(Ok(())) => (Ok(()), false),
+        Ok(Err(e)) => (Err(format!("ranker error: {e}")), false),
+        Err(panic_payload) => {
+            let msg = panic_message(&panic_payload);
+            tracing::error!(request_id, panic = %msg, "ranker panicked");
+            (Err(format!("ranker panicked: {msg}")), true)
+        }
+    };
+
+    if let Err(error) = rank_outcome {
+        if try_send_event(
+            tx_event,
+            EngineEvent::WorkerError { request_id, error },
+            request_id,
+        ) {
+            return IterationOutcome::EngineDisconnected;
+        }
+        return if ranker_panicked {
+            IterationOutcome::RankerPanicked
+        } else {
+            IterationOutcome::Clean
+        };
     }
+
+    // 1st window: dict 候補集約
+    let window = match mode {
+        ConversionMode::Live => LIVE_WINDOW,
+        ConversionMode::Commit => COMMIT_WINDOW,
+    };
+    let mut buffer: Vec<Candidate> = Vec::new();
+    drain_window(&rx_ranker, &cancel, window, &mut buffer);
+
+    // Phase 3-B B0d (Important 8): cancel されていなければ buffer が空でも
+    // Replace を送る。engine 側は前回 dispatch の stale 候補を本 Replace で
+    // 確実に clear できる。spec §9.3「変換失敗で前回候補が画面に残る」を防ぐ。
+    if !cancel.is_cancelled()
+        && try_send_event(
+            tx_event,
+            EngineEvent::Candidates {
+                request_id,
+                update: CandidateUpdate::Replace(buffer.clone()),
+            },
+            request_id,
+        )
+    {
+        return IterationOutcome::EngineDisconnected;
+    }
+
+    // 2nd window for Commit mode: LLM 後続結果
+    if mode == ConversionMode::Commit && !cancel.is_cancelled() {
+        let mut second_buffer: Vec<Candidate> = Vec::new();
+        drain_window(
+            &rx_ranker,
+            &cancel,
+            COMMIT_SECOND_WINDOW,
+            &mut second_buffer,
+        );
+        if !cancel.is_cancelled() && !second_buffer.is_empty() {
+            buffer.extend(second_buffer);
+            if try_send_event(
+                tx_event,
+                EngineEvent::Candidates {
+                    request_id,
+                    update: CandidateUpdate::Replace(buffer),
+                },
+                request_id,
+            ) {
+                return IterationOutcome::EngineDisconnected;
+            }
+        }
+    }
+    IterationOutcome::Clean
+}
+
+/// `catch_unwind` payload から表示用 message を best-effort で抽出する。
+///
+/// B0g #148 / 第 2 回 review C4: 旧 impl は `&'static str` / `String` のみ
+/// downcast し、`panic_any(anyhow::Error)` や user-defined error 経由の
+/// payload が `(non-string panic payload)` で消失していた。本版では
+/// payload type id を含めて返し、`kotoha-bin` 側の panic_hook が捕捉した
+/// location 情報と組合わせて root cause を辿れるようにする。
+///
+/// `kotoha-engine-core` は domain crate のため `anyhow::Error` への downcast
+/// は実装しない(crate dependency を増やさない)。実際の `anyhow` 表示は
+/// `kotoha-bin::panic_message` 側で行う。
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    format!(
+        "(non-string panic payload, type_id={:?})",
+        (**payload).type_id()
+    )
 }
 
 /// 指定 window 内に Ranker から届いた `RankerOutput` を `buffer` に集約する。
@@ -215,5 +320,44 @@ fn apply_to_buffer(buffer: &mut Vec<Candidate>, update: CandidateUpdate) {
             }
         }
         CandidateUpdate::Clear => buffer.clear(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Phase 3-B B0g (ISSUE #148 / C4): `panic_message` の payload type 拡充
+    //! が `&'static str` / `String` 経由 panic を取りこぼさないこと、未知 type の
+    //! payload でも `(non-string panic payload, type_id=...)` で type 情報が
+    //! 残ることを観測する。
+    use super::*;
+
+    fn capture_panic<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> Box<dyn std::any::Any + Send> {
+        panic::catch_unwind(f).expect_err("expected the closure to panic")
+    }
+
+    #[test]
+    fn panic_message_extracts_static_str() {
+        let payload = capture_panic(|| panic!("static panic message"));
+        assert_eq!(panic_message(&payload), "static panic message");
+    }
+
+    #[test]
+    fn panic_message_extracts_owned_string() {
+        let owned = String::from("owned panic message");
+        let payload = capture_panic(move || panic!("{}", owned));
+        assert_eq!(panic_message(&payload), "owned panic message");
+    }
+
+    #[test]
+    fn panic_message_includes_type_id_for_unknown_payload() {
+        // panic_any でカスタム型を投げる。`u32` 自体は std type だが
+        // `&'static str` / `String` のいずれにも該当しないため未知 type
+        // arm が発火し、type_id が message に含まれることを観測する。
+        let payload = capture_panic(|| std::panic::panic_any(42_u32));
+        let msg = panic_message(&payload);
+        assert!(
+            msg.starts_with("(non-string panic payload, type_id="),
+            "unexpected panic message: {msg}"
+        );
     }
 }

--- a/crates/kotoha-engine-core/src/engine/worker.rs
+++ b/crates/kotoha-engine-core/src/engine/worker.rs
@@ -43,6 +43,14 @@ pub const COMMIT_SECOND_WINDOW: Duration = Duration::from_millis(150);
 /// exit させる。exit 後は engine 主 thread が `tx_request.send` の Err を
 /// 観測し、enabled = false に degrade(spec §9.3「IME-disabled mode を
 /// user に通知」)。
+///
+/// # Flaky panic は scope 外
+///
+/// 本 counter は `IterationOutcome::Clean` で 0 リセットする。よって 1 keystroke
+/// 毎 panic / 次成功 / 次 panic / ... のような **flaky panic は永久に発火しない**。
+/// flaky 系の検出は本 const の責務外で、別途 sliding-window panic frequency
+/// metrics(B0g 後続 ADR 候補)で扱う。spec §9.1 row 2 の「worker thread 自体は
+/// loop continue で生存」と整合。
 const MAX_CONSECUTIVE_PANICS: u32 = 5;
 
 /// `RankerWorker` を spawn する。

--- a/crates/kotoha-engine-core/src/ranker/hybrid.rs
+++ b/crates/kotoha-engine-core/src/ranker/hybrid.rs
@@ -168,6 +168,8 @@ impl Ranker for HybridRanker {
                 Err(e) => {
                     tracing::warn!(
                         error = ?e,
+                        // TODO(B0g-b / I6 #148): redact `kana` to `kana_len = kana_owned.chars().count()`;
+                        //   WARN level outputs at default KOTOHA_LOG=info, leaking user-typed reading.
                         kana = %kana_owned,
                         "sudachi tokenize failed; using empty dict candidates"
                     );
@@ -187,7 +189,9 @@ impl Ranker for HybridRanker {
                     Err(e) => {
                         tracing::warn!(
                             error = ?e,
-                            kana = %kana_owned,
+                            // TODO(B0g-b / I6 #148): redact `kana` to `kana_len = kana_owned.chars().count()`;
+                        //   WARN level outputs at default KOTOHA_LOG=info, leaking user-typed reading.
+                        kana = %kana_owned,
                             "user_vocab find_by_prefix failed; using empty user candidates"
                         );
                         Vec::new()
@@ -200,6 +204,8 @@ impl Ranker for HybridRanker {
                 Err(e) => {
                     tracing::warn!(
                         error = ?e,
+                        // TODO(B0g-b / I6 #148): redact `kana` to `kana_len = kana_owned.chars().count()`;
+                        //   WARN level outputs at default KOTOHA_LOG=info, leaking user-typed reading.
                         kana = %kana_owned,
                         "learning_cache lookup failed; using empty cache hits"
                     );
@@ -312,6 +318,8 @@ impl Ranker for HybridRanker {
                     // graceful degradation: dict-only fallback、第 2 段 push なし。
                     tracing::warn!(
                         error = ?e,
+                        // TODO(B0g-b / I6 #148): redact `kana` to `kana_len = kana_owned.chars().count()`;
+                        //   WARN level outputs at default KOTOHA_LOG=info, leaking user-typed reading.
                         kana = %kana_owned,
                         "LLM backend failed, dict candidates only"
                     );

--- a/crates/kotoha-engine-core/src/ranker/hybrid.rs
+++ b/crates/kotoha-engine-core/src/ranker/hybrid.rs
@@ -227,6 +227,24 @@ impl Ranker for HybridRanker {
             let dict_cands_for_llm = dict_cands.clone();
             let user_cands_for_llm = user_cands.clone();
             let cache_surfaces_for_llm = cache_surfaces.clone();
+
+            // B0g #148 / 第 2 回 review I15: dict / user / learning 3 source が
+            // 全て空(個別 WARN を吐いた直後)の場合、user 視点では「変換不能」
+            // という degraded mode に等しい。spec §9.1 row 3「全 backend 全滅
+            // なら空 Replace を engine に送り tracing::error」を遵守し、merge
+            // 直前で all-empty 検出時に ERROR log を残す。空 Replace 自体は
+            // engine 側の「前回候補画面残留」防止のため引き続き送る(spec §9.3)。
+            let dict_all_empty = dict_cands_for_llm.is_empty()
+                && user_cands_for_llm.is_empty()
+                && cache_surfaces_for_llm.is_empty();
+            if dict_all_empty {
+                tracing::error!(
+                    kana_len = kana_owned.chars().count(),
+                    "all dict-tier backends returned empty (sudachi+uservocab+learningcache); \
+                     engine will receive empty candidates (spec §9.1 row 3)"
+                );
+            }
+
             let merged = merge_candidates(
                 vec![
                     (user_cands, CandidateSource::Dict),

--- a/crates/kotoha-engine-core/tests/worker_coalescing.rs
+++ b/crates/kotoha-engine-core/tests/worker_coalescing.rs
@@ -367,8 +367,22 @@ impl Ranker for AlwaysPanicRanker {
 /// user に通知」)。
 ///
 /// MAX_CONSECUTIVE_PANICS=5 のため、6 回目以降の dispatch で channel
-/// disconnect が観測される設計。本 test では 8 回 keystroke を送って
+/// disconnect が観測される設計。本 test では 10 回 keystroke を送って
 /// final state が IME-disabled であることを確認する。
+///
+/// # Theater pattern 防御(self-review #4)
+///
+/// 本 test の `enabled = false` 観測は、production code 中で **`tx_request.send`
+/// Err path 経由でのみ** 立つ前提に依存する。将来別経路(例:`focus_out` で
+/// disable 同等処理を追加する refactor)で `enabled = false` を立てる変更が
+/// 入ると本 test の検証根拠が変わる:
+///
+/// - 補助 assert 1:`state == Idle` を併せて assert(circuit breaker 経由は
+///   degrade_to_idle で必ず Idle に倒れるが、別経路は state を変えないかも)
+/// - 補助 assert 2:`candidate_count == 0` を併せて assert(同上)
+///
+/// flaky 化防止のため sleep margin を 20ms → 50ms に拡大(CI scheduler 圧迫
+/// 時の worker thread schedule 遅延吸収)。
 #[test]
 fn worker_circuit_breaker_disables_engine_after_repeated_ranker_panics() {
     let ranker = Arc::new(AlwaysPanicRanker);
@@ -378,17 +392,29 @@ fn worker_circuit_breaker_disables_engine_after_repeated_ranker_panics() {
     eng.enable();
     eng.focus_in();
 
-    // 連続 8 keystroke。最初の 5 回は WorkerError event 経由で degrade_to_idle、
-    // 6 回目以降に worker が channel close 済で tx_request.send Err → enabled=false。
-    for c in ['a', 'i', 'u', 'e', 'o', 'k', 's', 't'].iter() {
+    // 10 keystroke 連続(MAX_CONSECUTIVE_PANICS=5 を超えて margin 確保)。
+    // 最初の 5 回は WorkerError event 経由で degrade_to_idle、6 回目以降に
+    // worker が channel close 済で tx_request.send Err → enabled=false。
+    for c in ['a', 'i', 'u', 'e', 'o', 'k', 's', 't', 'n', 'h'].iter() {
         eng.process_key_event(key(*c));
         // worker thread に panic + channel close 反映の余裕を与える。
-        sleep(Duration::from_millis(20));
+        sleep(Duration::from_millis(50));
     }
 
+    // 三重 AND assert:circuit breaker 経由 degrade を特定。
     assert!(
         !eng.enabled_for_test(),
         "engine should have degraded to IME-disabled after consecutive Ranker panics; \
          enabled_for_test() returned true"
+    );
+    assert_eq!(
+        eng.state_for_test(),
+        kotoha_engine_core::EngineState::Idle,
+        "circuit breaker degrade path must end at Idle (degrade_to_idle invariant)"
+    );
+    assert_eq!(
+        eng.candidate_count_for_test(),
+        0,
+        "circuit breaker degrade path must clear candidate buffer"
     );
 }

--- a/crates/kotoha-engine-core/tests/worker_coalescing.rs
+++ b/crates/kotoha-engine-core/tests/worker_coalescing.rs
@@ -341,3 +341,54 @@ fn silent_ranker_clears_engine_candidates_via_empty_replace() {
     // 同じ Empty Replace を返す → candidates 空のまま。
     assert_eq!(eng.candidate_count_for_test(), 0);
 }
+
+// ------------------------------------------------------------------
+// Phase 3-B B0g (ISSUE #148): I16 deterministic ranker panic circuit breaker
+// ------------------------------------------------------------------
+
+/// 毎回 panic する Ranker。worker 連続 panic 上限到達 → worker exit →
+/// engine が IME-disabled に degrade することを観測する fixture。
+struct AlwaysPanicRanker;
+impl Ranker for AlwaysPanicRanker {
+    fn rank(
+        &self,
+        _kana: &str,
+        _ctx: &ConversionContext,
+        _cancel: Arc<dyn CancellationToken>,
+        _sink: std::sync::mpsc::Sender<RankerOutput>,
+    ) -> Result<(), RankerError> {
+        panic!("intentional ranker panic for circuit-breaker regression");
+    }
+}
+
+/// I16: Ranker.rank が deterministic に panic する場合、worker は連続 5 回で
+/// exit し、engine 主 thread は次 dispatch で `tx_request.send` の Err を
+/// 観測 → `enabled = false` に degrade する(spec §9.3「IME-disabled mode を
+/// user に通知」)。
+///
+/// MAX_CONSECUTIVE_PANICS=5 のため、6 回目以降の dispatch で channel
+/// disconnect が観測される設計。本 test では 8 回 keystroke を送って
+/// final state が IME-disabled であることを確認する。
+#[test]
+fn worker_circuit_breaker_disables_engine_after_repeated_ranker_panics() {
+    let ranker = Arc::new(AlwaysPanicRanker);
+    let host = Box::new(MockHostBridge::new());
+    let writer = Arc::new(StubWriter);
+    let mut eng = KotohaEngine::new(host, ranker, writer).expect("engine spawn");
+    eng.enable();
+    eng.focus_in();
+
+    // 連続 8 keystroke。最初の 5 回は WorkerError event 経由で degrade_to_idle、
+    // 6 回目以降に worker が channel close 済で tx_request.send Err → enabled=false。
+    for c in ['a', 'i', 'u', 'e', 'o', 'k', 's', 't'].iter() {
+        eng.process_key_event(key(*c));
+        // worker thread に panic + channel close 反映の余裕を与える。
+        sleep(Duration::from_millis(20));
+    }
+
+    assert!(
+        !eng.enabled_for_test(),
+        "engine should have degraded to IME-disabled after consecutive Ranker panics; \
+         enabled_for_test() returned true"
+    );
+}

--- a/crates/kotoha-engine-ibus/src/dispatcher.rs
+++ b/crates/kotoha-engine-ibus/src/dispatcher.rs
@@ -10,6 +10,8 @@
 //! 詳細詰め(spec §13 Open Q 9)。本 PR では single-method dispatcher を
 //! provide し、生 signal listener は kotoha-bin (M6) で確立する。
 
+use std::panic::{self, AssertUnwindSafe};
+
 use kotoha_engine_core::IMEEngine;
 
 use crate::keysym;
@@ -38,12 +40,42 @@ impl<E: IMEEngine> IBusEventDispatcher<E> {
     ///
     /// `true` なら engine が消費(IBus への return 値として `true` を返す)、
     /// `false` なら IBus は default 処理(application に key を渡す)。
+    ///
+    /// # Panic recovery
+    ///
+    /// B0g #148 / 第 2 回 review I17 + spec §9.1 row 5: `engine.process_key_event`
+    /// 内で発生した panic を catch_unwind で受け、engine state を `reset()` で
+    /// Idle に戻し、本 dispatch では `false`(forward)を返す。これにより:
+    ///
+    /// - IBus daemon 側 thread が panic で死んで keystroke が永久 hang する
+    ///   (D-Bus signal handler thread の `process_key_event` 経由 unwind)を
+    ///   防ぐ
+    /// - panic 検出は `tracing::error!` で観測される
+    /// - reset() 自体が panic した場合は二重 panic を避けるため再 catch_unwind
+    ///   で囲い、それも失敗したら最後の手段として `false` だけ返す
     pub fn dispatch_key(&mut self, keysym: u32, keycode: u32, state: u32) -> bool {
         let ev = keysym::from_ibus(keysym, keycode, state);
-        matches!(
-            self.engine.process_key_event(ev),
-            kotoha_engine_core::KeyEventResult::Consumed
-        )
+        let engine = &mut self.engine;
+        let result = panic::catch_unwind(AssertUnwindSafe(|| engine.process_key_event(ev)));
+        match result {
+            Ok(kotoha_engine_core::KeyEventResult::Consumed) => true,
+            Ok(kotoha_engine_core::KeyEventResult::Forwarded) => false,
+            Err(payload) => {
+                tracing::error!(
+                    keysym,
+                    keycode,
+                    state,
+                    panic_type = ?(*payload).type_id(),
+                    "engine.process_key_event panicked; resetting engine state"
+                );
+                // reset() 自体の二重 panic は session 全死亡を意味するので
+                // 静かに諦める(catch_unwind で flatten、`tracing::error!` のみ残す)。
+                let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                    self.engine.reset();
+                }));
+                false
+            }
+        }
     }
 
     pub fn dispatch_focus_in(&mut self) {
@@ -182,5 +214,58 @@ mod tests {
         let mut d = IBusEventDispatcher::new(MockEngine::new(KeyEventResult::Forwarded));
         d.dispatch_reset();
         assert_eq!(d.engine_mut().lifecycle, vec!["reset"]);
+    }
+
+    // --------------------------------------------------------------
+    // Phase 3-B B0g (ISSUE #148 / I17): dispatch_key panic catch
+    // --------------------------------------------------------------
+
+    /// `process_key_event` が panic する MockEngine。dispatcher の
+    /// catch_unwind 経路 + reset() invocation を観測する fixture。
+    struct PanickingEngine {
+        process_key_called: bool,
+        reset_called: bool,
+    }
+    impl PanickingEngine {
+        fn new() -> Self {
+            Self {
+                process_key_called: false,
+                reset_called: false,
+            }
+        }
+    }
+    impl IMEEngine for PanickingEngine {
+        fn process_key_event(&mut self, _key: KeyEvent) -> KeyEventResult {
+            self.process_key_called = true;
+            panic!("intentional process_key_event panic for I17 regression");
+        }
+        fn focus_in(&mut self) {}
+        fn focus_out(&mut self) {}
+        fn reset(&mut self) {
+            self.reset_called = true;
+        }
+        fn enable(&mut self) {}
+        fn disable(&mut self) {}
+    }
+
+    /// I17: dispatch_key 内で process_key_event が panic した場合、dispatcher
+    /// は catch_unwind で受けて reset() を呼び、戻り値は `false`(forward)を
+    /// 返す。IBus daemon 側 thread の永久 hang(spec §9.1 row 5)を防ぐ。
+    #[test]
+    fn dispatch_key_catches_engine_panic_and_resets_state() {
+        let mut d = IBusEventDispatcher::new(PanickingEngine::new());
+        let result = d.dispatch_key(0x6b, 0, 0);
+        assert!(
+            !result,
+            "dispatch_key should return false when engine.process_key_event panics"
+        );
+        assert!(
+            d.engine_mut().process_key_called,
+            "process_key_event should have been called before the panic"
+        );
+        assert!(
+            d.engine_mut().reset_called,
+            "reset() should be called after panic recovery in dispatch_key"
+        );
     }
 }

--- a/crates/kotoha-engine-ibus/src/dispatcher.rs
+++ b/crates/kotoha-engine-ibus/src/dispatcher.rs
@@ -68,11 +68,20 @@ impl<E: IMEEngine> IBusEventDispatcher<E> {
                     panic_type = ?(*payload).type_id(),
                     "engine.process_key_event panicked; resetting engine state"
                 );
-                // reset() 自体の二重 panic は session 全死亡を意味するので
-                // 静かに諦める(catch_unwind で flatten、`tracing::error!` のみ残す)。
-                let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                // reset() 自体の二重 panic は session 全死亡相当で recovery 不能
+                // だが、**reset 失敗の事実** は ERROR log に必ず残す(self-review #5
+                // 指摘:payload 中身は捨てても fact は残さないと後続 keystroke で
+                // 再 panic ループが起きた時に root cause traceability が失われる)。
+                let reset_result = panic::catch_unwind(AssertUnwindSafe(|| {
                     self.engine.reset();
                 }));
+                if let Err(reset_payload) = reset_result {
+                    tracing::error!(
+                        panic_type = ?(*reset_payload).type_id(),
+                        "engine.reset() panicked during dispatch_key recovery; \
+                         engine state corruption likely; subsequent keystrokes may panic again"
+                    );
+                }
                 false
             }
         }

--- a/crates/kotoha-engine-ibus/src/lookup_table.rs
+++ b/crates/kotoha-engine-ibus/src/lookup_table.rs
@@ -47,9 +47,28 @@ impl LookupTable {
                 }
             }
             CandidateUpdate::Clear => guard.clear(),
-            // `CandidateUpdate` は non_exhaustive(spec §4.2、Phase 5 で variant 追加余地)。
-            // 未知 variant が来た場合は IBus 側から見ると no-op で扱い、tracing で観測する。
-            other => tracing::warn!(?other, "unknown CandidateUpdate variant; treating as no-op"),
+            // `CandidateUpdate` は non_exhaustive(`crates/kotoha-engine-core/src/ranker/update.rs` 凍結)
+            // のため、外部 crate である本 module には wildcard arm が syntax 上必須。
+            // 未知 variant 到達時は **production では buffer 維持で no-op** に倒すが、
+            // 「lookup table が新 variant の意図通り更新されない silent failure」
+            // (B0g #148 / 第 2 回 review C5)を防ぐため以下を強制する:
+            //
+            // - `tracing::error!`(WARN ではなく ERROR、`KOTOHA_LOG=info` default で観測可)
+            // - `debug_assert!` で dev / test build では即 panic(CI 通過前に検出)
+            // - log には variant 内容(候補 surface 等)を一切載せず、`std::mem::discriminant`
+            //   のみを記録(S-N9 future log leak の予防)
+            other => {
+                let disc = std::mem::discriminant(&other);
+                tracing::error!(
+                    variant_discriminant = ?disc,
+                    "unhandled CandidateUpdate variant; lookup_table.rs no-op fallback fired; \
+                     update crates/kotoha-engine-ibus/src/lookup_table.rs to support the new variant"
+                );
+                debug_assert!(
+                    false,
+                    "unhandled CandidateUpdate variant in kotoha-engine-ibus::LookupTable::apply"
+                );
+            }
         }
         guard.clone()
     }

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -141,7 +141,8 @@ GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 applicatio
 |---|---|---|
 | ~~B0 (#140)~~ | 第 1 回包括レビュー Critical 4 + Important 9 消化 | **完了**(PR #141-#145、test 416 → 473) |
 | ~~B0f (#146)~~ | 機能完成宣言取り下げ + proxy / event loop fail-loud 化 | **完了**(PR #147 squash `9602dff`) |
-| **B0g-a (#148)** | C4 panic_message + C5 lookup_table + I9/I16 worker circuit breaker + I15 hybrid empty-fallback + I17 dispatcher panic catch | **進行中**(本 PR) |
+| **B0g-a (#148)** | C4 panic_message + C5 lookup_table + I9/I16 worker circuit breaker + I15 hybrid empty-fallback + I17 dispatcher panic catch | **進行中**(本 PR、self-review #5/#4 fix 済) |
+| B0g-b (#148) で追加検討 | self-review #2 ADR(`non_exhaustive` trade-off)、#3 ADR(flaky panic sliding-window metrics)、#7 `IMEEngine::enable` Result 化 で worker 死亡時 IBus daemon の re-enable loop 抑制 | B0g-a 後着手 |
 | B0g-b (#148) | I6 log credential leak redact + I7 HybridRanker child thread catch + I8 output sanitization | B0g-a 後着手 |
 | B0g-c (#148) | I10 theater fix + I11 spec §5.2 row 8 + I12 polling helper + I13 half-dead engine + I14 mock arg verify | B0g-b 後着手 |
 | B0h (#149) | hexagonal port 反転(C3) + SRP 分割(I1) + dispatcher Arc<Mutex>(I2) + dispatch async 化(I3) + Hybrid 切出し(I4) + stub feature gate(I5) | OSS 公開前必修 |

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -108,7 +108,8 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 | P2-D 完了時(P3-A 開始前) | n/a | 416 |
 | P3-A M1〜M6 + P3-B B1/B4/B5 完了時(B0e merge 直後) | n/a | 459 |
 | **P3-B B0e 完了時(2026-05-03)** | 432 | **473** |
-| **P3-B B0f 完了時(2026-05-03、本 PR)** | 432 | **473**(test 改変ゼロ) |
+| P3-B B0f 完了時(2026-05-03、PR #147) | 432 | 473(test 改変ゼロ) |
+| **P3-B B0g-a 完了時(2026-05-03、本 PR)** | **436** | **478**(+5: panic_message 3 + worker circuit breaker 1 + dispatcher panic catch 1) |
 
 註:`cargo test --workspace` (default features) と `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers` で結果が異なる。lefthook pre-push は default features を回す。第 1 回包括 review (B0a-B0e) では test-helpers feature 経由の合計値 (416 → 473) を baseline として参照する。過去の commit message で `446` / `448` / `454` と記載した数値はいずれも不正確で、上表が正規値。
 
@@ -139,8 +140,10 @@ GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 applicatio
 | # | Sub-milestone | 状態 |
 |---|---|---|
 | ~~B0 (#140)~~ | 第 1 回包括レビュー Critical 4 + Important 9 消化 | **完了**(PR #141-#145、test 416 → 473) |
-| **B0f (#146)** | 機能完成宣言取り下げ + proxy / event loop fail-loud 化 | **進行中**(本 PR) |
-| B0g (#148) | 第 2 回 review C4 / C5 / I7-I17 系の中期消化(silent failure / security / testing) | B0f 後着手 |
+| ~~B0f (#146)~~ | 機能完成宣言取り下げ + proxy / event loop fail-loud 化 | **完了**(PR #147 squash `9602dff`) |
+| **B0g-a (#148)** | C4 panic_message + C5 lookup_table + I9/I16 worker circuit breaker + I15 hybrid empty-fallback + I17 dispatcher panic catch | **進行中**(本 PR) |
+| B0g-b (#148) | I6 log credential leak redact + I7 HybridRanker child thread catch + I8 output sanitization | B0g-a 後着手 |
+| B0g-c (#148) | I10 theater fix + I11 spec §5.2 row 8 + I12 polling helper + I13 half-dead engine + I14 mock arg verify | B0g-b 後着手 |
 | B0h (#149) | hexagonal port 反転(C3) + SRP 分割(I1) + dispatcher Arc<Mutex>(I2) + dispatch async 化(I3) + Hybrid 切出し(I4) + stub feature gate(I5) | OSS 公開前必修 |
 | B2 | IBus signal body marshalling | B0f 後着手 |
 | B3 | IBus signal listener loop + event loop | B0f / B2 後着手 |


### PR DESCRIPTION
## Summary

- 第 2 回包括レビュー(2026-05-03)の **silent-failure dimension** から 5 件の Important + 2 件の Critical を消化
- B0g 全体は 3 sub-PR(本 a / b / c)に分割。本 PR は最も sensitive な panic / silent fallback 系
- diff 規模: 475 insertions / 98 deletions、test +5(test-helpers feature)、+4(default features)

## 消化した review 指摘

### Critical 2 件

- **C4 panic_message widening**: `Box<dyn Any>` downcast を `&'static str` / `String` だけから `anyhow::Error` (kotoha-bin 限定) + `type_id` fallback に拡張。global `std::panic::set_hook` を `init_tracing` 直後に登録し、panic location + payload を `tracing::error!` で確実に流す。3 unit test を追加。
- **C5 lookup_table.rs `_` arm fail-loud 化**: `non_exhaustive` enum 制約上 wildcard arm を削除はできない。代わりに `tracing::warn!` → `tracing::error!`、Debug の `?other` を `mem::discriminant` のみに変更(Phase 5 で variant 追加した時に candidate surface が log に流出するのを予防)、`debug_assert!` で dev / test build では即 panic。

### Important 5 件

- **I9 worker_loop top-level catch_unwind**: `worker_loop` body を `handle_one_request -> IterationOutcome` に refactor し、外側で `catch_unwind`。`apply_to_buffer` / `drain_window` 等の自前 code が panic しても worker thread が即死せず段階 degrade。
- **I16 deterministic Ranker panic circuit breaker**: 連続 panic 5 回で worker exit。engine 主 thread は `tx_request.send` Err を観測 → `enabled = false` に degrade(spec §9.3「IME-disabled mode を user に通知」)。`worker_circuit_breaker_disables_engine_after_repeated_ranker_panics` integration test を追加。
- **I15 hybrid empty-fallback explicit error**: 3 dict source 全滅時に `tracing::error!`(spec §9.1 row 3 文言通り)を 1 行追加。空 Replace 自体は引き続き送る(spec §9.3「前回候補画面残留」防止)。
- **I17 dispatch_key panic catch**: `engine.process_key_event` の panic を `catch_unwind` で受け、`engine.reset()` + `false` return。double-panic 防止のため reset も `catch_unwind` 越し。`dispatch_key_catches_engine_panic_and_resets_state` unit test を追加。

## 検証

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` 0 warnings
- [x] `cargo test --workspace` 432 → 436 PASS (+4)
- [x] `cargo test --workspace --features kotoha-engine-core/test-helpers,kotoha-storage/test-helpers` 473 → 478 PASS (+5)
- [x] `KOTOHA_ALLOW_STUB=1 ./target/debug/kotoha` exit 1 維持(B0f gate 不退化)

## Test plan

- [x] Unit: panic_message が `&'static str` / `String` / 未知 type の 3 path を正しく抽出
- [x] Unit: dispatch_key が PanickingEngine の panic を catch して reset 経路を通り false を返す
- [x] Integration: AlwaysPanicRanker で 8 keystroke 流して `enabled_for_test() == false` 観測

## Out of scope(B0g-b / B0g-c で対応)

- B0g-b: I6 log credential leak redact(hybrid.rs per-backend WARN + main.rs StubHostBridge trace)、I7 HybridRanker child thread `thread::spawn` 内 panic、I8 IMEHostBridge boundary での output sanitization
- B0g-c: I10 silent_ranker theater fix、I11 spec §5.2 row 8 cover、I12 polling helper、I13 half-dead engine assertion 強化、I14 mock arg verification

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)