### PR TITLE
chore: flip ROADMAP v0.3.0 ISSUE #174 checkbox to [x]

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ Kotoha プロジェクトの開発フェーズと、各フェーズの到達目�
 
 | ISSUE | spec | 状態 |
 |---|---|---|
-| [#174](https://github.com/std-koh-hinooka/kotoha-ime/issues/174) docs 構造改修と Obsidian vault 連携 | `docs/specs/_uncategorized/*` (8 spec frontmatter 整備) | [ ] |
+| [#174](https://github.com/std-koh-hinooka/kotoha-ime/issues/174) docs 構造改修と Obsidian vault 連携 | `docs/specs/_uncategorized/*` (8 spec frontmatter 整備) | [x] |
 | [#149](https://github.com/std-koh-hinooka/kotoha-ime/issues/149) P3-B B0h-f: I3 dispatch_rank_request async-ification | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [ ] |
 | [#136](https://github.com/std-koh-hinooka/kotoha-ime/issues/136) P3-B B3 + B6: signal listener loop + L3 manual smoke | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [ ] |
 


### PR DESCRIPTION
## Summary

Phase C-5 (docs structure overhaul + Obsidian vault wiring) was merged in [PR #175](https://github.com/std-koh-hinooka/kotoha-ime/pull/175) on 2026-05-04 (commit `99e95fc`). Separate cleanup PR per no-direct-push policy.

## Out of scope (per ADR 0019 §B)

- `docs/wbs/` retention is preserved (35 historical implementation logs intact)
- Cleanup PR for `docs/wbs/` move to `docs/_archive/wbs/` is the project-lead action item, gated by exit conditions stated in ADR 0019 §B (no active references + no new entries past 2026-12-31)

## Review note

1-line mechanical flip + PR #175 merged status verifiable on GitHub. lefthook PASS, no code review object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)