### PR TITLE
feat(input): cap Direct-mode buffer at 16 KiB (#39)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "kotoha-storage",
  "serial_test",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/kotoha-cli/Cargo.toml
+++ b/crates/kotoha-cli/Cargo.toml
@@ -12,6 +12,7 @@ description = "Kotoha: command-line frontend for manual verification of the Koto
 kotoha-core = { path = "../kotoha-core" }
 clap = { workspace = true }
 kotoha-storage = { path = "../kotoha-storage", optional = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kotoha-cli/Cargo.toml
+++ b/crates/kotoha-cli/Cargo.toml
@@ -13,6 +13,7 @@ kotoha-core = { path = "../kotoha-core" }
 clap = { workspace = true }
 kotoha-storage = { path = "../kotoha-storage", optional = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kotoha-cli/src/bin/romaji.rs
+++ b/crates/kotoha-cli/src/bin/romaji.rs
@@ -13,6 +13,11 @@ use std::process::ExitCode;
 use clap::{Parser, ValueEnum};
 use kotoha_cli::{format_line_output, process_line};
 use kotoha_core::{InputContext, InputMode};
+use tracing_subscriber::EnvFilter;
+
+/// Env var controlling the `tracing` filter directive. Mirrors `kotoha-bin`'s
+/// `KOTOHA_LOG` for consistency across the workspace's binaries.
+const KOTOHA_LOG_ENV: &str = "KOTOHA_LOG";
 
 /// CLI mode selector.
 ///
@@ -55,6 +60,7 @@ struct Cli {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    init_tracing();
 
     let mut ctx = InputContext::new();
     // `--mode direct` sets Sticky Direct before entering the stdin loop
@@ -89,4 +95,31 @@ fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+/// `tracing_subscriber` を stderr 向けに初期化する。`KOTOHA_LOG` 未設定時は
+/// `warn` default(CLI 通常運用で flooding しない)、設定済 + parse 失敗時は
+/// `eprintln!` で warning を出して `warn` に fallback する。
+///
+/// ISSUE #39 / PR #168 self-review High:本 binary は以前 subscriber 未初期化で
+/// `tracing::warn!` が `NoSubscriber` で drop されていた(BufferFull arm の
+/// observability 主張が CLI 経由で成立しなかった)。kotoha-bin の `init_tracing`
+/// と同 pattern で配線する。
+fn init_tracing() {
+    let filter = match std::env::var(KOTOHA_LOG_ENV) {
+        Ok(directive) => match EnvFilter::try_new(&directive) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!(
+                    "warning: invalid {KOTOHA_LOG_ENV}={directive:?} ({e}); falling back to warn"
+                );
+                EnvFilter::new("warn")
+            }
+        },
+        Err(_) => EnvFilter::new("warn"),
+    };
+    tracing_subscriber::fmt()
+        .with_writer(io::stderr)
+        .with_env_filter(filter)
+        .init();
 }

--- a/crates/kotoha-cli/src/lib.rs
+++ b/crates/kotoha-cli/src/lib.rs
@@ -56,6 +56,18 @@ pub fn process_line(ctx: &mut InputContext, line: &str) -> String {
             InputStep::Preedit | InputStep::Invalid(_) => {
                 // Intentionally silent per plan M6 既知懸念 1.
             }
+            InputStep::BufferFull(rejected) => {
+                // ISSUE #39: Direct buffer cap reached. Emit a tracing::warn
+                // (observable per spec §9.3) and drop the rejected char. Line-
+                // based CLI flow naturally bounds direct_buffer per line, so
+                // this branch is only reachable for pathological adversarial
+                // input piped through stdin (e.g., a single 16+ KiB Direct
+                // line with no commit boundary).
+                tracing::warn!(
+                    rejected_char = %rejected.escape_debug(),
+                    "InputContext direct_buffer full; dropping char (ISSUE #39 cap reached)"
+                );
+            }
             // `InputStep` is `#[non_exhaustive]`; future variants default to silent drop.
             _ => {}
         }

--- a/crates/kotoha-core/src/input/context.rs
+++ b/crates/kotoha-core/src/input/context.rs
@@ -12,6 +12,22 @@
 use crate::input::mode::{InputMode, ModeOrigin};
 use crate::romaji::{ConvertStep, RomajiConverter};
 
+/// Direct-mode buffer の memory cap(byte 単位)。本値を超える `input_char`
+/// 呼び出しは `InputStep::BufferFull` を返して reject される(spec §8 補足、
+/// ISSUE #39)。
+///
+/// # 値の根拠
+///
+/// 16 KiB は ASCII で約 16384 chars、4-byte UTF-8 で約 4096 chars に相当する。
+/// ISSUE #39 の suggestion「4096 chars」を memory-bounded 形に翻訳した値で、
+/// `String::len()` 経由 O(1) check が可能(`chars().count()` は O(n))。
+///
+/// # 解放契機
+///
+/// `commit()` / `cancel()` / `reset()` / 任意 transient → sticky 切替時に
+/// `direct_buffer` が clear され、本 cap も再リセットされる。
+pub const MAX_DIRECT_BUFFER_BYTES: usize = 16 * 1024;
+
 /// Per-char outcome of [`InputContext::input_char`].
 ///
 /// Marked `#[non_exhaustive]` so additional variants may be introduced in
@@ -27,6 +43,12 @@ pub enum InputStep {
     Committed(String),
     /// The char is outside the supported alphabet here and was discarded.
     Invalid(char),
+    /// The Direct-mode buffer has reached [`MAX_DIRECT_BUFFER_BYTES`] and the
+    /// supplied char was rejected (not pushed). The caller may call
+    /// [`InputContext::commit`] to drain the buffer and then retry the char.
+    /// Introduced for ISSUE #39 (defense in depth against unbounded buffer
+    /// growth from sustained `input_char` calls in Direct mode).
+    BufferFull(char),
 }
 
 /// Input mode state machine.
@@ -147,6 +169,9 @@ impl InputContext {
                 }
             }
             InputMode::Direct => {
+                if self.direct_buffer.len() + ch.len_utf8() > MAX_DIRECT_BUFFER_BYTES {
+                    return InputStep::BufferFull(ch);
+                }
                 self.direct_buffer.push(ch);
                 InputStep::Preedit
             }
@@ -488,5 +513,60 @@ mod tests {
         let b = InputContext::new();
         assert_eq!(a.mode(), b.mode());
         assert_eq!(a.preedit(), b.preedit());
+    }
+
+    // --- direct buffer cap (ISSUE #39) ---
+
+    #[test]
+    fn direct_buffer_accepts_chars_up_to_cap() {
+        let mut c = InputContext::new();
+        c.set_mode(InputMode::Direct);
+        // Push exactly MAX_DIRECT_BUFFER_BYTES ASCII chars (1 byte each).
+        for _ in 0..MAX_DIRECT_BUFFER_BYTES {
+            assert_eq!(c.input_char('x'), InputStep::Preedit);
+        }
+        assert_eq!(c.preedit().len(), MAX_DIRECT_BUFFER_BYTES);
+    }
+
+    #[test]
+    fn direct_buffer_rejects_char_at_cap_with_buffer_full() {
+        let mut c = InputContext::new();
+        c.set_mode(InputMode::Direct);
+        for _ in 0..MAX_DIRECT_BUFFER_BYTES {
+            let _ = c.input_char('a');
+        }
+        // Buffer is now full; the next char must be rejected verbatim.
+        assert_eq!(c.input_char('z'), InputStep::BufferFull('z'));
+        // Buffer length unchanged after the rejection.
+        assert_eq!(c.preedit().len(), MAX_DIRECT_BUFFER_BYTES);
+    }
+
+    #[test]
+    fn direct_buffer_rejects_multibyte_char_when_remaining_space_too_small() {
+        let mut c = InputContext::new();
+        c.set_mode(InputMode::Direct);
+        // Fill to MAX-1 bytes so a 2+ byte char would overflow.
+        for _ in 0..(MAX_DIRECT_BUFFER_BYTES - 1) {
+            let _ = c.input_char('a');
+        }
+        // 'あ' is 3-byte UTF-8 — does not fit in the remaining 1 byte slot.
+        assert_eq!(c.input_char('あ'), InputStep::BufferFull('あ'));
+        assert_eq!(c.preedit().len(), MAX_DIRECT_BUFFER_BYTES - 1);
+    }
+
+    #[test]
+    fn direct_buffer_recovers_after_commit_clears_buffer() {
+        let mut c = InputContext::new();
+        c.set_mode(InputMode::Direct);
+        for _ in 0..MAX_DIRECT_BUFFER_BYTES {
+            let _ = c.input_char('a');
+        }
+        assert_eq!(c.input_char('z'), InputStep::BufferFull('z'));
+        // Drain the buffer via commit.
+        let drained = c.commit();
+        assert_eq!(drained.len(), MAX_DIRECT_BUFFER_BYTES);
+        // After commit the cap is reset; the previously rejected char now fits.
+        assert_eq!(c.input_char('z'), InputStep::Preedit);
+        assert_eq!(c.preedit(), "z");
     }
 }


