### PR TITLE
docs(roadmap): reflect Phase 2 completion + Phase 3 sub-milestone breakdown (#172)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,8 +10,8 @@ ADR 0010 (`docs/adr/0010-kotoha-custom-romaji-base-model.md`) の決定により
 |---|---|---|---|
 | 0 | Foundation | Cargo workspace + ローマ字→かな変換 + 入力モード管理 + CLI | 完了 |
 | 1 | Kana→Kanji conversion | llama.cpp + Gemma-2-2B-jpn-it baseline によるかな→漢字変換 (P1-2.5 follow-up で Layer 3 smoke 14/15 達成) | 完了 (14/15 PASS, P1-4 で close 2026-04-25) |
-| 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ | **進行中 (foundation docs 完了)** |
-| 3 | IBus integration | IBus engine(GNOME Mutter 用) | 未着手 |
+| 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ + Hybrid Ranker | 完了 (P2-A〜P2-D 全 PR merge、最終 commit `be0fae9` 2026-05-02、test 416 PASS。follow-up backlog #92/#94/#100/#107 は OSS 公開前 triage) |
+| 3 | IBus integration | IBus engine(GNOME Mutter 用) | **進行中** (P3-A draft + P3-B B0/B0g/B0h 大部分/B1/B2/B4/B5 完了。残 B0h-f I3 async dispatch + B3 signal listener loop + B6 L3 manual smoke) |
 | 4 | fcitx5 integration | fcitx5 addon(KDE / wlroots 用) | 未着手 |
 | 5 | **Kotoha custom romaji-base model** | raw romaji keystrokes を直接受理する Kotoha 専用 90〜180M parameter モデルの自作 (data pipeline + training + GGUF 推論統合 + evaluation)。row 3 類の ICL 限界 + typo robustness + partial-input 対応を同時解決する | 未着手 |
 | 6 | Advanced features | タイポ訂正 + 文脈リランキング (Phase 5 の romaji-base モデルを技術基盤とする) | 未着手 |
@@ -39,31 +39,76 @@ P1-4 (PR #84, merge `95e7df9`) での Phase 1 close 後、Phase 2 foundation doc
 
 Phase 2「Dictionary and learning」は 4 milestone に分割する。詳細は `docs/superpowers/specs/2026-04-25-kotoha-phase-2-design.md` および ADR 0014 を参照。各 milestone の exact スコープは P2-A kick-off で確定する。
 
-### P2-A: Dictionary layer (工数目安 1〜2 週)
+### P2-A: Dictionary layer (完了、PR #97 / #99)
 
 - SudachiDict-core を runtime load する DictionaryBackend 実装
 - Kotoha 独自語彙 (敬称、IME 固有) の merge
 - Dictionary lookup の unit test / golden fixture (敬称 / 固有名詞 30+ cases)
 - BackendConfig 新 variant 追加 (ADR 0011 の non_exhaustive 拡張方針)
+- follow-up backlog: #92 (Layer 3 golden 530 cases) / #94 (P2-A 25+ findings triage) / #100 (10 hardening deferral)
 
-### P2-B: User dictionary (工数目安 3〜5 日、実装範囲確定後の再見積は約 6.5 day)
+### P2-B: User dictionary (完了、PR #98 / #102 / #104)
 
 - User dict entry 追加 / 削除 / 列挙 / 詳細取得の API
 - SQLite 永続化 (`kotoha-storage` 新 crate、共用 DB `kotoha.db`、ADR 0015 / P2-B spec `docs/superpowers/specs/2026-04-25-p2-b-user-dictionary-design.md` 参照)
 - CLI サブコマンド `kotoha-dict {add, remove, list, show}` の実装 (`update` / `import` / `export` / `init` は Phase 6+ で扱う、P2-B spec §3.8 参照)
-- 工数目安 (3〜5 日) は維持しつつ、SQLite layer 厚み + validation 同時投入 + spec 同期更新により実装範囲確定後の再見積は約 6.5 day となる。3 PR (P2-A hardening pre-PR + P2-B docs PR + P2-B code PR) に分割して 1 PR あたりの規模を Branch Scope Policy 範囲内に収める (P2-B spec §11 参照)
 
-### P2-C: Learning cache (工数目安 3〜5 日)
+### P2-C: Learning cache (完了、PR #106 + hardening #109/#111/#113/#115)
 
-- in-memory LRU + 起動時 load + shutdown save
+- in-memory + SQLite 永続(P2-B 同 DB に置き、同 Mutex<Connection> を共有)
 - data model: (kana_input, chosen_kanji, frequency, last_used_at)
-- eviction policy
+- 4 trait ISP split (`LearningCacheReader` / `LearningCacheWriter` / `UserVocabReader` / `UserVocabWriter`)
+- v002 migration + test-helpers feature gate
+- prerequisite hardening: bounded `usize as i64` (#109) / `Mutex` poison recovery (#111) / `MockLearningCacheStore` decoupling (#113) / `prepare_cached` perf (#115)
+- follow-up backlog: #107 (Medium / Low review residuals)
 
-### P2-D: Integration + rerank (工数目安 1〜2 週)
+### P2-D: Integration + rerank (完了、PR #117〜#127)
 
-- hybrid backend (dict + LLM) の factory 実装
+- hybrid backend (dict + LLM) の factory 実装(`kotoha-engine-core` crate に新 `HybridRanker` 配置、後に B0h-b で `kotoha-ranker-hybrid` crate に分離)
 - 候補 merge / dedupe / rerank (初期重み dict=0.95 / LLM=1.0)
 - regression test: Phase 1 14/15 が保たれること
+- final test count baseline: 416 PASS / 0 FAIL
+
+## Phase 3 マイルストーン分割
+
+Phase 3「IBus integration」は P3-A(設計 + skeleton)と P3-B(production wiring + L3 manual smoke)の 2 段階に分割する。詳細は `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md` および `docs/wbs/2026-05-02-phase3a-implementation.md` を参照。Phase 1 / Phase 2 と異なり、P3-A は「draft 完成」段階で 2 度の包括レビューにより機能完成宣言を取り下げ、P3-B B0g(silent-failure / security / testing residuals)+ B0h(architectural rework)で resolved した経緯を持つ。
+
+### P3-A: Design + skeleton (完了 draft、ISSUE #128 / PR #129〜#135)
+
+- `IMEEngine` / `IMEHostBridge` / `Ranker` の port trait 定義(spec §4)
+- `KotohaEngine` state machine(Idle / LiveConverting / CommitConverting / CandidatesShown、spec §5.2 表)
+- `RankerWorker` background thread + dual coalescing windows(typing 5ms / commit 30ms)
+- `IBusEventDispatcher` + `IBusHostBridge` skeleton(zbus 5 binding、proxy.rs は B0f まで silent stub、後に fail-loud 化、B2 で実 emit)
+- `kotoha-bin` 起動エントリ
+- ISSUE #128 は ADR 0016〜0018 候補の deferral と共に close(B0/B0f で機能完成宣言を取り下げ、B0g/B0h で resolved)
+
+### P3-B: Production wiring + L3 manual smoke (進行中、ISSUE #136 tracking)
+
+| Sub-milestone | 内容 | 状態 |
+|---|---|---|
+| B0 (#140) | 第 1 回包括レビュー Critical 4 + Important 9 消化 | 完了(PR #141〜#145、test 416 → 473) |
+| B0f (#146) | 機能完成宣言取り下げ + proxy / event loop fail-loud 化 | 完了(PR #147 squash `9602dff`) |
+| B0g-a/b/c (#148) | silent-failure / security / testing residuals 消化(panic_message / lookup_table / catch_unwind / sanitize / theater fix 等) | 完了(PR #150〜#152) |
+| B0h-a (#153) | C3 hexagonal driven port inversion(`learning_port` を engine-core に新設、`kotoha-engine-adapter` crate 切出し) | 完了(PR #154 squash `5c37d65`) |
+| B0h-b (#155) | I4 `HybridRanker` を `kotoha-ranker-hybrid` 別 crate へ切出し | 完了(PR #156 squash `3cc36a9`) |
+| B0h-c-i/ii/iii (#161/#163/#165) | I1 SRP 分割:`PreeditBuffer` / `CandidateBuffer` / `WorkerChannel` / `LearningSink` 抽出 | 完了(PR #162/#164/#166) |
+| B0h-d (#157) | I2 dispatcher `Arc<Mutex<dyn IMEEngine>>` 化(B3 multi-thread D-Bus listener の前提整備) | 完了(PR #158 squash `ba7dc6d`) |
+| B0h-e (#159) | I5 stub fallback feature gate(release default で stub symbol 0 link、`KOTOHA_ALLOW_STUB=1` exit 1) | 完了(PR #160 squash `7b58cbc`) |
+| B1 (#137) | kotoha-core 側 `Arc<dyn MorphologicalEngine + Send + Sync>` 返す production API + kotoha-bin の `StubRanker` を実 `HybridRanker` に置換 | 完了(PR #137) |
+| B4 (#138) | `KeyModifiers` の IBus full mapping(`IBusModifierType` 全列挙)+ RELEASE event handling | 完了(PR #138) |
+| B5 (#139) | KotohaEngine + 実 `HybridRanker` end-to-end integration test | 完了(PR #139) |
+| **B2 (#170)** | IBus signal body marshalling(`proxy.rs` 5 method を実 D-Bus signal emit に置換、`IBusText` / `IBusLookupTable` wire-format 確定:`(sa{sv}sv)` / `(sa{sv}uubbiavav)`) | **完了**(PR #171 squash `4731c50`、test 536 / 547) |
+| **B0h-f (#149 残)** | I3 `dispatch_rank_request` async-ification(`drain_events_blocking` 撤去 + wakeup channel) | **未着手**(spec §6.1 / §7 ADR 必須、B3 と密接で一体化推奨) |
+| **B3 (#136 残)** | `IBusEventDispatcher` の `zbus::blocking::MessageStream` 経由 signal listener loop(`kotoha-bin::run_ibus()` の `anyhow::bail!` 置換) | **未着手**(B0h-f と一体化、event loop integration) |
+| **B6 (#136 残)** | L3 manual smoke on GNOME Wayland(Firefox / GNOME Text Editor / VS Code で典型変換 10 件) | **未着手**(B2 / B3 完了後、`docs/wbs/` に追記) |
+
+### Phase 3 受け入れ基準
+
+- 実機(GNOME Wayland)で `cargo run --bin kotoha` 起動が IBus daemon に登録される
+- typical 10 件の Layer 3 manual smoke が PASS
+- coalescing window 値の empirical 確定(spec §13 Open Q 2)、必要なら ADR 追補
+- 既存 baseline(現状 536 default / 547 test-helpers)を 0 regression
+- Phase 1 14/15 regression が engine 経由でも保たれる
 
 ## Phase 5 マイルストーン分割
 
@@ -118,3 +163,10 @@ Data pipeline は kana→kanji ペアの大規模コーパス構築を担う。�
 - Phase 5 への restructure (ADR 0010) により、旧 Phase 5 (Advanced features) は Phase 6 へ、旧 Phase 6 (UX polish) は Phase 7 へ後ろ倒しされた
 - 旧 Phase 5 の「Shift 挙動設定」は、Phase 0 設計書 (`docs/superpowers/specs/2026-04-22-kotoha-phase-0-design.md`) revision 2 の判断により Phase 0 に前倒し済み。新 Phase 6 の内容は「タイポ訂正 + 文脈リランキング」のみ
 - 各 Phase の設計書は `docs/superpowers/specs/` に配置する
+
+## 改訂履歴
+
+| 日付 | 改訂内容 |
+|------|----------|
+| 2026-05-04 | Phase 2 を「完了」に、Phase 3 を「進行中」に更新。Phase 3 マイルストーン分割 section を新設(P3-A draft + P3-B B0/B0g/B0h-a〜e/B1/B2/B4/B5 完了、B0h-f / B3 / B6 残)。Phase 2 各 milestone entry に merge PR 番号を追記(ISSUE #172 / PR 後続) |
+| 2026-04-25 | ADR 0010 で旧 Phase 5/6 を 6/7 に後ろ倒し、新 Phase 5「Kotoha custom romaji-base model」を挿入(初版) |


### PR DESCRIPTION
## Summary

- ROADMAP の Phase 2 row を「完了」に、Phase 3 row を「進行中」に更新(merge PR 番号 + 残作業の明記付き)
- 新 section「Phase 3 マイルストーン分割」を Phase 2 / Phase 5 breakdown の間に追加。P3-A draft + P3-B B0/B0g/B0h-a〜e/B1/B2/B4/B5 を完了 marker、B0h-f / B3 / B6 を **未着手** で残作業として表示
- Phase 2 マイルストーン分割の各 entry に merge PR 番号を追記、ROADMAP が implementation index 役も果たすように
- 改訂履歴 table を末尾に新設(2026-05-04 / 2026-04-25 の 2 entry)

## Test plan

- [x] markdown lint clean(lefthook pre-commit doc-naming + fmt-check pass)
- [x] documentation only — source / spec / ADR / WBS は無変更
- [x] ISSUE #172 の acceptance criteria 全項目を満たす
- [x] secrets-check は spec/plan/ADR の内容と等価で、新規認証情報の混入なし

## Reference

- ISSUE #172: https://github.com/std-koh-hinooka/kotoha-ime/issues/172
- Phase 2 wrap-up commit: `be0fae9` (P2-D M4 wrap-up, 2026-05-02)
- Phase 3-B B2 wrap-up commit: `4731c50` (PR #171, 2026-05-03)
- Phase 3-A spec: `docs/superpowers/specs/2026-05-02-p3-a-ibus-engine-design.md`
- Phase 3-A WBS: `docs/wbs/2026-05-02-phase3a-implementation.md`