### PR TITLE
docs(engine-reactor-linux): refine ReactorHandles #[must_use] message (#186)

### DIFF
--- a/crates/kotoha-engine-reactor-linux/src/lib.rs
+++ b/crates/kotoha-engine-reactor-linux/src/lib.rs
@@ -38,7 +38,20 @@ pub struct LinuxReactor {
 /// main thread が DI wiring 時に保持し、各 producer thread に move する。
 /// drop されると `engine-loop` thread が即時 shutdown するため、
 /// `#[must_use]` で誤破棄を予防する。
-#[must_use = "ReactorHandles を drop すると engine-loop が即時 shutdown する"]
+///
+/// # Lifetime contract
+///
+/// `ReactorHandles` の drop は次の連鎖を起こす:
+///
+/// 1. `bridge_tx` / `worker_tx` / `shutdown_tx` が drop される
+/// 2. `LinuxReactor::recv()` の `select!` arm が `RecvError`(全 sender drop 時)
+///    または `Ok(Event::Shutdown)`(`shutdown_tx` 経由)を返す
+/// 3. `engine-loop` thread が即時 exit する
+///
+/// したがって `start()` 戻り値は **program lifetime** まで保持する変数に
+/// bind すること(典型的には `kotoha-bin::main` の local)。明示的な
+/// shutdown を意図する場合のみ scope を抜けて drop させる。
+#[must_use = "ReactorHandles を drop すると全 sender が close され engine-loop が即時 shutdown する。program lifetime まで bind するか、明示的に shutdown を意図する場合のみ drop すること"]
 pub struct ReactorHandles {
     pub reactor: LinuxReactor,
     pub bridge_tx: Sender<Event>,


### PR DESCRIPTION
## Summary

Refine \`#[must_use]\` message and rustdoc on \`ReactorHandles\` to be actionable.

Closes #186.

## Context

PR #183 self-review (type-design dimension) flagged that \`ReactorHandles\` carries a generic \`#[must_use]\` attribute without a refined message guiding callers on the consequence of dropping the value.

## Change

Single file: \`crates/kotoha-engine-reactor-linux/src/lib.rs\` (+14 / -1)

- \`#[must_use]\` message updated from descriptive to actionable
  - Before: \`\"ReactorHandles を drop すると engine-loop が即時 shutdown する\"\`
  - After: \`\"ReactorHandles を drop すると全 sender が close され engine-loop が即時 shutdown する。program lifetime まで bind するか、明示的に shutdown を意図する場合のみ drop すること\"\`
- Rustdoc gains a new \`# Lifetime contract\` section explaining the 3-step drop chain (sender drop → \`select!\` returns \`RecvError\` / \`Event::Shutdown\` → engine-loop exits)

## Deviation from ISSUE proposal

ISSUE #186 originally proposed wording around \"may leak threads\":

> \`#[must_use = \"...dropping it without calling shutdown() may leak threads...\"]\`

The actual semantic is the opposite. \`ReactorHandles\` does not have a \`shutdown()\` method — drop **is** shutdown. The refined message reflects this verified behavior (see \`LinuxReactor::recv()\` \`select!\` arms in \`lib.rs:75-91\` for the disconnect cascade).

## Self-review

- **Security**: N/A — message text only, no logic change
- **Architecture**: aligns ADR 0020 §採択 \`ReactorHandles\` ownership semantics with public-facing API documentation
- **Testing**: N/A — no behavior change to test; \`cargo build\` + \`clippy -D warnings\` confirm message parses cleanly

## Test plan

- [x] \`cargo build -p kotoha-engine-reactor-linux\` clean
- [x] \`cargo clippy -p kotoha-engine-reactor-linux --all-targets -- -D warnings\` clean
- [x] \`cargo test -p kotoha-engine-reactor-linux\` 5 pass / 0 fail
- [x] \`cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers\` no regression
- [x] \`cargo fmt --all -- --check\` clean
- [x] lefthook pre-commit (doc-naming + fmt-check + secrets-scan) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)