### PR TITLE
chore: kotoha-ime の spec frontmatter glossary_refs を拡充 (orphan 削減)

### DIFF
--- a/docs/specs/_uncategorized/bugfix-12-pre-commit-awk-fix.md
+++ b/docs/specs/_uncategorized/bugfix-12-pre-commit-awk-fix.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#12"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["lefthook"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/bugfix-23-convert-buffer-normalization.md
+++ b/docs/specs/_uncategorized/bugfix-23-convert-buffer-normalization.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#23"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["canonical-romaji","hatsuon","kana","lefthook","romaji","sokuon"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/bugfix-29-convert-mid-stream-normalize.md
+++ b/docs/specs/_uncategorized/bugfix-29-convert-mid-stream-normalize.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#29"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["kana","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-15-spec-pending-buffer-backtrack-rule.md
+++ b/docs/specs/_uncategorized/docs-15-spec-pending-buffer-backtrack-rule.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#15"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hatsuon","romaji","sokuon"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-16-canonical-romaji-adr-tracking-hook.md
+++ b/docs/specs/_uncategorized/docs-16-canonical-romaji-adr-tracking-hook.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#16"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["canonical-romaji","lefthook","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-20-romaji-design-adrs.md
+++ b/docs/specs/_uncategorized/docs-20-romaji-design-adrs.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#20"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["lefthook","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-22-non-ascii-retraction-policy.md
+++ b/docs/specs/_uncategorized/docs-22-non-ascii-retraction-policy.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#22"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-34-input-mode-adr.md
+++ b/docs/specs/_uncategorized/docs-34-input-mode-adr.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#34"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hiragana","karukan"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-46-plan-adr-canonical-renumber.md
+++ b/docs/specs/_uncategorized/docs-46-plan-adr-canonical-renumber.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#46"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["romaji","romaji-trie"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-54-phase0-finishing-docs.md
+++ b/docs/specs/_uncategorized/docs-54-phase0-finishing-docs.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#54"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["canonical-romaji","lefthook","shift-trigger"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-56-adr-0008-approve-option-1.md
+++ b/docs/specs/_uncategorized/docs-56-adr-0008-approve-option-1.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#56"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["canonical-romaji","kana","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-83-p1-4-phase1-wrap.md
+++ b/docs/specs/_uncategorized/docs-83-p1-4-phase1-wrap.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#83"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["backend-trait","candidate","gemma-2-2b-jpn-it","hiragana","katakana","layer-3-smoke","lefthook","romaji","row-3","zenz"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/docs-85-phase-2-foundation.md
+++ b/docs/specs/_uncategorized/docs-85-phase-2-foundation.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#85"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["backend-trait","candidate","gemma-2-2b-jpn-it","learning-cache","lefthook","row-3","system-dictionary","user-dictionary"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-1-project-setup.md
+++ b/docs/specs/_uncategorized/feature-1-project-setup.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#1"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["lefthook"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-10-docs-followup-round-1.md
+++ b/docs/specs/_uncategorized/feature-10-docs-followup-round-1.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#10"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-105-p2-c-learning-cache.md
+++ b/docs/specs/_uncategorized/feature-105-p2-c-learning-cache.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#105"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["kana","kotoha-dict","kotoha-storage","lefthook"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-13-spec-property-count-revise.md
+++ b/docs/specs/_uncategorized/feature-13-spec-property-count-revise.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#13"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["canonical-romaji","hatsuon","kana","romaji","yoon"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-17-kotoha-romaji-core.md
+++ b/docs/specs/_uncategorized/feature-17-kotoha-romaji-core.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#17"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["canonical-romaji","hatsuon","karukan","lefthook","romaji","sokuon"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-21-kotoha-romaji-tests.md
+++ b/docs/specs/_uncategorized/feature-21-kotoha-romaji-tests.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#21"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hatsuon","kana","lefthook","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-26-property-strategy-broaden.md
+++ b/docs/specs/_uncategorized/feature-26-property-strategy-broaden.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#26"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["lefthook","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-37-kotoha-input-module.md
+++ b/docs/specs/_uncategorized/feature-37-kotoha-input-module.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#37"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hiragana","preedit","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-40-kotoha-input-tests.md
+++ b/docs/specs/_uncategorized/feature-40-kotoha-input-tests.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#40"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["kana","karukan","lefthook","preedit","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-52-kotoha-cli.md
+++ b/docs/specs/_uncategorized/feature-52-kotoha-cli.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#52"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hiragana","kana","romaji","shift-trigger"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-65-kanji-skeleton-mockbackend.md
+++ b/docs/specs/_uncategorized/feature-65-kanji-skeleton-mockbackend.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#65"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["azookey","candidate","hiragana","kana","lefthook","mock-backend","prompt-template","romaji","zenz","zenzai"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-69-zenz-backend-layer3-smoke.md
+++ b/docs/specs/_uncategorized/feature-69-zenz-backend-layer3-smoke.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#69"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["azookey","backend-trait","candidate","chat-template","distillation","gemma-2-2b-jpn-it","gguf","greedy-decoding","hiragana","kana","katakana","layer-3-smoke","lefthook","mock-backend","pua-tokens","uv","zenz","zenzai"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-73-llama-cpp-backend-gemma-2-jpn.md
+++ b/docs/specs/_uncategorized/feature-73-llama-cpp-backend-gemma-2-jpn.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#73"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["azookey","gemma-2-2b-jpn-it","gguf","hiragana","kana","katakana","mock-backend","prompt-template","zenz","zenzai"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-75-prompt-optimization-15-row-fixture.md
+++ b/docs/specs/_uncategorized/feature-75-prompt-optimization-15-row-fixture.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#75"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["distillation","gemma-2-2b-jpn-it","gguf","icl","kana","karukan","layer-3-smoke","romaji","row-3","scratch-training"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-8-kotoha-core-skeleton.md
+++ b/docs/specs/_uncategorized/feature-8-kotoha-core-skeleton.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#8"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hiragana","kana","katakana","lefthook","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-86-p5a-expansion-iter1.md
+++ b/docs/specs/_uncategorized/feature-86-p5a-expansion-iter1.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#86"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["bias-sampling","karukan","partial-input","romaji","sudachipy","uv"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-91-p2-a-dictionary-layer.md
+++ b/docs/specs/_uncategorized/feature-91-p2-a-dictionary-layer.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#91"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hiragana","kotoha-dict","mock-backend","romaji","sudachipy"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/feature-98-p2-b-user-dictionary.md
+++ b/docs/specs/_uncategorized/feature-98-p2-b-user-dictionary.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#98"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["hiragana","kotoha-dict","kotoha-storage","lefthook","mock-backend","user-dictionary"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/kotoha-phase-0.md
+++ b/docs/specs/_uncategorized/kotoha-phase-0.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#1"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["azookey","canonical-romaji","gguf","hatsuon","hiragana","kana","karukan","katakana","lefthook","preedit","romaji","sokuon","zenz"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/kotoha-phase-1.md
+++ b/docs/specs/_uncategorized/kotoha-phase-1.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#75", "#83"]
 related_prs: []
