### PR TITLE
docs(spec): 36 WBS-migrated specs を status: deprecated に bulk 更新 (#178)

### DIFF
--- a/docs/specs/_uncategorized/bugfix-12-pre-commit-awk-fix.md
+++ b/docs/specs/_uncategorized/bugfix-12-pre-commit-awk-fix.md
@@ -1,11 +1,12 @@
 ---
 feature: bugfix-12-pre-commit-awk-fix
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#12"]
 related_prs: []
 glossary_refs: ["lefthook"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # 2026-04-23 bugfix/12 pre-commit awk fix — 実装ログ

--- a/docs/specs/_uncategorized/bugfix-23-convert-buffer-normalization.md
+++ b/docs/specs/_uncategorized/bugfix-23-convert-buffer-normalization.md
@@ -1,11 +1,12 @@
 ---
 feature: bugfix-23-convert-buffer-normalization
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#23"]
 related_prs: []
 glossary_refs: ["canonical-romaji","hatsuon","kana","lefthook","romaji","sokuon"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # #23 hotfix: convert() / flush() 終端 buffer 正規化

--- a/docs/specs/_uncategorized/bugfix-29-convert-mid-stream-normalize.md
+++ b/docs/specs/_uncategorized/bugfix-29-convert-mid-stream-normalize.md
@@ -1,11 +1,12 @@
 ---
 feature: bugfix-29-convert-mid-stream-normalize
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#29"]
 related_prs: []
 glossary_refs: ["kana","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # #29 hotfix: convert() mid-stream buffer 正規化

--- a/docs/specs/_uncategorized/docs-15-spec-pending-buffer-backtrack-rule.md
+++ b/docs/specs/_uncategorized/docs-15-spec-pending-buffer-backtrack-rule.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-15-spec-pending-buffer-backtrack-rule
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#15"]
 related_prs: []
 glossary_refs: ["hatsuon","romaji","sokuon"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # ISSUE #15: spec §9.3 — pending バッファの backtrack 規則 normative 化

--- a/docs/specs/_uncategorized/docs-16-canonical-romaji-adr-tracking-hook.md
+++ b/docs/specs/_uncategorized/docs-16-canonical-romaji-adr-tracking-hook.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-16-canonical-romaji-adr-tracking-hook
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#16"]
 related_prs: []
 glossary_refs: ["canonical-romaji","lefthook","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # 2026-04-23 docs/16-canonical-romaji-adr-tracking-hook 実装ログ

--- a/docs/specs/_uncategorized/docs-20-romaji-design-adrs.md
+++ b/docs/specs/_uncategorized/docs-20-romaji-design-adrs.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-20-romaji-design-adrs
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#20"]
 related_prs: []
 glossary_refs: ["lefthook","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # ISSUE #20: romaji design decisions を ADR 0005 / 0006 として記録

--- a/docs/specs/_uncategorized/docs-22-non-ascii-retraction-policy.md
+++ b/docs/specs/_uncategorized/docs-22-non-ascii-retraction-policy.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-22-non-ascii-retraction-policy
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#22"]
 related_prs: []
 glossary_refs: ["romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # #22 ADR: 非 ASCII 入力に対する StateMachine::push の normative policy pin

--- a/docs/specs/_uncategorized/docs-34-input-mode-adr.md
+++ b/docs/specs/_uncategorized/docs-34-input-mode-adr.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-34-input-mode-adr
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#34"]
 related_prs: []
 glossary_refs: ["hiragana","karukan"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M4a: ADR 0002 — input mode Transient vs Sticky + spec §8.5 ref fix

--- a/docs/specs/_uncategorized/docs-36-adr-count-narrative.md
+++ b/docs/specs/_uncategorized/docs-36-adr-count-narrative.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-36-adr-count-narrative
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#36"]
 related_prs: []
 glossary_refs: []
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # #36: Phase 0 spec narrative — ADR 総数 3→4 の更新

--- a/docs/specs/_uncategorized/docs-46-plan-adr-canonical-renumber.md
+++ b/docs/specs/_uncategorized/docs-46-plan-adr-canonical-renumber.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-46-plan-adr-canonical-renumber
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#46"]
 related_prs: []
 glossary_refs: ["romaji","romaji-trie"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # #46: Phase 0 plan — M7 ADR canonical renumber

--- a/docs/specs/_uncategorized/docs-54-phase0-finishing-docs.md
+++ b/docs/specs/_uncategorized/docs-54-phase0-finishing-docs.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-54-phase0-finishing-docs
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#54"]
 related_prs: []
 glossary_refs: ["canonical-romaji","lefthook","shift-trigger"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M7: Phase 0 finishing docs (ADRs 0003/0004/0007 + ROADMAP/README)

--- a/docs/specs/_uncategorized/docs-56-adr-0008-approve-option-1.md
+++ b/docs/specs/_uncategorized/docs-56-adr-0008-approve-option-1.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-56-adr-0008-approve-option-1
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#56"]
 related_prs: []
 glossary_refs: ["canonical-romaji","kana","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # 2026-04-24 ADR 0008 Status 昇格ログ

--- a/docs/specs/_uncategorized/docs-83-p1-4-phase1-wrap.md
+++ b/docs/specs/_uncategorized/docs-83-p1-4-phase1-wrap.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-83-p1-4-phase1-wrap
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#83"]
 related_prs: []
 glossary_refs: ["backend-trait","candidate","gemma-2-2b-jpn-it","hiragana","katakana","layer-3-smoke","lefthook","romaji","row-3","zenz"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P1-4 — Phase 1 最終 wrap (ADR 0009 promote + 0011/0012/0013 新規 + spec §14 完了宣言)

--- a/docs/specs/_uncategorized/docs-85-phase-2-foundation.md
+++ b/docs/specs/_uncategorized/docs-85-phase-2-foundation.md
@@ -1,11 +1,12 @@
 ---
 feature: docs-85-phase-2-foundation
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#85"]
 related_prs: []
 glossary_refs: ["backend-trait","candidate","gemma-2-2b-jpn-it","learning-cache","lefthook","row-3","system-dictionary","user-dictionary"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # Phase 2 foundation — ADR 0014 + Phase 2 spec draft + ROADMAP P2-A〜D (#85)

--- a/docs/specs/_uncategorized/feature-1-project-setup.md
+++ b/docs/specs/_uncategorized/feature-1-project-setup.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-1-project-setup
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#1"]
 related_prs: []
 glossary_refs: ["lefthook"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M1: Project setup

--- a/docs/specs/_uncategorized/feature-10-docs-followup-round-1.md
+++ b/docs/specs/_uncategorized/feature-10-docs-followup-round-1.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-10-docs-followup-round-1
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#10"]
 related_prs: []
 glossary_refs: ["romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # docs follow-up round 1: English templates + CLAUDE.md refinements

--- a/docs/specs/_uncategorized/feature-105-p2-c-learning-cache.md
+++ b/docs/specs/_uncategorized/feature-105-p2-c-learning-cache.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-105-p2-c-learning-cache
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#105"]
 related_prs: []
 glossary_refs: ["kana","kotoha-dict","kotoha-storage","lefthook"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P2-C(LearningCache 本実装)実装ログ

--- a/docs/specs/_uncategorized/feature-13-spec-property-count-revise.md
+++ b/docs/specs/_uncategorized/feature-13-spec-property-count-revise.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-13-spec-property-count-revise
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#13"]
 related_prs: []
 glossary_refs: ["canonical-romaji","hatsuon","kana","romaji","yoon"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # spec §11.3 revision + M3 implementation plan commit

--- a/docs/specs/_uncategorized/feature-17-kotoha-romaji-core.md
+++ b/docs/specs/_uncategorized/feature-17-kotoha-romaji-core.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-17-kotoha-romaji-core
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#17"]
 related_prs: []
 glossary_refs: ["canonical-romaji","hatsuon","karukan","lefthook","romaji","sokuon"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M3a: romaji module core — rules table + trie + state machine + RomajiConverter facade

--- a/docs/specs/_uncategorized/feature-21-kotoha-romaji-tests.md
+++ b/docs/specs/_uncategorized/feature-21-kotoha-romaji-tests.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-21-kotoha-romaji-tests
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#21"]
 related_prs: []
 glossary_refs: ["hatsuon","kana","lefthook","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M3b: romaji module — golden test + property test + proptest wiring

--- a/docs/specs/_uncategorized/feature-26-property-strategy-broaden.md
+++ b/docs/specs/_uncategorized/feature-26-property-strategy-broaden.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-26-property-strategy-broaden
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#26"]
 related_prs: []
 glossary_refs: ["lefthook","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # #26: romaji property strategy を plan-spec full alphabet に broaden

--- a/docs/specs/_uncategorized/feature-37-kotoha-input-module.md
+++ b/docs/specs/_uncategorized/feature-37-kotoha-input-module.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-37-kotoha-input-module
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#37"]
 related_prs: []
 glossary_refs: ["hiragana","preedit","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M4b: input module — InputMode / ModeOrigin / InputContext / InputStep

--- a/docs/specs/_uncategorized/feature-40-kotoha-input-tests.md
+++ b/docs/specs/_uncategorized/feature-40-kotoha-input-tests.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-40-kotoha-input-tests
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#40"]
 related_prs: []
 glossary_refs: ["kana","karukan","lefthook","preedit","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M4c: input module — mode golden + Karukan diff + 4 property tests

--- a/docs/specs/_uncategorized/feature-52-kotoha-cli.md
+++ b/docs/specs/_uncategorized/feature-52-kotoha-cli.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-52-kotoha-cli
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#52"]
 related_prs: []
 glossary_refs: ["hiragana","kana","romaji","shift-trigger"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M6: kotoha-cli — `kotoha-romaji` binary + `scripts/phase0-smoke.sh`

--- a/docs/specs/_uncategorized/feature-65-kanji-skeleton-mockbackend.md
+++ b/docs/specs/_uncategorized/feature-65-kanji-skeleton-mockbackend.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-65-kanji-skeleton-mockbackend
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#65"]
 related_prs: []
 glossary_refs: ["azookey","candidate","hiragana","kana","lefthook","mock-backend","prompt-template","romaji","zenz","zenzai"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P1-1: kanji skeleton + MockBackend

--- a/docs/specs/_uncategorized/feature-69-zenz-backend-layer3-smoke.md
+++ b/docs/specs/_uncategorized/feature-69-zenz-backend-layer3-smoke.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-69-zenz-backend-layer3-smoke
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#69"]
 related_prs: []
 glossary_refs: ["azookey","backend-trait","candidate","chat-template","distillation","gemma-2-2b-jpn-it","gguf","greedy-decoding","hiragana","kana","katakana","layer-3-smoke","lefthook","mock-backend","pua-tokens","uv","zenz","zenzai"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P1-2: ZenzBackend via llama-cpp-2 + Layer 3 smoke

--- a/docs/specs/_uncategorized/feature-73-llama-cpp-backend-gemma-2-jpn.md
+++ b/docs/specs/_uncategorized/feature-73-llama-cpp-backend-gemma-2-jpn.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-73-llama-cpp-backend-gemma-2-jpn
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#73"]
 related_prs: []
 glossary_refs: ["azookey","gemma-2-2b-jpn-it","gguf","hiragana","kana","katakana","mock-backend","prompt-template","zenz","zenzai"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P1-2.5 — LlamaCppBackend 汎用化 + Gemma-2-2B-jpn-it 採用 (実装ログ)

--- a/docs/specs/_uncategorized/feature-75-prompt-optimization-15-row-fixture.md
+++ b/docs/specs/_uncategorized/feature-75-prompt-optimization-15-row-fixture.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-75-prompt-optimization-15-row-fixture
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#75"]
 related_prs: []
 glossary_refs: ["distillation","gemma-2-2b-jpn-it","gguf","icl","kana","karukan","layer-3-smoke","romaji","row-3","scratch-training"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P1-2.5 follow-up — 15-row Layer 3 fixture restore + prompt v12 optimization (実装ログ)

--- a/docs/specs/_uncategorized/feature-8-kotoha-core-skeleton.md
+++ b/docs/specs/_uncategorized/feature-8-kotoha-core-skeleton.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-8-kotoha-core-skeleton
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#8"]
 related_prs: []
 glossary_refs: ["hiragana","kana","katakana","lefthook","romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # M2: kotoha-core skeleton + error + kana utilities

--- a/docs/specs/_uncategorized/feature-86-p5a-expansion-iter1.md
+++ b/docs/specs/_uncategorized/feature-86-p5a-expansion-iter1.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-86-p5a-expansion-iter1
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#86"]
 related_prs: []
 glossary_refs: ["bias-sampling","karukan","partial-input","romaji","sudachipy","uv"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # WBS: feature/86-p5a-expansion-iter1

--- a/docs/specs/_uncategorized/feature-91-p2-a-dictionary-layer.md
+++ b/docs/specs/_uncategorized/feature-91-p2-a-dictionary-layer.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-91-p2-a-dictionary-layer
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#91"]
 related_prs: []
 glossary_refs: ["hiragana","kotoha-dict","mock-backend","romaji","sudachipy"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P2-A WBS — Dictionary Layer Implementation Log

--- a/docs/specs/_uncategorized/feature-98-p2-b-user-dictionary.md
+++ b/docs/specs/_uncategorized/feature-98-p2-b-user-dictionary.md
@@ -1,11 +1,12 @@
 ---
 feature: feature-98-p2-b-user-dictionary
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#98"]
 related_prs: []
 glossary_refs: ["hiragana","kotoha-dict","kotoha-storage","lefthook","mock-backend","user-dictionary"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P2-B(User dictionary)実装ログ

--- a/docs/specs/_uncategorized/perf-19-trie-oncelock-cache.md
+++ b/docs/specs/_uncategorized/perf-19-trie-oncelock-cache.md
@@ -1,11 +1,12 @@
 ---
 feature: perf-19-trie-oncelock-cache
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#19"]
 related_prs: []
 glossary_refs: ["romaji"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # 2026-04-23 perf/19-trie-oncelock-cache 実装ログ

--- a/docs/specs/_uncategorized/phase3a-implementation.md
+++ b/docs/specs/_uncategorized/phase3a-implementation.md
@@ -1,11 +1,12 @@
 ---
 feature: phase3a-implementation
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: []
 related_prs: []
 glossary_refs: ["candidate","kana","kotoha-engine","kotoha-storage","lefthook","preedit","romaji","row-3"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # Phase 3-A IBus engine integration — implementation log

--- a/docs/specs/_uncategorized/refactor-60-assert-sh.md
+++ b/docs/specs/_uncategorized/refactor-60-assert-sh.md
@@ -1,11 +1,12 @@
 ---
 feature: refactor-60-assert-sh
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#60"]
 related_prs: []
 glossary_refs: ["lefthook","romaji","zenz"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # P1-0: scripts/lib/assert.sh 抽出 + Phase 0 smoke refactor

--- a/docs/specs/_uncategorized/test-25-rule-coverage-gap.md
+++ b/docs/specs/_uncategorized/test-25-rule-coverage-gap.md
@@ -1,11 +1,12 @@
 ---
 feature: test-25-rule-coverage-gap
-status: implemented
+status: deprecated
+deprecated_reason: "Phase E migration で旧 docs/wbs/ から spec 化した実装ログ性質の文書。Global CLAUDE.md §Development Flow legacy spec 取扱いルール (実装ログ性質 → status: deprecated、本文 14-section restructure 不要) に基づき deprecated 扱い。git history は参照点として保持 (2026-05-06)。"
 bounded_context: _uncategorized
 related_issues: ["#25"]
 related_prs: []
 glossary_refs: ["kana","romaji","sokuon","yoon"]
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-06
 ---
 
 # 2026-04-23 test/25-rule-coverage-gap 実装ログ


### PR DESCRIPTION
## Summary

Phase E migration で旧 \`docs/wbs/\` から spec 化された実装ログ性質の 36 文書を、Global CLAUDE.md §Development Flow に追加された legacy spec 取扱いルールに基づき deprecated 扱いに統一。

## ルール根拠

Global CLAUDE.md §Development Flow:

> legacy spec 取扱い (Phase E migration で旧 docs/{wbs,wiki}/ から spec 化されたファイル群):
> - 実装ログ性質: \`status: deprecated\` + \`deprecated_reason\` 明記。本文 14-section restructure は不要。

## 変更内容

各 spec の frontmatter に対して:

- \`status: implemented\` → \`status: deprecated\`
- \`deprecated_reason:\` 追加 (Phase E migration 由来 + git history 参照を明記)
- \`last_reviewed:\` を 2026-05-06 に更新

本文は変更なし。

## 対象 (36 spec)

bugfix / docs / feature / perf / refactor / test 系の各 issue tracking spec 全件。

## Why

Pilot (ai-learning#11 / image-generate#73 / infrastructure#37) で確立した 14-section restructure は機能 / 設計 spec 向け。本 PR は実装ログ性質の spec を対象とした補完的措置で、CLAUDE.md ルールに沿った正規化。機能 / 設計 spec の 14-section restructure は別途継続 (本 PR スコープ外)。

## Closes

Closes part of #178 (実装ログ性質 36 spec を deprecated 化、機能 spec 8 件は別途)

🤖 Generated with [Claude Code](https://claude.com/claude-code)