### PR TITLE
P3-B B0h-c-i: KotohaEngine SRP split — extract PreeditBuffer + CandidateBuffer (#149) (#161)

### DIFF
--- a/crates/kotoha-engine-core/src/engine/candidates.rs
+++ b/crates/kotoha-engine-core/src/engine/candidates.rs
@@ -1,0 +1,65 @@
+//! `CandidateBuffer` — ranker から到着した候補列 + 現在 highlight 位置の SRP-pure
+//! value 単位。
+//!
+//! Phase 3-B B0h-c-i (ISSUE #149 / #161) で `KotohaEngine` から抽出された 2 field
+//! (`candidates: Vec<Candidate>` + `highlight_idx: usize`)を 1 sub-struct に
+//! 集約する。本 sub-struct の責務は **「engine 内部に保持する候補列(filter 適用後)
+//! と、navigation で動かす highlight 位置を 1 単位として保持し、clear / index 維持
+//! の API を提供する」** こと。
+//!
+//! 本 PR (B0h-c-i) では既存呼び出し側との diff を最小化するため、`items` と
+//! `highlight` は依然 `pub(crate)` で直接 access する。method 経由への抽象化は
+//! B0h-c-ii / -iii で `transitions.rs` の free function を sub-struct method 化
+//! する際に併せて進める。
+
+use kotoha_core::Candidate;
+
+/// 候補列(`items`)と現在 highlight 位置(`highlight`)を 1 単位として持つ
+/// value 型。
+///
+/// # Invariants
+///
+/// - `items.is_empty()` ⇒ `highlight == 0`(空 buffer の highlight は 0 に
+///   固定する。`Remove` 経路は `truncate_highlight_to_len` で維持する)。
+/// - `!items.is_empty()` ⇒ `highlight < items.len()`(navigation / Remove で
+///   保たれる)。
+pub(crate) struct CandidateBuffer {
+    /// engine 内部に保持する候補列(filter / sanitize 適用後)。
+    /// `Replace` で全置換、`Append` で末尾追加、`Remove` で範囲 drain、
+    /// `Clear` で空にする。
+    pub(crate) items: Vec<Candidate>,
+    /// 現在 highlight 中の候補 index(0-based)。空 buffer の場合は 0、
+    /// それ以外では `0 <= highlight < items.len()`。
+    pub(crate) highlight: usize,
+}
+
+impl CandidateBuffer {
+    /// 空の buffer を構築する。
+    ///
+    /// # Postconditions
+    ///
+    /// - `items.is_empty()`
+    /// - `highlight == 0`
+    pub(crate) fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            highlight: 0,
+        }
+    }
+
+    /// `items` を空にし、`highlight` を 0 にリセットする。
+    ///
+    /// `focus_out` / `reset` / `disable` / `handle_return` (commit 後) /
+    /// `handle_escape` (CandidatesShown path) / `handle_typing` の
+    /// CandidatesShown re-entry / `dispatch_rank_request` の prior-clear /
+    /// `apply_candidate_update::Clear` 等で呼ばれる。
+    ///
+    /// # Postconditions
+    ///
+    /// - `items.is_empty()`
+    /// - `highlight == 0`
+    pub(crate) fn clear(&mut self) {
+        self.items.clear();
+        self.highlight = 0;
+    }
+}

--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -12,20 +12,22 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use kotoha_core::romaji::RomajiConverter;
-use kotoha_core::Candidate;
-
 use crate::cancel::{CancellationToken, StdCancellationToken};
 use crate::host_bridge::IMEHostBridge;
 use crate::ime_engine::IMEEngine;
 use crate::key_event::{KeyEvent, KeyEventResult};
 use crate::ranker::{CandidateUpdate, ConversionContext, ConversionMode, Ranker};
 
+mod candidates;
 mod commit_history;
 mod event;
+mod preedit;
 #[doc(hidden)]
 pub mod transitions;
 mod worker;
+
+use candidates::CandidateBuffer;
+use preedit::PreeditBuffer;
 
 pub use commit_history::CommitHistory;
 pub use worker::panic_message_from;