### PR DESCRIPTION
## Summary

Resolves the M4b owasp-security follow-up #39 by introducing a defensive memory cap on `InputContext::direct_buffer`. Sustained `input_char()` calls in Direct mode previously had no upper bound. The original threat model targeted the (eventual) Phase 3 IBus engine, but the IBus engine ended up using its own state machine in `kotoha-engine-core` and does NOT consume `InputContext`. The remaining real consumer is the line-based CLI (per ADR 0004), so this PR ships defense-in-depth for adversarial piped stdin in Direct mode.

## Design choice (#39 deferred decision)

Two options were on the table:

1. **Auto-commit-and-restart** — silently split user input on cap
2. **Surface `InputStep::BufferFull(char)` variant** — caller decides

**Chose option 2**. Auto-split is opaque ("why did my input get cut?") and violates the spirit of spec §9.3 (silent failure prohibition). The new variant carries the rejected char so callers can commit-and-retry, warn-and-drop, or whatever the caller deems appropriate.

## Implementation

- `MAX_DIRECT_BUFFER_BYTES: usize = 16 * 1024` (16 KiB) — byte-based cap for **O(1) check** via `String::len()`. Equivalent to ~16384 ASCII chars or ~4096 4-byte UTF-8 chars; matches the issue's "4096 chars" suggestion translated to memory-bounded form.
- New `InputStep::BufferFull(char)` variant on the existing `#[non_exhaustive]` enum (no breaking API change).
- `input_char` Direct path: checks `direct_buffer.len() + ch.len_utf8() > MAX_DIRECT_BUFFER_BYTES` before pushing.
- CLI `process_line`: explicit `BufferFull` arm emits `tracing::warn!` (observable per spec §9.3) and drops the rejected char. Required adding `tracing` to `kotoha-cli/Cargo.toml`.

## Tests (4 new)

In `crates/kotoha-core/src/input/context.rs`:
- `direct_buffer_accepts_chars_up_to_cap` — boundary at exact cap
- `direct_buffer_rejects_char_at_cap_with_buffer_full` — first overflow char
- `direct_buffer_rejects_multibyte_char_when_remaining_space_too_small` — multi-byte UTF-8 char that doesn't fit
- `direct_buffer_recovers_after_commit_clears_buffer` — post-commit retry

## Verification

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` = **508 PASS** / 0 FAIL (504 → 508, +4)
- [x] `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers` = **519 PASS** / 0 FAIL (515 → 519, +4)
- [x] `bash scripts/phase0-smoke.sh` = 10/10 PASS, 0/10 FAIL (regression check)
- [x] PR ≤ 500 lines (actual: 94 ins / 0 del across 4 files)

## Reference

- Closes #39
- Origin: P0 PR #38 owasp-security review
- Related ADRs: #0004 (CLI line-based commit) — explains why CLI is bounded per line under normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)