### PR TITLE
P3-B B0h-e: stub fallback feature gate (I5) (#149) (#159)

### DIFF
--- a/crates/kotoha-bin/Cargo.toml
+++ b/crates/kotoha-bin/Cargo.toml
@@ -12,6 +12,15 @@ authors.workspace = true
 name = "kotoha"
 path = "src/main.rs"
 
+[features]
+default = []
+# `dev-stubs` は開発時のみ有効化する fallback ranker / host bridge を gate する
+# feature。OFF(default)では `StubRanker` / `StubHostBridge` の struct + impl が
+# compile されず、release binary に含まれない。`KOTOHA_ALLOW_STUB=1` env var も
+# 本 feature OFF 時は常に効果無しとして扱う(spec §11)。
+# B0h-e (ISSUE #149 / #159) で導入。
+dev-stubs = []
+
 [dependencies]
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -29,6 +29,7 @@
 use std::panic::{self, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::process::ExitCode;
+#[cfg(feature = "dev-stubs")]
 use std::sync::mpsc;
 use std::sync::Arc;
 
@@ -163,11 +164,23 @@ fn init_tracing() {
 /// `KOTOHA_ALLOW_STUB` env var が `1` / `true` / `yes` のいずれかを指す場合 true。
 /// それ以外(未設定 / `0` 等)は false で、production 起動時は stub fallback を
 /// 拒否(spec §9.3「空候補返却で終わる」を防ぐ)。
+///
+/// B0h-e (#149 / #159):`dev-stubs` feature が OFF の場合(release default)は
+/// 常に `false` を返す。env var が誤設定されても fallback path は compile されず、
+/// production binary は stub に到達不能となる(spec §11 凍結)。
+#[cfg(feature = "dev-stubs")]
 fn stub_fallback_allowed() -> bool {
     matches!(
         std::env::var(KOTOHA_ALLOW_STUB_ENV).as_deref(),
         Ok("1" | "true" | "yes")
     )
+}
+
+#[cfg(not(feature = "dev-stubs"))]
+fn stub_fallback_allowed() -> bool {
+    // production / release default: stub fallback path は compile されない。
+    // `KOTOHA_ALLOW_STUB` 環境変数の値は無視される。
+    false
 }
 
 fn run_ibus() -> anyhow::Result<()> {
@@ -193,12 +206,19 @@ fn run_ibus() -> anyhow::Result<()> {
     let (learning_recorder, learning_lookup) =
         kotoha_engine_adapter::arc_sqlite_learning_cache(learning_store.clone());
     let allow_stub = stub_fallback_allowed();
+    // `dev-stubs` OFF では下記 `Err(e) if allow_stub =>` arm 自体が cfg で
+    // strip され、guard expression も含めて消えるため `allow_stub` は未参照
+    // 変数となる。`stub_fallback_allowed()` の env-var 読み(将来の logging
+    // hook 余地を含む)は production / dev で同 path を保持したいので変数自体
+    // は維持し、`let _` で discard して `-D warnings` clippy を黙らせる。
+    let _ = allow_stub;
     let (ranker, ranker_backend): (Arc<dyn kotoha_engine_core::Ranker>, &'static str) =
         match build_hybrid_ranker(user_vocab_port.clone(), learning_lookup.clone()) {
             Ok(r) => {
                 tracing::info!("HybridRanker constructed (dict-only path; LLM is Phase 3-B B2+)");
                 (r, "HybridRanker")
             }
+            #[cfg(feature = "dev-stubs")]
             Err(e) if allow_stub => {
                 tracing::error!(
                     error = ?e,
@@ -222,6 +242,7 @@ fn run_ibus() -> anyhow::Result<()> {
         &'static str,
     ) = match kotoha_engine_ibus::IBusHostBridge::new(ENGINE_OBJECT_PATH) {
         Ok(b) => (Box::new(b), "IBusHostBridge"),
+        #[cfg(feature = "dev-stubs")]
         Err(e) if allow_stub => {
             tracing::error!(
                 error = ?e,
@@ -289,8 +310,13 @@ fn build_hybrid_ranker(
 }
 
 /// 暫定 stub ranker(`KOTOHA_ALLOW_STUB=1` 時のみ fallback として利用)。
+///
+/// B0h-e (#149 / #159):`dev-stubs` feature が OFF(default / release)では
+/// 本 struct と impl が compile されず、release binary には link されない。
+#[cfg(feature = "dev-stubs")]
 struct StubRanker;
 
+#[cfg(feature = "dev-stubs")]
 impl kotoha_engine_core::Ranker for StubRanker {
     fn rank(
         &self,
@@ -309,8 +335,12 @@ impl kotoha_engine_core::Ranker for StubRanker {
 /// に流すと `KOTOHA_LOG=trace` 設定時に systemd journal / log aggregator へ
 /// 平文流出する。dev fallback path とはいえ user の手元で trace を有効化する
 /// ケース(debug session 中の log tail 等)を考慮し、`text_len` のみ記録する。
+///
+/// B0h-e (#149 / #159):`dev-stubs` feature gate を追加。`StubRanker` と同方針。
+#[cfg(feature = "dev-stubs")]
 struct StubHostBridge;
 
+#[cfg(feature = "dev-stubs")]
 impl kotoha_engine_core::IMEHostBridge for StubHostBridge {
     fn update_preedit(&self, text: &str, cursor: usize, visible: bool) {
         tracing::trace!(

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -148,9 +148,10 @@ GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 applicatio
 | ~~B0g-c (#148)~~ | I10 theater fix + I11 spec §5.2 row 8 + I12 polling helper + I13 half-dead engine + I14 mock arg verify | **完了**(PR #152 squash `833c7d9`、test 447 / 498) |
 | ~~B0h-a (#153)~~ | C3 hexagonal driven port 反転(`learning_port` を engine-core に新設、`kotoha-engine-adapter` crate 切出し、engine-core が storage を直接 import しない構造へ) | **完了**(PR #154 squash `5c37d65`、test 464 / 515) |
 | ~~B0h-b (#155)~~ | I4 `HybridRanker` を `kotoha-ranker-hybrid` 別 crate へ切り出し(engine-core から concrete adapter を分離、LLM features を ranker-hybrid 側に移送) | **完了**(PR #156 squash `3cc36a9`、test 504 / 515) |
-| **B0h-d (#157)** | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化(B3 event loop の前提整備) | **進行中**(本 PR、test 504 / 515) |
+| ~~B0h-d (#157)~~ | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化(B3 event loop の前提整備) | **完了**(PR #158 squash `ba7dc6d`、test 504 / 515) |
+| **B0h-e (#159)** | I5 stub fallback feature gate(`StubRanker` / `StubHostBridge` を `dev-stubs` feature で gate、release default で stub symbol 0 link) | **進行中**(本 PR、test 504 / 515) |
 | B0g 後追加検討(B0h 候補) | self-review#1〜#9: `non_exhaustive` trade-off ADR、flaky panic sliding-window metrics ADR、`IMEEngine::enable` Result 化、F4-F9 系 ADR | OSS 公開前 |
-| B0h-c / B0h-e / B0h-f (#149) | I1 SRP 分割 / I5 stub feature gate / I3 async dispatch | OSS 公開前必修 |
+| B0h-c / B0h-f (#149) | I1 SRP 分割 / I3 async dispatch | OSS 公開前必修 |
 | B2 | IBus signal body marshalling | B0f 後着手 |
 | B3 | IBus signal listener loop + event loop | B0f / B2 後着手 |
 | B6 | L3 manual smoke | B2 / B3 後着手 |


### PR DESCRIPTION
## Summary

- Add `kotoha-bin/[features] dev-stubs` (default OFF) at `crates/kotoha-bin/Cargo.toml:15-22`.
- Gate `StubRanker` / `StubHostBridge` struct + impl behind `#[cfg(feature = "dev-stubs")]` (`crates/kotoha-bin/src/main.rs:296-352`).
- `stub_fallback_allowed()` is now 2-defined: env-var check when `dev-stubs` ON, constant `false` when OFF (`main.rs:163-185`).
- The two `Err(e) if allow_stub =>` match arms (HybridRanker fallback at `main.rs:201-208` and IBusHostBridge fallback at `main.rs:227-234`) are also `#[cfg(feature = "dev-stubs")]` gated so the default match falls through to the fail-fast `Err` arm.
- `mpsc` import is also gated since it is only used inside `StubRanker::rank`.

## Verification (nm symbol count)

| Build | Stub symbols (`nm | grep -iE 'StubRanker|StubHostBridge'`) |
|---|---|
| `cargo build --release --bin kotoha` (default features) | **0** |
| `cargo build --release --bin kotoha --features kotoha-bin/dev-stubs` | **16** |

## Verification (runtime behaviour, debug build)

| Build + env | Outcome |
|---|---|
| default + `KOTOHA_ALLOW_STUB=1` | fail-fast at HybridRanker construction (stub arm absent) — exit 1 |
| `--features kotoha-bin/dev-stubs` + `KOTOHA_ALLOW_STUB=1` | falls back to `StubRanker` / `StubHostBridge`, then fail-loud at B0f event-loop gate — exit 1 |

Both paths still exit non-zero, preserving the B0f silent-failure ban.

## Test count

- Default features: 504 PASS / 0 FAIL (no change vs B0h-d baseline 504)
- `--features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers`: 515 PASS / 0 FAIL (no change vs B0h-d baseline 515)

## Test plan

- [ ] `cargo fmt --all` clean (verified locally)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean — both default AND `--features kotoha-bin/dev-stubs` (verified locally)
- [ ] `cargo test --workspace` 0 regression
- [ ] `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers` 0 regression
- [ ] `nm target/release/kotoha` shows 0 stub symbols on default features
- [ ] `nm target/release/kotoha` (built with `--features kotoha-bin/dev-stubs`) shows ≥1 stub symbols (positive verification)
- [ ] Self-review pending: pr-review-toolkit:silent-failure-hunter — no behaviour drift / cfg gate completeness / silent-fallback impossibility on release default

## Out of scope (tracked under #149)

- I1 SRP split (B0h-c)
- I3 dispatch async-ification (B0h-f)

## Reference

- Sub-issue: #159
- Parent: #149
- Predecessor: #157 (B0h-d, merged in PR #158)

🤖 Generated with [Claude Code](https://claude.com/claude-code)