-glossary_refs: ["llama-cpp-backend", "gemma-2-2b-jpn-it", "kana-kanji-conversion", "layer-3-smoke"]
+glossary_refs: ["azookey","backend-trait","candidate","canonical-romaji","chat-template","gemma-2-2b-jpn-it","gguf","hiragana","ime-engine","kana","kana-kanji-conversion","katakana","layer-3-smoke","learning-cache","lefthook","llama-cpp-backend","mock-backend","prompt-template","romaji","romaji-trie","row-3","system-dictionary","user-dictionary","zenz","zenzai"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/kotoha-phase-2.md
+++ b/docs/specs/_uncategorized/kotoha-phase-2.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#85", "#172"]
 related_prs: []
-glossary_refs: ["backend-trait", "user-dictionary", "learning-cache", "hybrid-ranker"]
+glossary_refs: ["backend-trait","candidate","gemma-2-2b-jpn-it","gguf","hiragana","hybrid-ranker","icl","kana","kotoha-dict","kotoha-storage","layer-3-smoke","learning-cache","preedit","row-3","system-dictionary","user-dictionary","vocabulary-lookup"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/kotoha-phase-5-custom-model.md
+++ b/docs/specs/_uncategorized/kotoha-phase-5-custom-model.md
@@ -4,7 +4,7 @@ status: draft
 bounded_context: _uncategorized
 related_issues: []
 related_prs: []
-glossary_refs: ["distillation", "gguf"]
+glossary_refs: ["candidate","distillation","edit-distance","gemma-2-2b-jpn-it","gguf","icl","kana","karukan","katakana","layer-3-smoke","learning-cache","lora","partial-input","romaji","row-3","scratch-training","zenz"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/p2-a-dictionary-layer.md
+++ b/docs/specs/_uncategorized/p2-a-dictionary-layer.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#92", "#94", "#100"]
 related_prs: []
-glossary_refs: ["sudachi-dict", "backend-trait"]
+glossary_refs: ["backend-trait","candidate","gguf","hiragana","kana","kotoha-dict","layer-3-smoke","learning-cache","lefthook","sudachi-dict","user-dictionary","user-vocab","uv"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/p2-b-user-dictionary.md
+++ b/docs/specs/_uncategorized/p2-b-user-dictionary.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: []
 related_prs: []
-glossary_refs: ["user-dictionary", "kotoha-storage"]
+glossary_refs: ["backend-trait","edit-distance","hiragana","kana","karukan","kotoha-dict","kotoha-storage","learning-cache","lefthook","pua-tokens","romaji","user-dictionary","user-vocab"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/p2-c-learning-cache.md
+++ b/docs/specs/_uncategorized/p2-c-learning-cache.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#107"]
 related_prs: []
-glossary_refs: ["learning-cache", "kotoha-storage"]
+glossary_refs: ["hiragana","kana","kotoha-dict","kotoha-storage","learning-cache","lefthook"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/p3-a-ibus-engine.md
+++ b/docs/specs/_uncategorized/p3-a-ibus-engine.md
@@ -4,7 +4,7 @@ status: draft
 bounded_context: _uncategorized
 related_issues: ["#128", "#136", "#149"]
 related_prs: []
-glossary_refs: ["phase3-ibus-engine-terms", "ranker-worker", "ime-host-bridge", "kotoha-engine"]
+glossary_refs: ["candidate","coalescing-window","hexagonal-architecture","hybrid-ranker","ime-engine","ime-host-bridge","kana","kotoha-engine","kotoha-storage","layer-3-smoke","lefthook","partial-input","phase3-ibus-engine-terms","preedit","ranker-worker","romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/perf-19-trie-oncelock-cache.md
+++ b/docs/specs/_uncategorized/perf-19-trie-oncelock-cache.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#19"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["romaji"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/phase3a-implementation.md
+++ b/docs/specs/_uncategorized/phase3a-implementation.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: []
 related_prs: []
-glossary_refs: []
+glossary_refs: ["candidate","kana","kotoha-engine","kotoha-storage","lefthook","preedit","romaji","row-3"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/refactor-60-assert-sh.md
+++ b/docs/specs/_uncategorized/refactor-60-assert-sh.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#60"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["lefthook","romaji","zenz"]
 last_reviewed: 2026-05-05
 ---
 

--- a/docs/specs/_uncategorized/test-25-rule-coverage-gap.md
+++ b/docs/specs/_uncategorized/test-25-rule-coverage-gap.md
@@ -4,7 +4,7 @@ status: implemented
 bounded_context: _uncategorized
 related_issues: ["#25"]
 related_prs: []
-glossary_refs: []
+glossary_refs: ["kana","romaji","sokuon","yoon"]
 last_reviewed: 2026-05-05
 ---
 


### PR DESCRIPTION
Phase E 統合検証 follow-up。kotoha-ime の各 spec body を vault scope concepts で grep し matched concept を frontmatter glossary_refs に union 反映。 43 files changed, 43 insertions(+), 43 deletions(-)