### PR TITLE
docs(roadmap): post-merge follow-up for PR #183 (B0h-f + B3)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@ Kotoha プロジェクトの開発フェーズと、各フェーズの到達目�
 | ISSUE | spec | 状態 |
 |---|---|---|
 | [#174](https://github.com/std-koh-hinooka/kotoha-ime/issues/174) docs 構造改修と Obsidian vault 連携 | `docs/specs/_uncategorized/*` (8 spec frontmatter 整備) | [x] |
-| [#149](https://github.com/std-koh-hinooka/kotoha-ime/issues/149) P3-B B0h-f: I3 dispatch_rank_request async-ification | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [ ] |
+| [#149](https://github.com/std-koh-hinooka/kotoha-ime/issues/149) P3-B B0h-f: I3 dispatch_rank_request async-ification | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [x] |
 | [#136](https://github.com/std-koh-hinooka/kotoha-ime/issues/136) P3-B B3 + B6: signal listener loop + L3 manual smoke | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [ ] |
 
 <!--
@@ -36,7 +36,7 @@ ADR 0010 (`docs/adr/0010-kotoha-custom-romaji-base-model.md`) の決定により
 | 0 | Foundation | Cargo workspace + ローマ字→かな変換 + 入力モード管理 + CLI | 完了 |
 | 1 | Kana→Kanji conversion | llama.cpp + Gemma-2-2B-jpn-it baseline によるかな→漢字変換 (P1-2.5 follow-up で Layer 3 smoke 14/15 達成) | 完了 (14/15 PASS, P1-4 で close 2026-04-25) |
 | 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ + Hybrid Ranker | 完了 (P2-A〜P2-D 全 PR merge、最終 commit `be0fae9` 2026-05-02、test 416 PASS。follow-up backlog #92/#94/#100/#107 は OSS 公開前 triage) |
-| 3 | IBus integration | IBus engine(GNOME Mutter 用) | **進行中** (P3-A draft + P3-B B0/B0g/B0h 大部分/B1/B2/B4/B5 完了。残 B0h-f I3 async dispatch + B3 signal listener loop + B6 L3 manual smoke) |
+| 3 | IBus integration | IBus engine(GNOME Mutter 用) | **進行中** (P3-A draft + P3-B B0/B0g/B0h 全/B1/B2/B3/B4/B5 完了。残 B6 = L3 manual smoke + zbus decode + SIGTERM hook) |
 | 4 | fcitx5 integration | fcitx5 addon(KDE / wlroots 用) | 未着手 |
 | 5 | **Kotoha custom romaji-base model** | raw romaji keystrokes を直接受理する Kotoha 専用 90〜180M parameter モデルの自作 (data pipeline + training + GGUF 推論統合 + evaluation)。row 3 類の ICL 限界 + typo robustness + partial-input 対応を同時解決する | 未着手 |
 | 6 | Advanced features | タイポ訂正 + 文脈リランキング (Phase 5 の romaji-base モデルを技術基盤とする) | 未着手 |
@@ -123,8 +123,8 @@ Phase 3「IBus integration」は P3-A(設計 + skeleton)と P3-B(production wiri
 | B4 (#138) | `KeyModifiers` の IBus full mapping(`IBusModifierType` 全列挙)+ RELEASE event handling | 完了(PR #138) |
 | B5 (#139) | KotohaEngine + 実 `HybridRanker` end-to-end integration test | 完了(PR #139) |
 | **B2 (#170)** | IBus signal body marshalling(`proxy.rs` 5 method を実 D-Bus signal emit に置換、`IBusText` / `IBusLookupTable` wire-format 確定:`(sa{sv}sv)` / `(sa{sv}uubbiavav)`) | **完了**(PR #171 squash `4731c50`、test 536 / 547) |
-| **B0h-f + B3 (#149 残 + #136 残)** | event-loop architecture 一体化(ADR 0020):4-thread lock-free topology + `EventReactor` trait + `kotoha-engine-reactor-linux` 新 crate + `drain_events_blocking` / `Arc<Mutex<dyn IMEEngine>>` 撤去 + zbus listener loop 実装 | **進行中**(2026-05-06 設計確定、`feature/149-p3b-b0hf-b3-event-loop` branch) |
-| **B6 (#136 残)** | L3 manual smoke on GNOME Wayland(Firefox / GNOME Text Editor / VS Code で典型変換 10 件) | **未着手**(B0h-f + B3 完了後、`docs/wbs/` に追記) |
+| **B0h-f + B3 (#149 + #136 一部)** | event-loop architecture 一体化(ADR 0020):4-thread lock-free topology + `EventReactor` trait + `kotoha-engine-reactor-linux` 新 crate + `drain_events_blocking` / `Arc<Mutex<dyn IMEEngine>>` 撤去 + zbus listener loop 実装 | **完了**(PR #183 squash `237eb38`、test 595 / 0、5dim self-review 12 findings 解消) |
+| **B6 (#136 残)** | L3 manual smoke on GNOME Wayland(Firefox / GNOME Text Editor / VS Code で典型変換 10 件)+ zbus `MessageStream` 完全 decode + SIGTERM/SIGINT hook(ADR 0020 §影響 rev2 で deferral 明記) | **未着手** |
 
 ### Phase 3 受け入れ基準
 
@@ -219,6 +219,7 @@ v0.3.0 以降は §Milestone Specification 完了条件 (annotated tag + リリ�
 
 | 日付 | 改訂内容 |
 |------|----------|
+| 2026-05-07 | Phase 3-B B0h-f + B3(#149 + #136 一部)merge 完了(PR #183 squash `237eb38`、test 595 / 0、5dim self-review 12 findings 解消)。Active マイルストーン v0.3.0 の #149 を `[x]`、Phase 3-B sub-milestone table の B0h-f + B3 entry を完了マーク。残作業は B6(L3 manual smoke + zbus decode + SIGTERM hook) |
 | 2026-05-06 | Phase 3-B B0h-f + B3 を一体化 entry に統合、ADR 0020(event-loop architecture)を起票し進行中マーク追加(branch `feature/149-p3b-b0hf-b3-event-loop`) |
 | 2026-05-05 | docs 構造移行 (PR #174): Active マイルストーン v0.3.0 table 化、完了済 v0.0.0/v0.1.0/v0.2.0 を SemVer マッピングで table 化、spec 参照を新パス (`docs/specs/_uncategorized/`) に更新 |
 | 2026-05-04 | Phase 2 を「完了」に、Phase 3 を「進行中」に更新。Phase 3 マイルストーン分割 section を新設(P3-A draft + P3-B B0/B0g/B0h-a〜e/B1/B2/B4/B5 完了、B0h-f / B3 / B6 残)。Phase 2 各 milestone entry に merge PR 番号を追記(ISSUE #172 / PR 後続) |


### PR DESCRIPTION
## Summary

Post-merge follow-up for PR #183 (P3-B B0h-f + B3 event-loop architecture, ADR 0020). Updates ROADMAP.md to reflect the completion of ISSUE #149 and the B3 portion of ISSUE #136.

Tracking ISSUE: #184. Closes #149.

## Changes

- Active milestone v0.3.0 table: ISSUE #149 marked `[x]`
- Phase 3 status row: B3 added to completed list, residual narrowed to B6 (L3 manual smoke + zbus decode + SIGTERM hook)
- Phase 3-B sub-milestone table:
  - B0h-f + B3 entry → 完了 with PR #183 reference and self-review summary (12 findings resolved)
  - B6 entry expanded to include zbus / SIGTERM scope per ADR 0020 §影響 rev2 deferral note
- Revision history: appended 2026-05-07 entry

## Post-merge follow-up checklist (per `~/.claude/rules/spec-management.md`)

- [x] **Spec status update**: N/A — `docs/specs/_uncategorized/p3-a-ibus-engine.md` remains `draft` until B6 (#136) completes (spec covers full Phase 3 scope, not just B0h-f + B3)
- [x] **Glossary sync**: N/A — `event-loop.md` / `event-reactor.md` already updated in PR #183 (last_reviewed: 2026-05-06)
- [x] **CLAUDE.md / README update**: N/A — no diff in `7842ca7..237eb38` for these files
- [x] **ROADMAP update**: this PR
- [x] **Vault sync**: N/A — no scope move / merge / deprecation in PR #183
- [x] **Milestone completion check**: N/A — Phase 3-B blocked on B6 (#136); v0.3.0 milestone remains Active

## Out-of-scope follow-up backlog (filed as separate ISSUEs)

5 design-quality nits identified during PR #183 self-review, tracked separately:

- #185 design: RequestId(u64) newtype
- #186 design: ReactorHandles #[must_use] message refinement
- #187 design: ListenerShutdown::observer wrap in newtype
- #188 design: EventReactor trait abstracts crossbeam_channel::RecvError
- #189 test: MockReactor self-tests when first consumer arrives

Per the PR #183 self-review summary, these are non-blocking and should land as a single follow-up PR after B6 (#136) merges.

## Test plan

- [x] `lefthook run pre-commit` passes (doc-naming, secrets-scan)
- [x] `lefthook run pre-push` will run on push (build, test, frontmatter validation)
- [x] No code changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)