### PR TITLE
refactor(storage): demote LearningCache test-only statics to pub(crate) (#107 S-3)

### DIFF
--- a/crates/kotoha-storage/Cargo.toml
+++ b/crates/kotoha-storage/Cargo.toml
@@ -26,14 +26,17 @@ default = ["bundled-sqlite"]
 # `bundled-sqlite` vendors the SQLite C library inside the rusqlite crate.
 # Default ON to avoid distro SQLite version drift (P2-B spec §4.3).
 bundled-sqlite = ["rusqlite/bundled"]
-# `test-helpers` exposes integration-test-only items
-# (`CapOverrideGuard`, `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE`,
-# `CAP_OVERRIDE_LOCK`, `effective_max_rows`) so that test crates under
-# `crates/kotoha-storage/tests/` can drive learning_cache eviction with a
-# small cap. The flag must NOT be enabled in release/production builds:
-# spec §4.5 / §4.6 require these helpers to be compiled out of the
-# production binary. lefthook's pre-push test steps enable the flag
-# explicitly via `--features kotoha-storage/test-helpers`.
+# `test-helpers` exposes integration-test-only items so that test crates
+# under `crates/kotoha-storage/tests/` can drive learning_cache eviction
+# with a small cap. The single externally-visible item is
+# `learning_cache::CapOverrideGuard` (RAII helper); the underlying statics
+# (`LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE` / `CAP_OVERRIDE_LOCK`) and the
+# `effective_max_rows()` cap function are crate-private to prevent direct
+# `.store(...)` bypass of the RAII contract (#107 / S-3 follow-up).
+# The flag must NOT be enabled in release/production builds: spec §4.5 /
+# §4.6 require these helpers to be compiled out of the production binary.
+# lefthook's pre-push test steps enable the flag explicitly via
+# `--features kotoha-storage/test-helpers`.
 test-helpers = []
 
 [[test]]

--- a/crates/kotoha-storage/src/learning_cache/sqlite.rs
+++ b/crates/kotoha-storage/src/learning_cache/sqlite.rs
@@ -17,25 +17,35 @@ pub const LEARNING_CACHE_MAX_ROWS: usize = 10_000;
 /// 本 static は **test-only** であり、`#[cfg(any(test, feature = "test-helpers"))]`
 /// で gate されているため production / release binary には含まれない
 /// (spec §4.5 / §4.6)。
-/// integration test crate(`crates/kotoha-storage/tests/*.rs`)から利用するため、
-/// crate feature `test-helpers` を有効化したときのみ `pub` として可視化する。
-/// 本 feature は `--features kotoha-storage/test-helpers` を渡したテスト時のみ
-/// 有効化する想定で、production binary では常に compile-out される。
+///
+/// # Visibility
+///
+/// `pub(crate)`(B0g 後の ISSUE #107 / S-3 follow-up):本 static を直接
+/// `.store(...)` で書き換える経路は [`CapOverrideGuard`] の RAII 契約を bypass
+/// するため、外部 crate(integration test 含む)からは [`CapOverrideGuard::new`] /
+/// [`CapOverrideGuard::lock_only`] のみを使う規約とする。本 static の直接
+/// access は同 crate 内 (`learning_cache::sqlite` module 内 unit test や
+/// `CapOverrideGuard::Drop`)に限定する。
 ///
 /// 10,000 行を実際に挿入するテストは時間 / メモリの観点で非現実的なため、
 /// 単体テスト / integration テストはこの override を介して小さな上限値で
 /// eviction 動作を検証する。
 #[cfg(any(test, feature = "test-helpers"))]
-pub static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
+pub(crate) static LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
 
 /// override の直列化用 Mutex(複数 test が同時 override しないよう直列化)。
 ///
 /// 本 static は **test-only** であり、`#[cfg(any(test, feature = "test-helpers"))]`
 /// で gate されているため production / release binary には含まれない。
-/// integration test crate から利用するため、crate feature `test-helpers` を
-/// 有効化したときのみ `pub` として可視化する。
+///
+/// # Visibility
+///
+/// `pub(crate)`(ISSUE #107 / S-3 follow-up):本 lock を直接取得する経路は
+/// [`CapOverrideGuard`] の RAII 契約を bypass するため、外部 crate からは
+/// [`CapOverrideGuard::new`] / [`CapOverrideGuard::lock_only`] のみを使う規約
+/// とする。
 #[cfg(any(test, feature = "test-helpers"))]
-pub static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// 行数上限の effective value を返す。
 ///
@@ -45,8 +55,11 @@ pub static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// test build (`cargo test` の unit test、または `--features test-helpers` を
 /// 有効化した integration test) では override 値を反映する。
 ///
-/// `pub` 公開は test build に限定する(spec §4.5 / §4.6)。production からは
-/// `pub(crate)` でのみ参照可能で、外部 crate に test-only API は露出しない。
+/// # Visibility
+///
+/// `pub(crate)`(ISSUE #107 / S-3 follow-up):本関数は内部 cap 計算 helper で
+/// 外部 crate からの直接呼び出し経路は無い(record_choice 内部で参照される
+/// のみ)。両 cfg variant とも `pub(crate)` で統一して expose 範囲を縮小する。
 ///
 /// # Postconditions
 ///
@@ -55,7 +68,7 @@ pub static CAP_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 ///   それ以外の場合は override 値を返す
 #[cfg(any(test, feature = "test-helpers"))]
 #[inline]
-pub fn effective_max_rows() -> usize {
+pub(crate) fn effective_max_rows() -> usize {
     let v = LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.load(Ordering::SeqCst);
     if v != 0 {
         return v;
@@ -67,7 +80,6 @@ pub fn effective_max_rows() -> usize {
 ///
 /// override 機構は `#[cfg(any(test, feature = "test-helpers"))]` で
 /// compile-out されるため、production では常に [`LEARNING_CACHE_MAX_ROWS`] を返す。
-/// crate-internal 利用に限定するため `pub(crate)` で公開する。
 #[cfg(not(any(test, feature = "test-helpers")))]
 #[inline]
 pub(crate) fn effective_max_rows() -> usize {


### PR DESCRIPTION
## Summary

Resolves the Low **S-3** finding from the PR #106 (Phase 2-C) review batch tracked in #107. The raw statics that underpin `CapOverrideGuard`'s RAII contract were previously `pub`, allowing external code to call `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE.store(N)` directly and bypass the lock acquisition + Drop-time cleanup the guard provides.

Demote 3 items from `pub` to `pub(crate)` (gated under `#[cfg(any(test, feature = "test-helpers"))]`):

- `LEARNING_CACHE_MAX_ROWS_TEST_OVERRIDE: AtomicUsize`
- `CAP_OVERRIDE_LOCK: Mutex<()>`
- `effective_max_rows()` (test-helpers variant; production variant was already `pub(crate)`)

The single externally-visible API surface for cap override is now `learning_cache::CapOverrideGuard` (RAII: `new(cap)` / `lock_only()`).

## Verification

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers -- -D warnings` clean
- [x] `cargo test --workspace` = **508 PASS** / 0 FAIL (unchanged from prior PR #168)
- [x] `cargo test --workspace --features kotoha-storage/test-helpers,kotoha-ranker-hybrid/test-helpers` = **519 PASS** / 0 FAIL
- [x] No behavior change — same-crate access paths (`sqlite.rs` unit tests, `CapOverrideGuard::new`/`Drop`, `database.rs`) all work unchanged
- [x] External integration test (`tests/learning_cache_store.rs`) already uses `CapOverrideGuard` API; unaffected

## Test plan

- [ ] CI green (lefthook pre-push already PASS locally)

## Reference

- Refs #107 (S-3 closed; Medium A-1/A-2/A-3/A-4, Low T-1..T-9, P-2..P-5 remain open)
- Origin: PR #106 (P2-C) 4-dim team-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)