### PR TITLE
P3-B B0h-c-ii: KotohaEngine SRP split — extract WorkerChannel (#149) (#163)

### DIFF
--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -25,9 +25,11 @@ mod preedit;
 #[doc(hidden)]
 pub mod transitions;
 mod worker;
+mod worker_channel;
 
 use candidates::CandidateBuffer;
 use preedit::PreeditBuffer;
+use worker_channel::WorkerChannel;
 
 pub use commit_history::CommitHistory;
 pub use worker::panic_message_from;
@@ -68,19 +70,23 @@ pub(crate) struct RequestHandle {
 /// - `active_request.is_some()` ⇒ `cancel_token` が一意に存在
 /// - `commit_history.total_chars() <= 200`([`CommitHistory::push`] で維持)
 ///
-/// # Phase 3-B B0h-c-i (ISSUE #149 / #161) field 整理
+/// # Phase 3-B B0h-c-i (ISSUE #149 / #161) / B0h-c-ii (#163) field 整理
 ///
-/// 旧 4 field を 2 sub-struct に集約:
+/// 旧 7 field を 3 sub-struct に集約:
 /// - `current_preedit: String` + `romaji: RomajiConverter` →
 ///   [`preedit::PreeditBuffer`] (`engine.preedit.current` / `engine.preedit.romaji`)
 /// - `candidates: Vec<Candidate>` + `highlight_idx: usize` →
 ///   [`candidates::CandidateBuffer`] (`engine.candidates.items` /
 ///   `engine.candidates.highlight`)
+/// - `tx_request` + `rx_event` + `worker_handle` →
+///   [`worker_channel::WorkerChannel`] (`engine.worker.tx_request` /
+///   `engine.worker.rx_event`)。本 sub-struct が `Drop` impl を持つため
+///   `KotohaEngine::Drop` は撤去された。
 ///
-/// 残 11 field (`state` / `host` / `ranker` / `learning_writer` /
+/// 残 8 field (`state` / `host` / `ranker` / `learning_writer` /
 /// `commit_history` / `active_request` / `request_id_seed` / `last_commit_at` /
-/// `enabled` / `focused` / channel 群) は B0h-c-ii (`WorkerChannel`) と
-/// B0h-c-iii (`LearningSink` + transitions.rs method 化) で順次抽出する。
+/// `enabled` / `focused`) は B0h-c-iii (`LearningSink` +
+/// transitions.rs method 化) で順次抽出する。
 pub struct KotohaEngine {
     pub(crate) state: EngineState,
     pub(crate) host: Box<dyn IMEHostBridge>,
@@ -94,12 +100,10 @@ pub struct KotohaEngine {
     pub(crate) last_commit_at: Instant,
     pub(crate) enabled: bool,
     pub(crate) focused: bool,
-    /// `RankerWorker` 主 thread への request 送信 channel。
-    pub(crate) tx_request: mpsc::Sender<event::RankRequest>,
-    /// `RankerWorker` から engine 主 thread への event 受信 channel。
-    pub(crate) rx_event: mpsc::Receiver<event::EngineEvent>,
-    /// Worker thread join handle(`Drop` impl で best-effort 終了)。
-    pub(crate) worker_handle: Option<std::thread::JoinHandle<()>>,
+    /// `RankerWorker` 主 thread と engine 主 thread を結ぶ channel pair および
+    /// worker thread join handle。本 sub-struct の `Drop` impl が `tx_request`
+    /// drop → worker exit → 別 thread で join の順で safe shutdown を行う。
+    pub(crate) worker: WorkerChannel,
 }
 
 impl KotohaEngine {
@@ -123,7 +127,7 @@ impl KotohaEngine {
         ranker: Arc<dyn Ranker>,
         learning_writer: Arc<dyn crate::learning_port::LearningRecorder>,
     ) -> io::Result<Self> {
-        let (tx_request, rx_event, worker_handle) = worker::spawn_worker()?;
+        let worker = WorkerChannel::new()?;
         Ok(Self {
             state: EngineState::Idle,
             host,
@@ -137,9 +141,7 @@ impl KotohaEngine {
             last_commit_at: Instant::now(),
             enabled: false,
             focused: false,
-            tx_request,
-            rx_event,
-            worker_handle: Some(worker_handle),
+            worker,
         })
     }
 
@@ -184,7 +186,7 @@ impl KotohaEngine {
             cancel_token,
             ranker: self.ranker.clone(),
         };
-        if self.tx_request.send(req).is_err() {
+        if self.worker.tx_request.send(req).is_err() {
             // worker thread が死亡している。spec §9.1 row 2 に従い、
             // engine 状態を Idle に戻して候補ウィンドウを閉じ、stale な
             // active_request を残さない(後続 keystroke の cancel_active が
@@ -269,7 +271,7 @@ impl KotohaEngine {
     pub(crate) fn drain_events_blocking(&mut self, max_wait: Duration, target_id: u64) {
         let deadline = Instant::now() + max_wait;
         while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
-            match self.rx_event.recv_timeout(remaining) {
+            match self.worker.rx_event.recv_timeout(remaining) {
                 Ok(event::EngineEvent::Candidates { request_id, update }) => {
                     if request_id != target_id {
                         continue;
@@ -309,7 +311,7 @@ impl KotohaEngine {
     pub(crate) fn drain_pending_events(&mut self) {
         let active_id = self.active_request.as_ref().map(|h| h.id);
         loop {
-            match self.rx_event.try_recv() {
+            match self.worker.rx_event.try_recv() {
                 Ok(event::EngineEvent::Candidates { request_id, update }) => {
                     if active_id != Some(request_id) {
                         continue; // mismatch discard
@@ -482,21 +484,8 @@ impl IMEEngine for KotohaEngine {
     }
 }
 
-impl Drop for KotohaEngine {
-    /// `tx_request` を drop することで worker thread が `recv() == Err` を
-    /// 検出して loop を抜ける。worker は best-effort で join する(blocking
-    /// したくないため、separate thread で待機し、main thread は即時 return)。
-    fn drop(&mut self) {
-        if let Some(h) = self.worker_handle.take() {
-            std::thread::Builder::new()
-                .name("kotoha-ranker-worker-joiner".into())
-                .spawn(move || {
-                    let _ = h.join();
-                })
-                .ok();
-        }
-    }
-}
+// worker thread の shutdown は `worker: WorkerChannel` の `Drop` impl が担う
+// (B0h-c-ii #163 で `KotohaEngine::Drop` から移管)。
 
 #[cfg(feature = "test-helpers")]
 impl KotohaEngine {

--- a/crates/kotoha-engine-core/src/engine/worker_channel.rs
+++ b/crates/kotoha-engine-core/src/engine/worker_channel.rs
@@ -1,0 +1,93 @@
+//! `WorkerChannel` — `RankerWorker` 主 thread と engine 主 thread の channel pair
+//! および worker thread join handle を 1 単位として保持する resource owner。
+//!
+//! Phase 3-B B0h-c-ii (ISSUE #149 / #163) で `KotohaEngine` から抽出された 3 field
+//! (`tx_request: mpsc::Sender<RankRequest>` + `rx_event: mpsc::Receiver<EngineEvent>` +
+//! `worker_handle: Option<JoinHandle<()>>`)を 1 sub-struct に集約する。
+//!
+//! 本 sub-struct の責務は **「worker thread の lifetime と紐付く 3 リソースを 1 単位
+//! として保持し、所有権 drop で安全に worker を停止させる」** こと。`KotohaEngine::Drop`
+//! 旧実装は本 sub-struct の `Drop` impl に移管された(下記 # Drop semantics 参照)。
+//!
+//! 本 PR (B0h-c-ii) では既存呼び出し側との diff を最小化するため、`tx_request` /
+//! `rx_event` は依然 `pub(crate)` で直接 access する。method 経由への抽象化
+//! (`send_request` / `try_recv_event` / `recv_event_timeout` 等)は B0h-c-iii で
+//! `transitions.rs` の free function method 化と同時に進める。
+
+use std::io;
+use std::sync::mpsc;
+use std::thread;
+
+use super::event::{EngineEvent, RankRequest};
+use super::worker;
+
+/// `RankerWorker` 関連 3 リソースを 1 単位として保持する resource owner。
+///
+/// # Invariants
+///
+/// - `tx_request` / `rx_event` は worker thread と接続されている(本 struct を
+///   経由しない別 channel に差し替えることはできない、constructor 経由のみ)。
+/// - `handle.is_some()` ⇒ worker thread は spawn 済(`new()` の Postconditions)。
+///   `Drop` 内部では `take()` で None に遷移する。
+///
+/// # Drop semantics
+///
+/// `Drop::drop` で `handle.take()` し、別 thread (`kotoha-ranker-worker-joiner`) で
+/// 非 blocking join を行う。Drop::drop 自体が return した後、Rust の field drop 順
+/// (declaration 順)で `tx_request` が drop され、worker `rx_request.recv()` が
+/// `Err` を返して loop を抜ける。これにより:
+///
+/// - 親 thread は Drop で blocking しない(joiner thread に委譲)
+/// - worker thread は `tx_request` drop 後に確実に exit する
+/// - `rx_event` 受信側に取り残された event は drop と共に破棄される
+///
+/// 旧実装(B0h-c-ii 以前)は同等の logic を `KotohaEngine::Drop` に直接書いていた。
+/// 本 PR で resource lifetime と engine state lifecycle を分離したことで、
+/// engine 自体の Drop impl は撤去されている。
+pub(crate) struct WorkerChannel {
+    /// engine 主 thread → worker への `RankRequest` 送信 channel。
+    pub(crate) tx_request: mpsc::Sender<RankRequest>,
+    /// worker → engine 主 thread への `EngineEvent` 受信 channel。
+    pub(crate) rx_event: mpsc::Receiver<EngineEvent>,
+    /// Worker thread join handle。`Drop` で `take()` し joiner thread に委譲する。
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl WorkerChannel {
+    /// `RankerWorker` を新規 spawn し、紐付く 3 リソースを 1 単位として返す。
+    ///
+    /// # Postconditions
+    ///
+    /// - `tx_request` / `rx_event` は spawn された worker thread と接続済
+    /// - `handle.is_some()`
+    ///
+    /// # Errors
+    ///
+    /// - [`io::Error`] — OS が thread spawn を拒否した場合(thread resource 枯渇等)。
+    ///   呼び出し側([`super::KotohaEngine::new`])で `Result` 経由 propagate する
+    ///   (spec §9.1 row 5)。
+    pub(crate) fn new() -> io::Result<Self> {
+        let (tx_request, rx_event, handle) = worker::spawn_worker()?;
+        Ok(Self {
+            tx_request,
+            rx_event,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for WorkerChannel {
+    /// `tx_request` を drop することで worker thread が `recv() == Err` を
+    /// 検出して loop を抜ける。worker は best-effort で join する(blocking
+    /// したくないため、separate thread で待機し、main thread は即時 return)。
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            thread::Builder::new()
+                .name("kotoha-ranker-worker-joiner".into())
+                .spawn(move || {
+                    let _ = h.join();
+                })
+                .ok();
+        }
+    }
+}

--- a/crates/kotoha-engine-core/src/engine/worker_channel.rs
+++ b/crates/kotoha-engine-core/src/engine/worker_channel.rs
@@ -45,6 +45,11 @@ use super::worker;
 /// 本 PR で resource lifetime と engine state lifecycle を分離したことで、
 /// engine 自体の Drop impl は撤去されている。
 pub(crate) struct WorkerChannel {
+    // 注意: 本 struct の field 宣言順序は **load-bearing**(`Drop` semantics に
+    // 直接影響する)。`Drop::drop` 完了後の field drop は宣言順で行われるため、
+    // `tx_request` が **必ず最初** に drop される必要がある(worker `rx_request.recv()`
+    // を Err 復帰させ、joiner thread の `h.join()` を完了可能にするため)。
+    // field を並び替える PR は本 invariant を再検証すること。
     /// engine 主 thread → worker への `RankRequest` 送信 channel。
     pub(crate) tx_request: mpsc::Sender<RankRequest>,
     /// worker → engine 主 thread への `EngineEvent` 受信 channel。

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -104,6 +104,7 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 | B0h-b | I4 `HybridRanker` を `kotoha-ranker-hybrid` 別 crate へ切り出し | #156 | `feature/155-b0h-b-...` |
 | B0h-d | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化 | #158 | `feature/157-b0h-d-...` |
 | B0h-e | I5 stub fallback `dev-stubs` feature gate | #160 | `feature/159-b0h-e-...` |
+| B0h-c-i | I1 SRP 分割 sub-PR 1/3:`PreeditBuffer` + `CandidateBuffer` 抽出 | #162 | `feature/161-b0h-c-i-...` |
 
 ## Test count(実測)
 
@@ -120,7 +121,8 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 | P3-B B0h-b 完了時(2026-05-03、PR #156) | 504 | 515(default +40: workspace feature unification で engine_wrap_hybrid.rs が default にも参加、test-helpers は変動なし) |
 | P3-B B0h-d 完了時(2026-05-03、PR #158) | 504 | 515(test 改変ゼロ) |
 | P3-B B0h-e 完了時(2026-05-04、PR #160) | 504 | 515(test 改変ゼロ) |
-| **P3-B B0h-c-i 完了時(2026-05-04、本 PR)** | **504** | **515**(test 改変ゼロ、SRP 内部 refactor のみ) |
+| P3-B B0h-c-i 完了時(2026-05-04、PR #162) | 504 | 515(test 改変ゼロ、SRP 内部 refactor のみ) |
+| **P3-B B0h-c-ii 完了時(2026-05-04、本 PR)** | **504** | **515**(test 改変ゼロ、`WorkerChannel` 抽出 + Drop 移管のみ) |
 
 註:`cargo test --workspace` (default features) と `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers` で結果が異なる。lefthook pre-push は default features を回す。第 1 回包括 review (B0a-B0e) では test-helpers feature 経由の合計値 (416 → 473) を baseline として参照する。過去の commit message で `446` / `448` / `454` と記載した数値はいずれも不正確で、上表が正規値。
 
@@ -159,8 +161,8 @@ GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 applicatio
 | ~~B0h-b (#155)~~ | I4 `HybridRanker` を `kotoha-ranker-hybrid` 別 crate へ切り出し(engine-core から concrete adapter を分離、LLM features を ranker-hybrid 側に移送) | **完了**(PR #156 squash `3cc36a9`、test 504 / 515) |
 | ~~B0h-d (#157)~~ | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化(B3 event loop の前提整備) | **完了**(PR #158 squash `ba7dc6d`、test 504 / 515) |
 | ~~B0h-e (#159)~~ | I5 stub fallback feature gate(`StubRanker` / `StubHostBridge` を `dev-stubs` feature で gate、release default で stub symbol 0 link) | **完了**(PR #160 squash `7b58cbc`、test 504 / 515) |
-| **B0h-c-i (#161)** | I1 SRP 分割 sub-PR 1/3:`PreeditBuffer` + `CandidateBuffer` 抽出(`current_preedit` + `romaji` / `candidates` + `highlight_idx` を 2 sub-struct に集約) | **進行中**(本 PR、test 504 / 515) |
-| B0h-c-ii | I1 SRP 分割 sub-PR 2/3:`WorkerChannel` 抽出(`tx_request` / `rx_event` / `worker_handle` / `request_id_seed` を 1 sub-struct に集約) | OSS 公開前必修 |
+| ~~B0h-c-i (#161)~~ | I1 SRP 分割 sub-PR 1/3:`PreeditBuffer` + `CandidateBuffer` 抽出(`current_preedit` + `romaji` / `candidates` + `highlight_idx` を 2 sub-struct に集約) | **完了**(PR #162 squash `9c3bd0e`、test 504 / 515) |
+| **B0h-c-ii (#163)** | I1 SRP 分割 sub-PR 2/3:`WorkerChannel` 抽出(`tx_request` / `rx_event` / `worker_handle` を 1 sub-struct に集約、`KotohaEngine::Drop` を `WorkerChannel::Drop` に移管。`request_id_seed` は engine 側に残置) | **進行中**(本 PR、test 504 / 515) |
 | B0h-c-iii | I1 SRP 分割 sub-PR 3/3:`LearningSink` 抽出 + `transitions.rs` 全 free function を sub-struct method 経由に書き換え | OSS 公開前必修 |
 | B0g 後追加検討(B0h 候補) | self-review#1〜#9: `non_exhaustive` trade-off ADR、flaky panic sliding-window metrics ADR、`IMEEngine::enable` Result 化、F4-F9 系 ADR | OSS 公開前 |
 | B0h-f (#149) | I3 async dispatch(`drain_events_blocking` 撤去 + wakeup channel) | OSS 公開前必修 |


### PR DESCRIPTION
## Summary

Sub-PR 2/3 of **B0h-c** (I1 SRP split) tracked in #149. Following B0h-c-i (#161, PR #162) which extracted `PreeditBuffer` + `CandidateBuffer`, this PR groups the worker thread infrastructure into a dedicated RAII sub-struct.

- `WorkerChannel { tx_request, rx_event, handle: Option<JoinHandle> }` (new file `crates/kotoha-engine-core/src/engine/worker_channel.rs`)

Replaces 3 `pub(crate)` fields:

| Before | After |
|---|---|
| `tx_request: mpsc::Sender<RankRequest>` | `worker.tx_request` |
| `rx_event: mpsc::Receiver<EngineEvent>` | `worker.rx_event` |
| `worker_handle: Option<JoinHandle<()>>` | `worker.handle` (private) |

**Drop logic migration**: The previous `KotohaEngine::Drop` impl is moved into `WorkerChannel::Drop`. Field drop order ensures `tx_request` drops first → worker recv loop exits → `handle` is taken and joined via a spawned joiner thread so the parent thread does not block on shutdown. Same observable behavior as before.

**`request_id_seed` stays on KotohaEngine** per the handoff plan — it is engine-side state matched against worker responses, not a worker resource. The handoff document explicitly listed it on the residual `KotohaEngine` struct.

## Out of scope (deferred to B0h-c-iii)

- `LearningSink` extraction (`learning_writer` / `commit_history` / `last_commit_at`)
- `transitions.rs` free-function → method conversion

## Verification

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers -- -D warnings` clean
- [x] `cargo test --workspace` = 504 PASS / 0 FAIL (baseline preserved)
- [x] `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers` = 515 PASS / 0 FAIL
- [x] `KOTOHA_ALLOW_STUB=1 ./target/debug/kotoha` exit 1 (B0f gate intact)
- [x] `nm target/release/kotoha | grep -ci stub` = 0 (B0h-e gate intact)
- [x] PR ≤ 500 lines (actual: 120 ins / 36 del across 2 src files + 1 WBS)

## Test plan

- [ ] CI green (lefthook pre-push already PASS locally)
- [ ] Self-review (silent-failure-hunter) catches any worker-shutdown regression
- [ ] No regression on default 504 / test-helpers 515 baselines

## Reference

- Parent: #149 (B0h tracking)
- Issue: #163 (B0h-c-ii sub-issue)
- Predecessors: #154 (B0h-a), #156 (B0h-b), #158 (B0h-d), #160 (B0h-e), #162 (B0h-c-i)
- Successor: B0h-c-iii (LearningSink + transitions.rs method 化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)