### PR TITLE
refactor(engine-core,reactor-linux): abstract crossbeam RecvError via ReactorError (#188)

### DIFF
--- a/crates/kotoha-engine-core/src/reactor/mock.rs
+++ b/crates/kotoha-engine-core/src/reactor/mock.rs
@@ -10,9 +10,7 @@ use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use crossbeam_channel::{RecvError, RecvTimeoutError};
-
-use crate::reactor::{Event, EventReactor};
+use crate::reactor::{Event, EventReactor, ReactorError};
 
 /// queue ベースの `EventReactor` mock。
 ///
@@ -20,8 +18,8 @@ use crate::reactor::{Event, EventReactor};
 ///
 /// - queue が空かつ `closed = false` で `recv()` を呼ぶことは usage error。
 ///   real reactor とは異なり blocking しない(deterministic test 担保のため)。
-///   `debug_assert!` で検出し、release では `Err(RecvError)` を返す。
-/// - `close()` 後の `recv()` / `recv_timeout()` は `Disconnected` 相当を返す。
+///   `debug_assert!` で検出し、release では `Err(ReactorError::Disconnected)` を返す。
+/// - `close()` 後の `recv()` / `recv_timeout()` は `ReactorError::Disconnected` を返す。
 pub struct MockReactor {
     inner: Mutex<MockState>,
 }
@@ -72,30 +70,30 @@ impl Default for MockReactor {
 }
 
 impl EventReactor for MockReactor {
-    fn recv(&self) -> Result<Event, RecvError> {
+    fn recv(&self) -> Result<Event, ReactorError> {
         let mut s = self.lock();
         if let Some(ev) = s.queue.pop_front() {
             return Ok(ev);
         }
         if s.closed {
-            return Err(RecvError);
+            return Err(ReactorError::Disconnected);
         }
         debug_assert!(
             false,
             "MockReactor::recv called on empty queue without close(); \
              test should push events or close before recv"
         );
-        Err(RecvError)
+        Err(ReactorError::Disconnected)
     }
 
-    fn recv_timeout(&self, _timeout: Duration) -> Result<Event, RecvTimeoutError> {
+    fn recv_timeout(&self, _timeout: Duration) -> Result<Event, ReactorError> {
         let mut s = self.lock();
         if let Some(ev) = s.queue.pop_front() {
             Ok(ev)
         } else if s.closed {
-            Err(RecvTimeoutError::Disconnected)
+            Err(ReactorError::Disconnected)
         } else {
-            Err(RecvTimeoutError::Timeout)
+            Err(ReactorError::Timeout)
         }
     }
 }

--- a/crates/kotoha-engine-core/src/reactor/mod.rs
+++ b/crates/kotoha-engine-core/src/reactor/mod.rs
@@ -13,20 +13,46 @@ pub use event::{Event, IBusResetKind, WorkerPayload};
 
 use std::time::Duration;
 
+/// `EventReactor::recv*` が返す OS 非依存の error 型。
+///
+/// `kotoha-engine-core` の port boundary では `crossbeam_channel::RecvError` /
+/// `crossbeam_channel::RecvTimeoutError` を直接露出させない。Linux 実装は
+/// crossbeam の error variant を本 enum へ map する責務を持つ
+/// (`kotoha-engine-reactor-linux::LinuxReactor` impl 参照)。将来 macOS
+/// (kqueue) / Windows (IOCP) 実装が追加されても、それぞれの native error を
+/// 本 enum へ map することで trait 契約は不変に保たれる。
+///
+/// # Variants
+///
+/// - [`ReactorError::Disconnected`] — 全 Sender が drop され event 源が完全に
+///   閉じた状態。`recv` / `recv_timeout` どちらも返しうる
+/// - [`ReactorError::Timeout`] — `recv_timeout` の指定 duration 経過。`recv`
+///   は本 variant を返さない(blocking 仕様のため)
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReactorError {
+    /// 全 Sender drop による reactor 終了状態。
+    #[error("reactor disconnected: all senders dropped")]
+    Disconnected,
+    /// `recv_timeout` の timeout 経過。
+    #[error("reactor recv timed out")]
+    Timeout,
+}
+
 /// engine-loop thread が単一 thread で multiplex する event 受信機構の port。
 ///
 /// # Invariants
 ///
 /// - 実装は `Send + 'static`(engine-loop thread に move される)
 /// - `recv` は `Event::Shutdown` または全 Sender drop を観測したら以降
-///   `Err(crossbeam_channel::RecvError)` を返してよい
+///   [`ReactorError::Disconnected`] を返してよい
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use kotoha_engine_core::reactor::{Event, EventReactor};
+/// use kotoha_engine_core::reactor::{Event, EventReactor, ReactorError};
 ///
-/// fn run<R: EventReactor>(reactor: &R) -> Result<(), crossbeam_channel::RecvError> {
+/// fn run<R: EventReactor>(reactor: &R) -> Result<(), ReactorError> {
 ///     loop {
 ///         match reactor.recv()? {
 ///             Event::Shutdown => break Ok(()),
@@ -40,15 +66,16 @@ pub trait EventReactor: Send + 'static {
     ///
     /// # Errors
     ///
-    /// - 全 Sender が drop された場合 `crossbeam_channel::RecvError`
-    fn recv(&self) -> Result<Event, crossbeam_channel::RecvError>;
+    /// - [`ReactorError::Disconnected`] — 全 Sender が drop された場合
+    ///
+    /// 本 method は [`ReactorError::Timeout`] を返さない(blocking のため)。
+    fn recv(&self) -> Result<Event, ReactorError>;
 
     /// timeout 付き受信。`coalescing window`(spec §7.3)等で利用する。
     ///
     /// # Errors
     ///
-    /// - timeout 経過: `crossbeam_channel::RecvTimeoutError::Timeout`
-    /// - 全 Sender drop: `crossbeam_channel::RecvTimeoutError::Disconnected`
-    fn recv_timeout(&self, timeout: Duration)
-        -> Result<Event, crossbeam_channel::RecvTimeoutError>;
+    /// - [`ReactorError::Timeout`] — 指定 duration 経過(event 不到達)
+    /// - [`ReactorError::Disconnected`] — 全 Sender が drop された場合
+    fn recv_timeout(&self, timeout: Duration) -> Result<Event, ReactorError>;
 }

--- a/crates/kotoha-engine-reactor-linux/src/lib.rs
+++ b/crates/kotoha-engine-reactor-linux/src/lib.rs
@@ -17,8 +17,8 @@
 
 use std::time::Duration;
 
-use crossbeam_channel::{select, unbounded, Receiver, RecvError, RecvTimeoutError, Sender};
-use kotoha_engine_core::reactor::{Event, EventReactor};
+use crossbeam_channel::{select, unbounded, Receiver, Sender};
+use kotoha_engine_core::reactor::{Event, EventReactor, ReactorError};
 
 /// Linux 専用の event reactor 実装。
 ///
@@ -44,9 +44,11 @@ pub struct LinuxReactor {
 /// `ReactorHandles` の drop は次の連鎖を起こす:
 ///
 /// 1. `bridge_tx` / `worker_tx` / `shutdown_tx` が drop される
-/// 2. `LinuxReactor::recv()` の `select!` arm が `RecvError`(全 sender drop 時)
+/// 2. `LinuxReactor::recv()` が [`ReactorError::Disconnected`] (全 sender drop 時)
 ///    または `Ok(Event::Shutdown)`(`shutdown_tx` 経由)を返す
 /// 3. `engine-loop` thread が即時 exit する
+///
+/// [`ReactorError::Disconnected`]: kotoha_engine_core::reactor::ReactorError::Disconnected
 ///
 /// したがって `start()` 戻り値は **program lifetime** まで保持する変数に
 /// bind すること(典型的には `kotoha-bin::main` の local)。明示的な
@@ -86,20 +88,20 @@ pub fn start() -> ReactorHandles {
 }
 
 impl EventReactor for LinuxReactor {
-    fn recv(&self) -> Result<Event, RecvError> {
+    fn recv(&self) -> Result<Event, ReactorError> {
         select! {
-            recv(self.bridge_rx) -> ev => ev,
-            recv(self.worker_rx) -> ev => ev,
+            recv(self.bridge_rx) -> ev => ev.map_err(|_| ReactorError::Disconnected),
+            recv(self.worker_rx) -> ev => ev.map_err(|_| ReactorError::Disconnected),
             recv(self.shutdown_rx) -> _ => Ok(Event::Shutdown),
         }
     }
 
-    fn recv_timeout(&self, timeout: Duration) -> Result<Event, RecvTimeoutError> {
+    fn recv_timeout(&self, timeout: Duration) -> Result<Event, ReactorError> {
         select! {
-            recv(self.bridge_rx) -> ev => ev.map_err(RecvTimeoutError::from),
-            recv(self.worker_rx) -> ev => ev.map_err(RecvTimeoutError::from),
+            recv(self.bridge_rx) -> ev => ev.map_err(|_| ReactorError::Disconnected),
+            recv(self.worker_rx) -> ev => ev.map_err(|_| ReactorError::Disconnected),
             recv(self.shutdown_rx) -> _ => Ok(Event::Shutdown),
-            default(timeout) => Err(RecvTimeoutError::Timeout),
+            default(timeout) => Err(ReactorError::Timeout),
         }
     }
 }

--- a/crates/kotoha-engine-reactor-linux/tests/integration.rs
+++ b/crates/kotoha-engine-reactor-linux/tests/integration.rs
@@ -10,8 +10,7 @@
 
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::RecvTimeoutError;
-use kotoha_engine_core::reactor::{Event, EventReactor, IBusResetKind};
+use kotoha_engine_core::reactor::{Event, EventReactor, IBusResetKind, ReactorError};
 use kotoha_engine_reactor_linux::{start, ReactorHandles};
 
 /// `shutdown_tx` を drop するだけで `Event::Shutdown` が `recv()` から
@@ -90,8 +89,8 @@ fn recv_timeout_returns_timeout_when_quiet() {
     } = start();
     let res = reactor.recv_timeout(Duration::from_millis(20));
     assert!(
-        matches!(res, Err(RecvTimeoutError::Timeout)),
-        "expected RecvTimeoutError::Timeout, got {res:?}"
+        matches!(res, Err(ReactorError::Timeout)),
+        "expected ReactorError::Timeout, got {res:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Introduce \`ReactorError\` at the \`kotoha-engine-core::reactor\` port boundary so the \`EventReactor\` trait no longer leaks \`crossbeam_channel::RecvError\` / \`crossbeam_channel::RecvTimeoutError\`. Closes #188.

## Why

PR #183 self-review (architecture dimension) flagged that \`EventReactor\` is meant to abstract the multiplexing mechanism (Linux uses crossbeam, macOS may use kqueue, Windows IOCP). Exposing crossbeam types in the trait public API couples the trait to the Linux implementation choice.

ADR 0020 §採択 Q3 / Q4 already specified this trait as OS-independent — this PR aligns the type signatures with that intent.

## Change scope

4 files / +60 / -34:

- \`crates/kotoha-engine-core/src/reactor/mod.rs\` — add \`#[non_exhaustive] ReactorError\` enum (\`Disconnected\` + \`Timeout\`, \`thiserror::Error\` derive). Trait \`EventReactor::recv()\` / \`recv_timeout()\` now return \`Result<Event, ReactorError>\`.
- \`crates/kotoha-engine-core/src/reactor/mock.rs\` — drop crossbeam imports, return \`ReactorError::Disconnected\` / \`::Timeout\`.
- \`crates/kotoha-engine-reactor-linux/src/lib.rs\` — drop \`RecvError\` / \`RecvTimeoutError\` from public surface, \`select!\` arms map crossbeam \`Err\` → \`ReactorError::Disconnected\`. \`ReactorHandles\` rustdoc updated with intra-doc link.
- \`crates/kotoha-engine-reactor-linux/tests/integration.rs\` — replace \`RecvTimeoutError::Timeout\` matcher with \`ReactorError::Timeout\`; drop unused crossbeam import.

## Behavior

Identical. The error mapping is 1:1:
- crossbeam \`RecvError\` (any) → \`ReactorError::Disconnected\`
- crossbeam \`RecvTimeoutError::Timeout\` → \`ReactorError::Timeout\`
- crossbeam \`RecvTimeoutError::Disconnected\` → \`ReactorError::Disconnected\`

\`kotoha-bin/src/engine_loop.rs\` was already using \`Err(_)\` catch-all on \`reactor.recv()\`, so no caller change was required there.

## Self-review

- **Security**: N/A — no auth / input-validation / log-injection surface
- **Architecture**: directly addresses ADR 0020 §採択 Q4 trait-abstraction goal; \`EventReactor\` public API now contains zero crossbeam type references
- **Type design**: \`#[non_exhaustive]\` allows future variants (e.g., per-source \`Disconnected { source: ChannelKind }\`) without breaking the API; \`thiserror::Error\` derive supports \`?\` propagation in callers when desired
- **Testing**: integration test \`recv_timeout_returns_timeout_when_quiet\` updated to assert on \`ReactorError::Timeout\`; semantics preserved. \`MockReactor\` unit-test coverage tracked separately as #189 (deferred)
- **Silent failure**: no new error suppression paths

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers\` no regression
- [x] \`cargo fmt --all -- --check\` clean
- [x] lefthook pre-commit (doc-naming + fmt-check + secrets-scan) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)