### PR TITLE
P3-B B0h-c-iii: KotohaEngine SRP split — extract LearningSink (#149) (#165)

### DIFF
--- a/crates/kotoha-engine-core/src/engine/learning.rs
+++ b/crates/kotoha-engine-core/src/engine/learning.rs
@@ -1,0 +1,74 @@
+//! `LearningSink` — commit lifecycle に紐付く 3 リソースの SRP-pure value 単位。
+//!
+//! Phase 3-B B0h-c-iii (ISSUE #149 / #165) で `KotohaEngine` から抽出された 3 field
+//! (`learning_writer: Arc<dyn LearningRecorder>` + `commit_history: CommitHistory` +
+//! `last_commit_at: Instant`)を 1 sub-struct に集約する。
+//!
+//! 本 sub-struct の責務は **「commit 確定 path で lock-step 更新される 3 リソース
+//! (学習 sink への記録 / 直近 commit 文字列 buffer / 最終 commit 時刻)を 1 単位として
+//! 保持し、`focus_out` / `reset` 時の clear 制御を一括で行えるようにする」** こと。
+//!
+//! 本 PR (B0h-c-iii) では既存呼び出し側との diff を最小化するため、`recorder` /
+//! `commit_history` / `last_commit_at` は依然 `pub(crate)` で直接 access する。
+//! method 経由(`record_commit(kana, surface)` で 3 操作を 1 呼び出しに consolidate
+//! する等)への抽象化は将来 PR(transitions.rs free-function method 化と併せ B0h-c-iv)
+//! で進める。
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use super::commit_history::CommitHistory;
+use crate::learning_port::LearningRecorder;
+
+/// commit lifecycle の 3 リソースを 1 単位として持つ value 型。
+///
+/// # Invariants
+///
+/// - `commit_history.total_chars() <= 200`(spec §5.3、`CommitHistory::push` 内で
+///   維持)。
+/// - `last_commit_at` は最後に commit が確定した瞬間の `Instant`。`new()` 直後は
+///   `Instant::now()` で初期化される(まだ commit が無くても `time_since_last_commit`
+///   が呼べるよう sentinel)。
+/// - `recorder` は `Arc<dyn LearningRecorder>` で複数の adapter にも shared 可能
+///   (現状は `kotoha-engine-adapter::arc_sqlite_learning_cache` 経由 1 件のみ)。
+pub(crate) struct LearningSink {
+    /// 学習 cache への commit 記録 sink(Phase 3-A spec §3.3 driven port)。
+    /// `record_choice(kana, surface)` を commit 確定時に呼ぶ。
+    pub(crate) recorder: Arc<dyn LearningRecorder>,
+    /// 直近 commit 文字列の rolling buffer。`Ranker::rank` の
+    /// `ConversionContext::commit_history` snapshot として渡される(spec §5.3)。
+    pub(crate) commit_history: CommitHistory,
+    /// 最終 commit 時刻。`Ranker::rank` の `ConversionContext::time_since_last_commit`
+    /// に渡される(spec §5.3、long-idle で context decay の hint に使う)。
+    pub(crate) last_commit_at: Instant,
+}
+
+impl LearningSink {
+    /// `Arc<dyn LearningRecorder>` を DI で受け、空の commit_history と
+    /// 現在時刻 sentinel で初期化された sink を構築する。
+    ///
+    /// # Postconditions
+    ///
+    /// - `commit_history` は空(`commit_history.total_chars() == 0`)
+    /// - `last_commit_at` は `Instant::now()`(sentinel、まだ commit 無し)
+    pub(crate) fn new(recorder: Arc<dyn LearningRecorder>) -> Self {
+        Self {
+            recorder,
+            commit_history: CommitHistory::new(),
+            last_commit_at: Instant::now(),
+        }
+    }
+
+    /// `commit_history` を clear する(`focus_out` / `reset` で呼ばれる)。
+    ///
+    /// `last_commit_at` は意図的に reset しない:context decay は時刻基準で測られ、
+    /// focus 切替で「新規入力 session が始まった」と扱う必要が無いため(現行仕様の
+    /// 維持。spec §5.3 で focus_out が context をどこまで巻き戻すかは今後の Open Q)。
+    ///
+    /// # Postconditions
+    ///
+    /// - `commit_history.total_chars() == 0`
+    pub(crate) fn clear_history(&mut self) {
+        self.commit_history.clear();
+    }
+}

--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -21,6 +21,7 @@ use crate::ranker::{CandidateUpdate, ConversionContext, ConversionMode, Ranker};
 mod candidates;
 mod commit_history;
 mod event;
+mod learning;
 mod preedit;
 #[doc(hidden)]
 pub mod transitions;
@@ -28,6 +29,7 @@ mod worker;
 mod worker_channel;
 
 use candidates::CandidateBuffer;
+use learning::LearningSink;
 use preedit::PreeditBuffer;
 use worker_channel::WorkerChannel;
 
@@ -70,40 +72,45 @@ pub(crate) struct RequestHandle {
 /// - `active_request.is_some()` ⇒ `cancel_token` が一意に存在
 /// - `commit_history.total_chars() <= 200`([`CommitHistory::push`] で維持)
 ///
-/// # Phase 3-B B0h-c-i (ISSUE #149 / #161) / B0h-c-ii (#163) field 整理
+/// # Phase 3-B B0h-c (ISSUE #149) field 整理(sub-PR i / ii / iii で完了)
 ///
-/// 旧 7 field を 3 sub-struct に集約:
+/// 旧 10 raw field を 4 sub-struct に集約:
 /// - `current_preedit: String` + `romaji: RomajiConverter` →
 ///   [`preedit::PreeditBuffer`] (`engine.preedit.current` / `engine.preedit.romaji`)
+///   — B0h-c-i (#161 / PR #162)
 /// - `candidates: Vec<Candidate>` + `highlight_idx: usize` →
 ///   [`candidates::CandidateBuffer`] (`engine.candidates.items` /
-///   `engine.candidates.highlight`)
+///   `engine.candidates.highlight`)— B0h-c-i
 /// - `tx_request` + `rx_event` + `worker_handle` →
 ///   [`worker_channel::WorkerChannel`] (`engine.worker.tx_request` /
 ///   `engine.worker.rx_event`)。本 sub-struct が `Drop` impl を持つため
-///   `KotohaEngine::Drop` は撤去された。
+///   `KotohaEngine::Drop` は撤去された — B0h-c-ii (#163 / PR #164)
+/// - `learning_writer` + `commit_history` + `last_commit_at` →
+///   [`learning::LearningSink`] (`engine.learning.recorder` /
+///   `engine.learning.commit_history` / `engine.learning.last_commit_at`)
+///   — B0h-c-iii (#165、本 PR)
 ///
-/// 残 8 field (`state` / `host` / `ranker` / `learning_writer` /
-/// `commit_history` / `active_request` / `request_id_seed` / `last_commit_at` /
-/// `enabled` / `focused`) は B0h-c-iii (`LearningSink` +
-/// transitions.rs method 化) で順次抽出する。
+/// 残 7 field (`state` / `host` / `ranker` / `active_request` /
+/// `request_id_seed` / `enabled` / `focused`)は state machine 駆動 + 外部 DI +
+/// flag のみで cohesive、追加分割は不要。
 pub struct KotohaEngine {
     pub(crate) state: EngineState,
     pub(crate) host: Box<dyn IMEHostBridge>,
     pub(crate) ranker: Arc<dyn Ranker>,
-    pub(crate) learning_writer: Arc<dyn crate::learning_port::LearningRecorder>,
     pub(crate) preedit: PreeditBuffer,
-    pub(crate) commit_history: CommitHistory,
     pub(crate) candidates: CandidateBuffer,
     pub(crate) active_request: Option<RequestHandle>,
     pub(crate) request_id_seed: u64,
-    pub(crate) last_commit_at: Instant,
     pub(crate) enabled: bool,
     pub(crate) focused: bool,
     /// `RankerWorker` 主 thread と engine 主 thread を結ぶ channel pair および
     /// worker thread join handle。本 sub-struct の `Drop` impl が `tx_request`
     /// drop → worker exit → 別 thread で join の順で safe shutdown を行う。
     pub(crate) worker: WorkerChannel,
+    /// commit lifecycle に紐付く 3 リソース(学習 sink / 直近 commit 文字列 /
+    /// 最終 commit 時刻)。`handle_return` で lock-step 更新され、
+    /// `dispatch_rank_request` で `ConversionContext` に snapshot される。
+    pub(crate) learning: LearningSink,
 }
 
 impl KotohaEngine {
@@ -132,16 +139,14 @@ impl KotohaEngine {
             state: EngineState::Idle,
             host,
             ranker,
-            learning_writer,
             preedit: PreeditBuffer::new(),
-            commit_history: CommitHistory::new(),
             candidates: CandidateBuffer::new(),
             active_request: None,
             request_id_seed: 0,
-            last_commit_at: Instant::now(),
             enabled: false,
             focused: false,
             worker,
+            learning: LearningSink::new(learning_writer),
         })
     }
 
@@ -170,8 +175,8 @@ impl KotohaEngine {
         let request_id = self.next_request_id();
         let cancel_token = Arc::new(StdCancellationToken::new());
         let ctx = ConversionContext {
-            commit_history: self.commit_history.snapshot(),
-            time_since_last_commit: self.last_commit_at.elapsed(),
+            commit_history: self.learning.commit_history.snapshot(),
+            time_since_last_commit: self.learning.last_commit_at.elapsed(),
             mode,
         };
         self.active_request = Some(RequestHandle {
@@ -450,7 +455,7 @@ impl IMEEngine for KotohaEngine {
         // spec §5.2: focus_out は cancel + clear + Idle
         self.cancel_active();
         self.preedit.clear();
-        self.commit_history.clear();
+        self.learning.clear_history();
         self.candidates.clear();
         self.host.hide_candidate_window();
         self.host.update_preedit("", 0, false);
@@ -462,7 +467,7 @@ impl IMEEngine for KotohaEngine {
         // spec §5.2: reset は focus_out と同等処理
         self.cancel_active();
         self.preedit.clear();
-        self.commit_history.clear();
+        self.learning.clear_history();
         self.candidates.clear();
         self.host.hide_candidate_window();
         self.host.update_preedit("", 0, false);

--- a/crates/kotoha-engine-core/src/engine/transitions.rs
+++ b/crates/kotoha-engine-core/src/engine/transitions.rs
@@ -225,13 +225,17 @@ fn handle_return(engine: &mut KotohaEngine) -> KeyEventResult {
 
     engine.host.commit_text(&selected.surface);
     if let Err(e) = engine
-        .learning_writer
+        .learning
+        .recorder
         .record_choice(&kana_at_request, &selected.surface)
     {
         tracing::warn!(error = %e, "learning_cache record_choice failed; commit succeeded");
     }
-    engine.commit_history.push(selected.surface.clone());
-    engine.last_commit_at = std::time::Instant::now();
+    engine
+        .learning
+        .commit_history
+        .push(selected.surface.clone());
+    engine.learning.last_commit_at = std::time::Instant::now();
 
     engine.host.hide_candidate_window();
     engine.host.update_preedit("", 0, false);

--- a/docs/wbs/2026-05-02-phase3a-implementation.md
+++ b/docs/wbs/2026-05-02-phase3a-implementation.md
@@ -105,6 +105,7 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 | B0h-d | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化 | #158 | `feature/157-b0h-d-...` |
 | B0h-e | I5 stub fallback `dev-stubs` feature gate | #160 | `feature/159-b0h-e-...` |
 | B0h-c-i | I1 SRP 分割 sub-PR 1/3:`PreeditBuffer` + `CandidateBuffer` 抽出 | #162 | `feature/161-b0h-c-i-...` |
+| B0h-c-ii | I1 SRP 分割 sub-PR 2/3:`WorkerChannel` 抽出 + Drop 移管 | #164 | `feature/163-b0h-c-ii-...` |
 
 ## Test count(実測)
 
@@ -122,7 +123,8 @@ ISSUE #140(P3-B B0)で第 1 回レビューの Critical 4 + Important 9 を消�
 | P3-B B0h-d 完了時(2026-05-03、PR #158) | 504 | 515(test 改変ゼロ) |
 | P3-B B0h-e 完了時(2026-05-04、PR #160) | 504 | 515(test 改変ゼロ) |
 | P3-B B0h-c-i 完了時(2026-05-04、PR #162) | 504 | 515(test 改変ゼロ、SRP 内部 refactor のみ) |
-| **P3-B B0h-c-ii 完了時(2026-05-04、本 PR)** | **504** | **515**(test 改変ゼロ、`WorkerChannel` 抽出 + Drop 移管のみ) |
+| P3-B B0h-c-ii 完了時(2026-05-04、PR #164) | 504 | 515(test 改変ゼロ、`WorkerChannel` 抽出 + Drop 移管のみ) |
+| **P3-B B0h-c-iii 完了時(2026-05-04、本 PR)** | **504** | **515**(test 改変ゼロ、`LearningSink` 抽出のみ、SRP 4 sub-struct 完成) |
 
 註:`cargo test --workspace` (default features) と `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers` で結果が異なる。lefthook pre-push は default features を回す。第 1 回包括 review (B0a-B0e) では test-helpers feature 経由の合計値 (416 → 473) を baseline として参照する。過去の commit message で `446` / `448` / `454` と記載した数値はいずれも不正確で、上表が正規値。
 
@@ -162,8 +164,8 @@ GNOME Wayland session 上で `cargo run --bin kotoha` 起動 + 以下 applicatio
 | ~~B0h-d (#157)~~ | I2 `IBusEventDispatcher` を `Arc<Mutex<dyn IMEEngine>>` 化(B3 event loop の前提整備) | **完了**(PR #158 squash `ba7dc6d`、test 504 / 515) |
 | ~~B0h-e (#159)~~ | I5 stub fallback feature gate(`StubRanker` / `StubHostBridge` を `dev-stubs` feature で gate、release default で stub symbol 0 link) | **完了**(PR #160 squash `7b58cbc`、test 504 / 515) |
 | ~~B0h-c-i (#161)~~ | I1 SRP 分割 sub-PR 1/3:`PreeditBuffer` + `CandidateBuffer` 抽出(`current_preedit` + `romaji` / `candidates` + `highlight_idx` を 2 sub-struct に集約) | **完了**(PR #162 squash `9c3bd0e`、test 504 / 515) |
-| **B0h-c-ii (#163)** | I1 SRP 分割 sub-PR 2/3:`WorkerChannel` 抽出(`tx_request` / `rx_event` / `worker_handle` を 1 sub-struct に集約、`KotohaEngine::Drop` を `WorkerChannel::Drop` に移管。`request_id_seed` は engine 側に残置) | **進行中**(本 PR、test 504 / 515) |
-| B0h-c-iii | I1 SRP 分割 sub-PR 3/3:`LearningSink` 抽出 + `transitions.rs` 全 free function を sub-struct method 経由に書き換え | OSS 公開前必修 |
+| ~~B0h-c-ii (#163)~~ | I1 SRP 分割 sub-PR 2/3:`WorkerChannel` 抽出(`tx_request` / `rx_event` / `worker_handle` を 1 sub-struct に集約、`KotohaEngine::Drop` を `WorkerChannel::Drop` に移管。`request_id_seed` は engine 側に残置) | **完了**(PR #164 squash `7dd4b70`、test 504 / 515) |
+| **B0h-c-iii (#165)** | I1 SRP 分割 sub-PR 3/3:`LearningSink` 抽出(`learning_writer` + `commit_history` + `last_commit_at` を 1 sub-struct に集約)。transitions.rs の free-function method 化は API ergonomics 課題で SRP とは独立、本 PR 範囲外(B0h-c-iv で別途扱うか判断) | **進行中**(本 PR、test 504 / 515) |
 | B0g 後追加検討(B0h 候補) | self-review#1〜#9: `non_exhaustive` trade-off ADR、flaky panic sliding-window metrics ADR、`IMEEngine::enable` Result 化、F4-F9 系 ADR | OSS 公開前 |
 | B0h-f (#149) | I3 async dispatch(`drain_events_blocking` 撤去 + wakeup channel) | OSS 公開前必修 |
 | B2 | IBus signal body marshalling | B0f 後着手 |


### PR DESCRIPTION
## Summary

Final sub-PR (3/3) of **B0h-c** (I1 SRP split) tracked in #149. Following B0h-c-i (#161 / PR #162: PreeditBuffer + CandidateBuffer) and B0h-c-ii (#163 / PR #164: WorkerChannel), this PR extracts the commit-lifecycle resources into a dedicated sub-struct.

- `LearningSink { recorder: Arc<dyn LearningRecorder>, commit_history: CommitHistory, last_commit_at: Instant }` (new file `crates/kotoha-engine-core/src/engine/learning.rs`)

Replaces 3 `pub(crate)` fields:

| Before | After |
|---|---|
| `learning_writer: Arc<dyn LearningRecorder>` | `learning.recorder` |
| `commit_history: CommitHistory` | `learning.commit_history` |
| `last_commit_at: Instant` | `learning.last_commit_at` |

These three fields form a coherent grouping touched in lock-step by `handle_return` (`record_choice` + `commit_history.push` + `last_commit_at = now()`) and consumed by `dispatch_rank_request` (snapshot + elapsed for `ConversionContext`).

## SRP decomposition complete after this PR

`KotohaEngine` field layout after B0h-c-i / -ii / -iii:

- **4 sub-struct fields**: `preedit` (PreeditBuffer) / `candidates` (CandidateBuffer) / `worker` (WorkerChannel) / `learning` (LearningSink)
- **7 residual fields**: `state` / `host` / `ranker` / `active_request` / `request_id_seed` / `enabled` / `focused` (state machine + DI + flags only)

10 raw responsibilities → 4 cohesive sub-structs + 7 minimal coordination fields. Field count reduced from 15 to 11.

## Out of scope

- `transitions.rs` free-function → method conversion is API ergonomics, not SRP, and may be deferred or skipped (separate B0h-c-iv if pursued)
- I3 async dispatch (B0h-f)
- Method consolidation like `LearningSink::record_commit(kana, surface)` (defer to keep diff mechanical)

## Verification

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers -- -D warnings` clean
- [x] `cargo test --workspace` = 504 PASS / 0 FAIL (baseline preserved)
- [x] `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers` = 515 PASS / 0 FAIL
- [x] `KOTOHA_ALLOW_STUB=1 ./target/debug/kotoha` exit 1 (B0f gate intact)
- [x] `nm target/release/kotoha | grep -ci stub` = 0 (B0h-e gate intact)
- [x] PR ≤ 500 lines (actual: 109 ins / 24 del across 3 src files + 1 WBS)

## Test plan

- [ ] CI green (lefthook pre-push already PASS locally)
- [ ] Self-review (silent-failure-hunter) catches any commit-path regression
- [ ] No regression on default 504 / test-helpers 515 baselines

## Reference

- Parent: #149 (B0h tracking)
- Issue: #165 (B0h-c-iii sub-issue)
- Predecessors: #154 / #156 / #158 / #160 / #162 / #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)