@@ -62,19 +64,31 @@ pub(crate) struct RequestHandle {
 ///
 /// # Invariants
 ///
-/// - `state == Idle` ⇒ `current_preedit.is_empty() && active_request.is_none()`
+/// - `state == Idle` ⇒ `preedit.current.is_empty() && active_request.is_none()`
 /// - `active_request.is_some()` ⇒ `cancel_token` が一意に存在
 /// - `commit_history.total_chars() <= 200`([`CommitHistory::push`] で維持)
+///
+/// # Phase 3-B B0h-c-i (ISSUE #149 / #161) field 整理
+///
+/// 旧 4 field を 2 sub-struct に集約:
+/// - `current_preedit: String` + `romaji: RomajiConverter` →
+///   [`preedit::PreeditBuffer`] (`engine.preedit.current` / `engine.preedit.romaji`)
+/// - `candidates: Vec<Candidate>` + `highlight_idx: usize` →
+///   [`candidates::CandidateBuffer`] (`engine.candidates.items` /
+///   `engine.candidates.highlight`)
+///
+/// 残 11 field (`state` / `host` / `ranker` / `learning_writer` /
+/// `commit_history` / `active_request` / `request_id_seed` / `last_commit_at` /
+/// `enabled` / `focused` / channel 群) は B0h-c-ii (`WorkerChannel`) と
+/// B0h-c-iii (`LearningSink` + transitions.rs method 化) で順次抽出する。
 pub struct KotohaEngine {
     pub(crate) state: EngineState,
     pub(crate) host: Box<dyn IMEHostBridge>,
     pub(crate) ranker: Arc<dyn Ranker>,
     pub(crate) learning_writer: Arc<dyn crate::learning_port::LearningRecorder>,
-    pub(crate) romaji: RomajiConverter,
-    pub(crate) current_preedit: String,
+    pub(crate) preedit: PreeditBuffer,
     pub(crate) commit_history: CommitHistory,
-    pub(crate) candidates: Vec<Candidate>,
-    pub(crate) highlight_idx: usize,
+    pub(crate) candidates: CandidateBuffer,
     pub(crate) active_request: Option<RequestHandle>,
     pub(crate) request_id_seed: u64,
     pub(crate) last_commit_at: Instant,
@@ -115,11 +129,9 @@ impl KotohaEngine {
             host,
             ranker,
             learning_writer,
-            romaji: RomajiConverter::new(),
-            current_preedit: String::new(),
+            preedit: PreeditBuffer::new(),
             commit_history: CommitHistory::new(),
-            candidates: Vec::new(),
-            highlight_idx: 0,
+            candidates: CandidateBuffer::new(),
             active_request: None,
             request_id_seed: 0,
             last_commit_at: Instant::now(),
@@ -167,7 +179,7 @@ impl KotohaEngine {
 
         let req = event::RankRequest {
             request_id,
-            kana: self.current_preedit.clone(),
+            kana: self.preedit.current.clone(),
             ctx,
             cancel_token,
             ranker: self.ranker.clone(),
@@ -190,7 +202,6 @@ impl KotohaEngine {
             );
             self.active_request = None;
             self.candidates.clear();
-            self.highlight_idx = 0;
             self.host.hide_candidate_window();
             self.state = EngineState::Idle;
             self.enabled = false;
@@ -215,10 +226,10 @@ impl KotohaEngine {
         // 発火しない。direct-call test (`apply_candidate_update_for_test`) が
         // 単体 API として apply boundary を assert するために apply 側の
         // 検出は維持する(両者の発火条件は排他、二重通知はしない)。
-        let had_displayed_before_dispatch = !self.candidates.is_empty();
+        let had_displayed_before_dispatch = !self.candidates.items.is_empty();
         self.candidates.clear();
         self.drain_events_blocking(max_wait, request_id);
-        if had_displayed_before_dispatch && self.candidates.is_empty() {
+        if had_displayed_before_dispatch && self.candidates.items.is_empty() {
             self.host.update_candidates(CandidateUpdate::Clear);
             self.host.hide_candidate_window();
         }
@@ -229,9 +240,9 @@ impl KotohaEngine {
     /// 呼び、CommitConverting 中で候補非空なら CandidatesShown へ遷移して
     /// `update_candidates` を host に発行する。
     fn maybe_promote_commit_to_candidates_shown(&mut self) {
-        if self.state == EngineState::CommitConverting && !self.candidates.is_empty() {
+        if self.state == EngineState::CommitConverting && !self.candidates.items.is_empty() {
             self.host
-                .update_candidates(CandidateUpdate::Replace(self.candidates.clone()));
+                .update_candidates(CandidateUpdate::Replace(self.candidates.items.clone()));
             self.state = EngineState::CandidatesShown;
         }
     }
@@ -240,7 +251,6 @@ impl KotohaEngine {
     fn degrade_to_idle(&mut self) {
         self.active_request = None;
         self.candidates.clear();
-        self.highlight_idx = 0;
         self.host.hide_candidate_window();
         self.state = EngineState::Idle;
     }
@@ -351,40 +361,39 @@ impl KotohaEngine {
     pub(crate) fn apply_candidate_update(&mut self, update: CandidateUpdate) {
         match update {
             CandidateUpdate::Replace(c) => {
-                let prior_was_nonempty = !self.candidates.is_empty();
+                let prior_was_nonempty = !self.candidates.items.is_empty();
                 let filtered = filter_safe_candidates(c);
-                self.candidates = filtered;
-                self.highlight_idx = 0;
-                if prior_was_nonempty && self.candidates.is_empty() {
+                self.candidates.items = filtered;
+                self.candidates.highlight = 0;
+                if prior_was_nonempty && self.candidates.items.is_empty() {
                     self.host.update_candidates(CandidateUpdate::Clear);
                     self.host.hide_candidate_window();
                 }
             }
             CandidateUpdate::Append(c) => {
-                // Append は self.candidates に extend するため:
+                // Append は self.candidates.items に extend するため:
                 // - prior=non-empty + extend(任意) → post=non-empty(Clear 不要)
                 // - prior=empty + extend(空) → post=empty(host も既に hide 状態のため通知不要)
                 // - prior=empty + extend(非空) → post=non-empty(caller transitions.rs が
-                //   `if !candidates.is_empty()` で host.update_candidates を出す経路が存在)
+                //   `if !candidates.items.is_empty()` で host.update_candidates を出す経路が存在)
                 // よって本 path 内に host.Clear + hide を fire する必要のある branch は
                 // 存在しない(self-review#3 で dead code 撤去、Replace path 限定の規約)。
                 let filtered = filter_safe_candidates(c);
-                self.candidates.extend(filtered);
+                self.candidates.items.extend(filtered);
             }
             CandidateUpdate::Remove(r) => {
-                let len = self.candidates.len();
+                let len = self.candidates.items.len();
                 let start = r.start.min(len);
                 let end = r.end.min(len);
                 if start < end {
-                    self.candidates.drain(start..end);
+                    self.candidates.items.drain(start..end);
                 }
-                if self.highlight_idx >= self.candidates.len() {
-                    self.highlight_idx = self.candidates.len().saturating_sub(1);
+                if self.candidates.highlight >= self.candidates.items.len() {
+                    self.candidates.highlight = self.candidates.items.len().saturating_sub(1);
                 }
             }
             CandidateUpdate::Clear => {
                 self.candidates.clear();
-                self.highlight_idx = 0;
             }
         }
     }
@@ -438,11 +447,9 @@ impl IMEEngine for KotohaEngine {
     fn focus_out(&mut self) {
         // spec §5.2: focus_out は cancel + clear + Idle
         self.cancel_active();
-        self.current_preedit.clear();
-        self.romaji.reset_pending();
+        self.preedit.clear();
         self.commit_history.clear();
         self.candidates.clear();
-        self.highlight_idx = 0;
         self.host.hide_candidate_window();
         self.host.update_preedit("", 0, false);
         self.state = EngineState::Idle;
@@ -452,11 +459,9 @@ impl IMEEngine for KotohaEngine {
     fn reset(&mut self) {
         // spec §5.2: reset は focus_out と同等処理
         self.cancel_active();
-        self.current_preedit.clear();
-        self.romaji.reset_pending();
+        self.preedit.clear();
         self.commit_history.clear();
         self.candidates.clear();
-        self.highlight_idx = 0;
         self.host.hide_candidate_window();
         self.host.update_preedit("", 0, false);
         self.state = EngineState::Idle;
@@ -468,10 +473,8 @@ impl IMEEngine for KotohaEngine {
 
     fn disable(&mut self) {
         self.cancel_active();
-        self.current_preedit.clear();
-        self.romaji.reset_pending();
+        self.preedit.clear();
         self.candidates.clear();
-        self.highlight_idx = 0;
         self.host.hide_candidate_window();
         self.host.update_preedit("", 0, false);
         self.state = EngineState::Idle;
@@ -499,15 +502,15 @@ impl Drop for KotohaEngine {
 impl KotohaEngine {
     /// Test-only inspector: 現在 preedit の clone を返す。
     pub fn preedit_for_test(&self) -> String {
-        self.current_preedit.clone()
+        self.preedit.current.clone()
     }
     /// Test-only inspector: 現在 candidate 数を返す。
     pub fn candidate_count_for_test(&self) -> usize {
-        self.candidates.len()
+        self.candidates.items.len()
     }
     /// Test-only inspector: 現在 highlight idx を返す。
     pub fn highlight_idx_for_test(&self) -> usize {
-        self.highlight_idx
+        self.candidates.highlight
     }
     /// Test-only inspector: 現在 state を返す。
     pub fn state_for_test(&self) -> EngineState {
@@ -525,7 +528,7 @@ impl KotohaEngine {
     /// B0g-b #148 / I8 sanitization filter が正しく Candidate を drop している
     /// か観測するための accessor。
     pub fn candidates_for_test(&self) -> Vec<kotoha_core::Candidate> {
-        self.candidates.clone()
+        self.candidates.items.clone()
     }
 
     /// Test-only: `drain_pending_events()` を直接呼んで rx_event の pending な

--- a/crates/kotoha-engine-core/src/engine/preedit.rs
+++ b/crates/kotoha-engine-core/src/engine/preedit.rs
@@ -1,0 +1,62 @@
+//! `PreeditBuffer` — kana surface + Romaji 変換器の SRP-pure value 単位。
+//!
+//! Phase 3-B B0h-c-i (ISSUE #149 / #161) で `KotohaEngine` から抽出された 2 field
+//! (`current_preedit: String` + `romaji: RomajiConverter`)を 1 sub-struct に
+//! 集約する。本 sub-struct の責務は **「IBus に通知される pre-edit 表示文字列」と、
+//! 続く typing で push される RomajiConverter pending state を 1 単位として保持し、
+//! reset / pop / push / size 観測の API を提供する** こと。
+//!
+//! 本 PR (B0h-c-i) では既存呼び出し側との diff を最小化するため、`current` と
+//! `romaji` は依然 `pub(crate)` で直接 access する。method 経由への抽象化は
+//! B0h-c-ii / -iii の `transitions.rs` 全 free function method 化と同時に進める。
+
+use kotoha_core::romaji::RomajiConverter;
+
+/// Pre-edit kana surface(`current`)と RomajiConverter pending state(`romaji`)を
+/// 1 単位として持つ value 型。
+///
+/// # Invariants
+///
+/// - `current` は IBus 側 `update_preedit` で表示される literal kana surface
+///   (filter / sanitize は engine boundary で別途実施される。本 buffer 自体に
+///   sanitize 責務は無い)。
+/// - `romaji` の pending state は次 typing で `push` され、`reset_pending` で
+///   破棄できる。`current` と `romaji` の同期は呼び出し側(`transitions.rs`)が
+///   各 keystroke で維持する(本 PR では method 抽象化を行わない)。
+pub(crate) struct PreeditBuffer {
+    /// IBus に通知される pre-edit 表示文字列。確定済 kana が末尾追加され、
+    /// commit / focus_out / reset / disable で `clear` される。
+    pub(crate) current: String,
+    /// 次 typing 用の Romaji 変換器 pending state。`reset_pending` で
+    /// pending を破棄し、`push` で 1 char ずつ ConvertStep を返す。
+    pub(crate) romaji: RomajiConverter,
+}
+
+impl PreeditBuffer {
+    /// 空の buffer を構築する。
+    ///
+    /// # Postconditions
+    ///
+    /// - `current.is_empty()`
+    /// - `romaji` pending は `RomajiConverter::new()` 状態
+    pub(crate) fn new() -> Self {
+        Self {
+            current: String::new(),
+            romaji: RomajiConverter::new(),
+        }
+    }
+
+    /// `current` をクリアし、Romaji pending state を破棄する。
+    ///
+    /// `focus_out` / `reset` / `disable` / `handle_return` (commit 後) /
+    /// `handle_escape` (LiveConverting / CommitConverting path) で呼ばれる。
+    ///
+    /// # Postconditions
+    ///
+    /// - `current.is_empty()`
+    /// - `romaji` pending state cleared
+    pub(crate) fn clear(&mut self) {
+        self.current.clear();
+        self.romaji.reset_pending();
+    }
+}

--- a/crates/kotoha-engine-core/src/engine/transitions.rs
+++ b/crates/kotoha-engine-core/src/engine/transitions.rs
@@ -50,30 +50,29 @@ fn handle_typing(engine: &mut KotohaEngine, key: KeyEvent) -> KeyEventResult {
     if engine.state == EngineState::CandidatesShown {
         engine.host.hide_candidate_window();
         engine.candidates.clear();
-        engine.highlight_idx = 0;
     }
 
     // RomajiConverter::push でストリーミング 1 char convert(state を蓄積)。
     // push 後に normalize_pending で sokuon/hatsuon edge を確定させる。
     let mut committed = String::new();
-    if let ConvertStep::Committed(s) = engine.romaji.push(ch) {
+    if let ConvertStep::Committed(s) = engine.preedit.romaji.push(ch) {
         committed.push_str(&s);
     }
-    committed.push_str(&engine.romaji.normalize_pending());
+    committed.push_str(&engine.preedit.romaji.normalize_pending());
     if !committed.is_empty() {
-        engine.current_preedit.push_str(&committed);
+        engine.preedit.current.push_str(&committed);
     }
 
     // preedit 更新
-    let cursor = engine.current_preedit.chars().count();
+    let cursor = engine.preedit.current.chars().count();
     engine.host.update_preedit(
-        &engine.current_preedit,
+        &engine.preedit.current,
         cursor,
-        !engine.current_preedit.is_empty(),
+        !engine.preedit.current.is_empty(),
     );
 
     // 状態遷移 → LiveConverting(preedit 非空時のみ)
-    if !engine.current_preedit.is_empty() {
+    if !engine.preedit.current.is_empty() {
         engine.cancel_active();
         engine.dispatch_rank_request(ConversionMode::Live);
         // B0g #148 / I16:dispatch_rank_request が worker channel disconnect を
@@ -84,10 +83,10 @@ fn handle_typing(engine: &mut KotohaEngine, key: KeyEvent) -> KeyEventResult {
         if !engine.enabled {
             return KeyEventResult::Consumed;
         }
-        if !engine.candidates.is_empty() {
+        if !engine.candidates.items.is_empty() {
             engine
                 .host
-                .update_candidates(CandidateUpdate::Replace(engine.candidates.clone()));
+                .update_candidates(CandidateUpdate::Replace(engine.candidates.items.clone()));
             engine.host.show_candidate_window();
         }
         engine.state = EngineState::LiveConverting;
@@ -110,31 +109,30 @@ fn handle_backspace(engine: &mut KotohaEngine) -> KeyEventResult {
             if engine.state == EngineState::CandidatesShown {
                 engine.host.hide_candidate_window();
                 engine.candidates.clear();
-                engine.highlight_idx = 0;
             }
 
             // spec §6.2: kana 末尾 1 char pop + romaji pending reset
-            engine.current_preedit.pop();
-            engine.romaji.reset_pending();
+            engine.preedit.current.pop();
+            engine.preedit.romaji.reset_pending();
 
-            let cursor = engine.current_preedit.chars().count();
+            let cursor = engine.preedit.current.chars().count();
             engine.host.update_preedit(
-                &engine.current_preedit,
+                &engine.preedit.current,
                 cursor,
-                !engine.current_preedit.is_empty(),
+                !engine.preedit.current.is_empty(),
             );
 
             engine.cancel_active();
 
-            if engine.current_preedit.is_empty() {
+            if engine.preedit.current.is_empty() {
                 engine.host.hide_candidate_window();
                 engine.state = EngineState::Idle;
             } else {
                 engine.dispatch_rank_request(ConversionMode::Live);
-                if !engine.candidates.is_empty() {
-                    engine
-                        .host
-                        .update_candidates(CandidateUpdate::Replace(engine.candidates.clone()));
+                if !engine.candidates.items.is_empty() {
+                    engine.host.update_candidates(CandidateUpdate::Replace(
+                        engine.candidates.items.clone(),
+                    ));
                     engine.host.show_candidate_window();
                 }
                 engine.state = EngineState::LiveConverting;
@@ -164,7 +162,6 @@ fn handle_space(engine: &mut KotohaEngine) -> KeyEventResult {
             engine.cancel_active();
             // spec §5.2 row 4: 即 CommitConverting + show_candidate_window
             engine.candidates.clear();
-            engine.highlight_idx = 0;
             engine.state = EngineState::CommitConverting;
             engine.host.show_candidate_window();
 
@@ -172,10 +169,10 @@ fn handle_space(engine: &mut KotohaEngine) -> KeyEventResult {
 
             // 候補が dispatch 内 drain で間に合っていれば row 7 遷移を即適用。
             // 間に合っていなければ後続 keystroke の drain_pending_events で対応。
-            if !engine.candidates.is_empty() {
+            if !engine.candidates.items.is_empty() {
                 engine
                     .host
-                    .update_candidates(CandidateUpdate::Replace(engine.candidates.clone()));
+                    .update_candidates(CandidateUpdate::Replace(engine.candidates.items.clone()));
                 engine.state = EngineState::CandidatesShown;
             }
             KeyEventResult::Consumed
@@ -189,11 +186,11 @@ fn handle_space(engine: &mut KotohaEngine) -> KeyEventResult {
 
 /// Return / Enter — commit 確定(spec §6.3)。
 fn handle_return(engine: &mut KotohaEngine) -> KeyEventResult {
-    if engine.state != EngineState::CandidatesShown || engine.candidates.is_empty() {
+    if engine.state != EngineState::CandidatesShown || engine.candidates.items.is_empty() {
         return KeyEventResult::Forwarded;
     }
-    let selected: Candidate = engine.candidates[engine.highlight_idx].clone();
-    let kana_at_request = engine.current_preedit.clone();
+    let selected: Candidate = engine.candidates.items[engine.candidates.highlight].clone();
+    let kana_at_request = engine.preedit.current.clone();
 
     // B0g-b #148 / 第 2 回 review I8: host 出力の trust boundary で sanitization。
     // 改ざん辞書 / 悪意ある LLM 出力 / Phase 5 custom model から来た候補が ANSI
@@ -219,10 +216,8 @@ fn handle_return(engine: &mut KotohaEngine) -> KeyEventResult {
         // F2 cleanup:UI 状態を Idle に戻して user が次操作できるようにする。
         engine.host.hide_candidate_window();
         engine.host.update_preedit("", 0, false);
-        engine.current_preedit.clear();
-        engine.romaji.reset_pending();
+        engine.preedit.clear();
         engine.candidates.clear();
-        engine.highlight_idx = 0;
         engine.cancel_active();
         engine.state = EngineState::Idle;
         return KeyEventResult::Consumed;
@@ -240,10 +235,8 @@ fn handle_return(engine: &mut KotohaEngine) -> KeyEventResult {
 
     engine.host.hide_candidate_window();
     engine.host.update_preedit("", 0, false);
-    engine.current_preedit.clear();
-    engine.romaji.reset_pending();
+    engine.preedit.clear();
     engine.candidates.clear();
-    engine.highlight_idx = 0;
     engine.cancel_active();
     engine.state = EngineState::Idle;
     KeyEventResult::Consumed
@@ -255,10 +248,8 @@ fn handle_escape(engine: &mut KotohaEngine) -> KeyEventResult {
         EngineState::Idle => KeyEventResult::Forwarded,
         EngineState::LiveConverting | EngineState::CommitConverting => {
             engine.cancel_active();
-            engine.current_preedit.clear();
-            engine.romaji.reset_pending();
+            engine.preedit.clear();
             engine.candidates.clear();
-            engine.highlight_idx = 0;
             engine.host.update_preedit("", 0, false);
             engine.host.hide_candidate_window();
             engine.state = EngineState::Idle;
@@ -268,16 +259,15 @@ fn handle_escape(engine: &mut KotohaEngine) -> KeyEventResult {
             // spec §5.2: CandidatesShown で Esc は候補閉、preedit kana 維持で Live 復帰
             engine.host.hide_candidate_window();
             engine.candidates.clear();
-            engine.highlight_idx = 0;
             engine.cancel_active();
-            if engine.current_preedit.is_empty() {
+            if engine.preedit.current.is_empty() {
                 engine.state = EngineState::Idle;
             } else {
                 engine.dispatch_rank_request(ConversionMode::Live);
-                if !engine.candidates.is_empty() {
-                    engine
-                        .host
-                        .update_candidates(CandidateUpdate::Replace(engine.candidates.clone()));
+                if !engine.candidates.items.is_empty() {
+                    engine.host.update_candidates(CandidateUpdate::Replace(
+                        engine.candidates.items.clone(),
+                    ));
                     engine.host.show_candidate_window();
                 }
                 engine.state = EngineState::LiveConverting;
@@ -289,21 +279,21 @@ fn handle_escape(engine: &mut KotohaEngine) -> KeyEventResult {
 
 /// 候補 navigation(↑↓←→ / Tab、CandidatesShown で highlight 移動)。
 fn handle_navigation(engine: &mut KotohaEngine, keysym: u32) -> KeyEventResult {
-    if engine.state != EngineState::CandidatesShown || engine.candidates.is_empty() {
+    if engine.state != EngineState::CandidatesShown || engine.candidates.items.is_empty() {
         return KeyEventResult::Forwarded;
     }
-    let n = engine.candidates.len();
+    let n = engine.candidates.items.len();
     match keysym {
         keysyms::DOWN | keysyms::TAB | keysyms::RIGHT => {
-            engine.highlight_idx = (engine.highlight_idx + 1) % n;
+            engine.candidates.highlight = (engine.candidates.highlight + 1) % n;
         }
         keysyms::UP | keysyms::LEFT => {
-            engine.highlight_idx = (engine.highlight_idx + n - 1) % n;
+            engine.candidates.highlight = (engine.candidates.highlight + n - 1) % n;
         }
         _ => return KeyEventResult::Forwarded,
     }
     engine
         .host
-        .update_candidates(CandidateUpdate::Replace(engine.candidates.clone()));
+        .update_candidates(CandidateUpdate::Replace(engine.candidates.items.clone()));
     KeyEventResult::Consumed
 }

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -100,6 +100,10 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 | B1 | kotoha-bin 実 HybridRanker 配線 | #137 | `feature/136-p3b-b1-production-ranker-wiring` |
 | B4 | KeyModifiers full IBus mapping + RELEASE handling | #138 | `feature/136-p3b-b4-keymodifiers-full-mapping` |
 | B5 | KotohaEngine + 実 HybridRanker e2e test | #139 | `feature/136-p3b-b5-engine-wrap-integration` |
+| B0h-a | C3 hexagonal driven port 反転 (`learning_port` + `kotoha-engine-adapter`) | #154 | `feature/153-b0h-a-...` |
+| B0h-b | I4 `HybridRanker` を `kotoha-ranker-hybrid` 別 crate へ切り出し | #156 | `feature/155-b0h-b-...` |
+| B0h-d | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化 | #158 | `feature/157-b0h-d-...` |
+| B0h-e | I5 stub fallback `dev-stubs` feature gate | #160 | `feature/159-b0h-e-...` |
 
 ## Test count(実測)
 
@@ -111,7 +115,12 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 | P3-B B0f 完了時(2026-05-03、PR #147) | 432 | 473(test 改変ゼロ) |
 | P3-B B0g-a 完了時(2026-05-03、PR #150) | 436 | 478(+5: panic_message 3 + worker circuit breaker 1 + dispatcher panic catch 1) |
 | P3-B B0g-b 完了時(2026-05-03、PR #151) | 447 | 491(+13: sanitize unit 7 + filter 4 + boundary_notify regression 2) |
-| **P3-B B0g-c 完了時(2026-05-03、本 PR)** | **447** | **498**(+7: row 8 4 件 + I14 demo 1 + boundary skip-when-empty 1 + silent_ranker e2e 1) |
+| P3-B B0g-c 完了時(2026-05-03、PR #152) | 447 | 498(+7: row 8 4 件 + I14 demo 1 + boundary skip-when-empty 1 + silent_ranker e2e 1) |
+| P3-B B0h-a 完了時(2026-05-03、PR #154) | 464 | 515(+17 / +17: hexagonal port 反転で domain port test 群が test-helpers なしでも回るようになり default 集合に組込) |
+| P3-B B0h-b 完了時(2026-05-03、PR #156) | 504 | 515(default +40: workspace feature unification で engine_wrap_hybrid.rs が default にも参加、test-helpers は変動なし) |
+| P3-B B0h-d 完了時(2026-05-03、PR #158) | 504 | 515(test 改変ゼロ) |
+| P3-B B0h-e 完了時(2026-05-04、PR #160) | 504 | 515(test 改変ゼロ) |
+| **P3-B B0h-c-i 完了時(2026-05-04、本 PR)** | **504** | **515**(test 改変ゼロ、SRP 内部 refactor のみ) |
 
 註:`cargo test --workspace` (default features) と `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers` で結果が異なる。lefthook pre-push は default features を回す。第 1 回包括 review (B0a-B0e) では test-helpers feature 経由の合計値 (416 → 473) を baseline として参照する。過去の commit message で `446` / `448` / `454` と記載した数値はいずれも不正確で、上表が正規値。
 
@@ -149,9 +158,12 @@ GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 applicatio
 | ~~B0h-a (#153)~~ | C3 hexagonal driven port 反転(`learning_port` を engine-core に新設、`kotoha-engine-adapter` crate 切出し、engine-core が storage を直接 import しない構造へ) | **完了**(PR #154 squash `5c37d65`、test 464 / 515) |
 | ~~B0h-b (#155)~~ | I4 `HybridRanker` を `kotoha-ranker-hybrid` 別 crate へ切り出し(engine-core から concrete adapter を分離、LLM features を ranker-hybrid 側に移送) | **完了**(PR #156 squash `3cc36a9`、test 504 / 515) |
 | ~~B0h-d (#157)~~ | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化(B3 event loop の前提整備) | **完了**(PR #158 squash `ba7dc6d`、test 504 / 515) |
-| **B0h-e (#159)** | I5 stub fallback feature gate(`StubRanker` / `StubHostBridge` を `dev-stubs` feature で gate、release default で stub symbol 0 link) | **進行中**(本 PR、test 504 / 515) |
+| ~~B0h-e (#159)~~ | I5 stub fallback feature gate(`StubRanker` / `StubHostBridge` を `dev-stubs` feature で gate、release default で stub symbol 0 link) | **完了**(PR #160 squash `7b58cbc`、test 504 / 515) |
+| **B0h-c-i (#161)** | I1 SRP 分割 sub-PR 1/3:`PreeditBuffer` + `CandidateBuffer` 抽出(`current_preedit` + `romaji` / `candidates` + `highlight_idx` を 2 sub-struct に集約) | **進行中**(本 PR、test 504 / 515) |
+| B0h-c-ii | I1 SRP 分割 sub-PR 2/3:`WorkerChannel` 抽出(`tx_request` / `rx_event` / `worker_handle` / `request_id_seed` を 1 sub-struct に集約) | OSS 公開前必修 |
+| B0h-c-iii | I1 SRP 分割 sub-PR 3/3:`LearningSink` 抽出 + `transitions.rs` 全 free function を sub-struct method 経由に書き換え | OSS 公開前必修 |
 | B0g 後追加検討(B0h 候補) | self-review#1〜#9: `non_exhaustive` trade-off ADR、flaky panic sliding-window metrics ADR、`IMEEngine::enable` Result 化、F4-F9 系 ADR | OSS 公開前 |
-| B0h-c / B0h-f (#149) | I1 SRP 分割 / I3 async dispatch | OSS 公開前必修 |
+| B0h-f (#149) | I3 async dispatch(`drain_events_blocking` 撤去 + wakeup channel) | OSS 公開前必修 |
 | B2 | IBus signal body marshalling | B0f 後着手 |
 | B3 | IBus signal listener loop + event loop | B0f / B2 後着手 |
 | B6 | L3 manual smoke | B2 / B3 後着手 |


### PR DESCRIPTION
## Summary

Sub-PR 1/3 of **B0h-c** (I1 SRP split) tracked in #149. Extract two value-typed sub-structs from `KotohaEngine` to start decomposing the 15-field god struct identified in the 2nd comprehensive review.

- `PreeditBuffer { current: String, romaji: RomajiConverter }` — kana surface + RomajiConverter pending state
- `CandidateBuffer { items: Vec<Candidate>, highlight: usize }` — ranker output list + navigation cursor

Replaces 4 `pub(crate)` fields with 2 sub-struct fields:

| Before | After |
|---|---|
| `current_preedit: String` | `preedit.current` |
| `romaji: RomajiConverter` | `preedit.romaji` |
| `candidates: Vec<Candidate>` | `candidates.items` |
| `highlight_idx: usize` | `candidates.highlight` |

Both sub-structs expose a `clear()` method that consolidates the previously-scattered reset logic in `focus_out` / `reset` / `disable` / `handle_return` / `handle_escape` paths.

## Out of scope (deferred to subsequent sub-PRs)

- **B0h-c-ii**: `WorkerChannel` extraction (`tx_request` / `rx_event` / `worker_handle` / `request_id_seed`)
- **B0h-c-iii**: `LearningSink` extraction + `transitions.rs` free-function → method conversion
- **B0h-f**: I3 async dispatch (separate)

## Verification

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers -- -D warnings` clean
- [x] `cargo test --workspace` = 504 PASS / 0 FAIL (baseline preserved)
- [x] `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers` = 515 PASS / 0 FAIL
- [x] `KOTOHA_ALLOW_STUB=1 ./target/debug/kotoha` exit 1 (B0f gate intact)
- [x] `nm target/release/kotoha | grep -ci stub` = 0 (B0h-e gate intact)
- [x] No new public API surface (sub-structs `pub(crate)`)
- [x] PR ≤ 500 lines (actual: 226 ins / 94 del across 4 src files + 1 WBS)

## Test plan

- [ ] CI green (lefthook pre-push already PASS locally)
- [ ] Self-review (silent-failure-hunter) catches any boundary regression
- [ ] No regression on default 504 / test-helpers 515 baselines

## Reference

- Parent: #149 (B0h tracking)
- Issue: #161 (B0h-c-i sub-issue)
- Predecessors: #154 (B0h-a), #156 (B0h-b), #158 (B0h-d), #160 (B0h-e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)