### PR TITLE
refactor(engine-core): introduce RequestId(u64) newtype for ranker request IDs (#185)

### DIFF
--- a/crates/kotoha-engine-core/src/engine/event.rs
+++ b/crates/kotoha-engine-core/src/engine/event.rs
@@ -12,10 +12,11 @@ use std::sync::Arc;
 
 use crate::cancel::StdCancellationToken;
 use crate::ranker::{ConversionContext, Ranker};
+use crate::request_id::RequestId;
 
 /// engine 主 thread から worker thread へ送る 1 RankRequest。
 pub(crate) struct RankRequest {
-    pub(crate) request_id: u64,
+    pub(crate) request_id: RequestId,
     pub(crate) kana: String,
     pub(crate) ctx: ConversionContext,
     pub(crate) cancel_token: Arc<StdCancellationToken>,

--- a/crates/kotoha-engine-core/src/engine/mod.rs
+++ b/crates/kotoha-engine-core/src/engine/mod.rs
@@ -18,6 +18,7 @@ use crate::ime_engine::IMEEngine;
 use crate::key_event::{KeyEvent, KeyEventResult};
 use crate::ranker::{CandidateUpdate, ConversionContext, ConversionMode, Ranker};
 use crate::reactor::{Event, WorkerPayload};
+use crate::request_id::RequestId;
 
 mod candidates;
 mod commit_history;
@@ -56,7 +57,7 @@ pub enum EngineState {
 /// engine 主 thread side の safety net として `EngineEvent::Candidates` の
 /// `request_id` と照合する。
 pub(crate) struct RequestHandle {
-    pub(crate) id: u64,
+    pub(crate) id: RequestId,
     pub(crate) cancel_token: Arc<StdCancellationToken>,
 }
 
@@ -101,7 +102,7 @@ pub struct KotohaEngine {
     pub(crate) preedit: PreeditBuffer,
     pub(crate) candidates: CandidateBuffer,
     pub(crate) active_request: Option<RequestHandle>,
-    pub(crate) request_id_seed: u64,
+    pub(crate) request_id_seed: RequestId,
     pub(crate) enabled: bool,
     pub(crate) focused: bool,
     /// `RankerWorker` 主 thread と engine 主 thread を結ぶ channel pair および
@@ -144,7 +145,7 @@ impl KotohaEngine {
             preedit: PreeditBuffer::new(),
             candidates: CandidateBuffer::new(),
             active_request: None,
-            request_id_seed: 0,
+            request_id_seed: RequestId::ZERO,
             enabled: false,
             focused: false,
             worker,
@@ -153,8 +154,8 @@ impl KotohaEngine {
     }
 
     /// 次 request_id を採番する(64-bit 単調増加、spec §7.5)。
-    pub(crate) fn next_request_id(&mut self) -> u64 {
-        self.request_id_seed = self.request_id_seed.wrapping_add(1);
+    pub(crate) fn next_request_id(&mut self) -> RequestId {
+        self.request_id_seed = self.request_id_seed.next();
         self.request_id_seed
     }
 
@@ -224,7 +225,7 @@ impl KotohaEngine {
             // 明示 cancel する。さらに preedit + host preedit も clear して
             // UI に stale 文字列が残らないようにする(degrade_to_idle と同等)。
             tracing::error!(
-                request_id,
+                request_id = %request_id,
                 "ranker worker channel closed; engine going to IME-disabled (consecutive panic threshold reached \
                  or worker exited unexpectedly)"
             );
@@ -286,13 +287,13 @@ impl KotohaEngine {
     ///   CandidatesShown へ昇格(spec §5.2 row 7)
     /// - `payload == Error(_)` で `request_id == active_request.id` ⇒
     ///   engine state を Idle に degrade(spec §9.1 row 2)
-    pub fn apply_candidate_update(&mut self, request_id: u64, payload: WorkerPayload) {
+    pub fn apply_candidate_update(&mut self, request_id: RequestId, payload: WorkerPayload) {
         let active_id = self.active_request.as_ref().map(|h| h.id);
         match payload {
             WorkerPayload::Candidates(update) => {
                 if active_id != Some(request_id) {
                     tracing::trace!(
-                        request_id,
+                        request_id = %request_id,
                         ?active_id,
                         "discarding stale Candidates from worker (request_id mismatch)"
                     );
@@ -304,12 +305,12 @@ impl KotohaEngine {
             }
             WorkerPayload::Error(error) => {
                 let sanitized = sanitize_log_text(&error);
-                tracing::error!(request_id, error = %sanitized, "ranker worker error");
+                tracing::error!(request_id = %request_id, error = %sanitized, "ranker worker error");
                 if active_id == Some(request_id) {
                     self.degrade_to_idle();
                 } else {
                     tracing::trace!(
-                        request_id,
+                        request_id = %request_id,
                         ?active_id,
                         "ranker worker error is for stale request, no degrade"
                     );
@@ -904,7 +905,7 @@ mod apply_candidate_update_tests {
 
     /// 共通 helper:noop ranker / stub writer / host bridge で engine を組む。
     /// 各 test は active_request を手動で立てて apply_candidate_update を呼ぶ。
-    fn build_engine_with_active_request(active_id: u64) -> (KotohaEngine, MockHostBridge) {
+    fn build_engine_with_active_request(active_id: RequestId) -> (KotohaEngine, MockHostBridge) {
         struct NoopRanker;
         impl crate::Ranker for NoopRanker {
             fn rank(
@@ -962,9 +963,9 @@ mod apply_candidate_update_tests {
 
     #[test]
     fn candidates_with_matching_id_apply_buffer_and_notify_host_in_live() {
-        let (mut engine, host) = build_engine_with_active_request(42);
+        let (mut engine, host) = build_engine_with_active_request(RequestId::new(42));
         engine.apply_candidate_update(
-            42,
+            RequestId::new(42),
             WorkerPayload::Candidates(CandidateUpdate::Replace(vec![Candidate::new("蚊", -1.0)])),
         );
         assert_eq!(engine.candidate_count_for_test(), 1);
@@ -981,10 +982,10 @@ mod apply_candidate_update_tests {
 
     #[test]
     fn candidates_with_mismatched_id_are_silently_discarded() {
-        let (mut engine, host) = build_engine_with_active_request(42);
+        let (mut engine, host) = build_engine_with_active_request(RequestId::new(42));
         // 別 id の output:state 変化なし、host 通知なし。
         engine.apply_candidate_update(
-            999,
+            RequestId::new(999),
             WorkerPayload::Candidates(CandidateUpdate::Replace(vec![Candidate::new(
                 "stale", -1.0,
             )])),
@@ -1004,8 +1005,11 @@ mod apply_candidate_update_tests {
 
     #[test]
     fn worker_error_with_matching_id_degrades_to_idle() {
-        let (mut engine, host) = build_engine_with_active_request(42);
-        engine.apply_candidate_update(42, WorkerPayload::Error("timeout".to_string()));
+        let (mut engine, host) = build_engine_with_active_request(RequestId::new(42));
+        engine.apply_candidate_update(
+            RequestId::new(42),
+            WorkerPayload::Error("timeout".to_string()),
+        );
         assert_eq!(engine.state_for_test(), EngineState::Idle);
         assert_eq!(
             engine.preedit_for_test(),
@@ -1032,9 +1036,12 @@ mod apply_candidate_update_tests {
 
     #[test]
     fn worker_error_with_mismatched_id_does_not_degrade() {
-        let (mut engine, host) = build_engine_with_active_request(42);
+        let (mut engine, host) = build_engine_with_active_request(RequestId::new(42));
         let host_op_count_before = host.operations().len();
-        engine.apply_candidate_update(999, WorkerPayload::Error("stale".to_string()));
+        engine.apply_candidate_update(
+            RequestId::new(999),
+            WorkerPayload::Error("stale".to_string()),
+        );
         // state は LiveConverting のまま、preedit は維持される。
         assert_eq!(engine.state_for_test(), EngineState::LiveConverting);
         assert_eq!(engine.preedit_for_test(), "か");

--- a/crates/kotoha-engine-core/src/engine/worker.rs
+++ b/crates/kotoha-engine-core/src/engine/worker.rs
@@ -22,6 +22,7 @@ use kotoha_core::Candidate;
 use crate::cancel::CancellationToken;
 use crate::ranker::{CandidateUpdate, ConversionMode, RankerOutput};
 use crate::reactor::{Event, WorkerPayload};
+use crate::request_id::RequestId;
 
 use super::event::RankRequest;
 
@@ -91,9 +92,12 @@ pub(crate) fn spawn_worker(
 
 /// engine-loop receiver が drop された場合に worker_loop を即時終了させる helper。
 /// `tx_event.send` が `Err` を返したら debug log を残して `true` を返す。
-fn try_send_event(tx_event: &Sender<Event>, ev: Event, request_id: u64) -> bool {
+fn try_send_event(tx_event: &Sender<Event>, ev: Event, request_id: RequestId) -> bool {
     if tx_event.send(ev).is_err() {
-        tracing::debug!(request_id, "engine-loop receiver dropped; worker exiting");
+        tracing::debug!(
+            request_id = %request_id,
+            "engine-loop receiver dropped; worker exiting"
+        );
         return true;
     }
     false
@@ -129,7 +133,7 @@ fn worker_loop(rx_request: Receiver<RankRequest>, tx_event: Sender<Event>) {
             Err(payload) => {
                 let msg = panic_message_from(&payload);
                 tracing::error!(
-                    request_id,
+                    request_id = %request_id,
                     panic = %msg,
                     "worker_loop body panicked outside Ranker::rank"
                 );
@@ -188,7 +192,7 @@ fn handle_one_request(req: RankRequest, tx_event: &Sender<Event>) -> IterationOu
         Ok(Err(e)) => (Err(format!("ranker error: {e}")), false),
         Err(panic_payload) => {
             let msg = panic_message_from(&panic_payload);
-            tracing::error!(request_id, panic = %msg, "ranker panicked");
+            tracing::error!(request_id = %request_id, panic = %msg, "ranker panicked");
             (Err(format!("ranker panicked: {msg}")), true)
         }
     };

--- a/crates/kotoha-engine-core/src/lib.rs
+++ b/crates/kotoha-engine-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod key_event;
 pub mod learning_port;
 pub mod ranker;
 pub mod reactor;
+pub mod request_id;
 pub mod sanitize;
 
 #[cfg(feature = "test-helpers")]
@@ -51,3 +52,4 @@ pub use ranker::{
     CandidateUpdate, ConversionContext, ConversionMode, Ranker, RankerError, RankerOutput,
 };
 pub use reactor::{Event, EventReactor, IBusResetKind, WorkerPayload};
+pub use request_id::RequestId;

--- a/crates/kotoha-engine-core/src/reactor/event.rs
+++ b/crates/kotoha-engine-core/src/reactor/event.rs
@@ -6,6 +6,7 @@
 
 use crate::key_event::KeyEvent;
 use crate::ranker::CandidateUpdate;
+use crate::request_id::RequestId;
 
 /// engine-loop thread が単一 thread で multiplex する全 event source の sum 型。
 ///
@@ -33,7 +34,7 @@ pub enum Event {
     /// ranker-worker thread が生成した候補 update + worker error。
     /// 旧 `EngineEvent::Candidates` / `EngineEvent::WorkerError` を統合した形。
     WorkerOutput {
-        request_id: u64,
+        request_id: RequestId,
         payload: WorkerPayload,
     },
 

--- a/crates/kotoha-engine-core/src/request_id.rs
+++ b/crates/kotoha-engine-core/src/request_id.rs
@@ -1,0 +1,122 @@
+//! `RequestId` — engine ⇄ ranker-worker 経路で使う request 識別子の newtype。
+//!
+//! 旧 bare `u64` は user ID / candidate index などの他の数値と type system 上
+//! 区別できず、誤って swap してもコンパイルが通る surface だった。本 newtype
+//! で「これは ranker request の識別子である」という意図を型に昇格させる。
+//!
+//! # 採番セマンティクス
+//!
+//! - 単調増加(`u64::wrapping_add(1)`)。`u64::MAX` で 0 へ折り返す。実機の
+//!   IME 用途では 1 keystroke / 1 採番として 64 bit 空間を消費し切るには
+//!   およそ 10^11 年要するため、wrap 衝突の現実的リスクは無い
+//! - `KotohaEngine` の `request_id_seed` は engine-loop thread が単独所有する
+//!   ため、`&mut self` 経路で `next()` を呼ぶ
+//! - 将来 atomic seed が必要になった場合のために `next_from_atomic` を提供する
+//!   が、現状の単一 thread モデルでは使用しない
+
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// engine が発行する ranker request の単調増加 ID。
+///
+/// # Invariants
+///
+/// - `RequestId(0)` は `Default::default()` の値であり、未採番状態を示す
+///   sentinel として使ってよい(spec §7.5)。最初の採番は `next()` で
+///   `RequestId(1)` から始まる
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RequestId(u64);
+
+impl RequestId {
+    /// 未採番状態を示す sentinel(`RequestId(0)`)。
+    pub const ZERO: Self = Self(0);
+
+    /// raw `u64` から構築する(test fixture / migration path 用)。
+    ///
+    /// production code では `KotohaEngine::next_request_id()` 経由で取得する
+    /// のが原則であり、本 constructor は test と外部 ID の取り込みに限定する。
+    #[must_use]
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// 内部 `u64` を取り出す(log / metric / FFI 境界で必要時のみ)。
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// 次 ID を返す(`u64::wrapping_add(1)`)。
+    ///
+    /// 単一 thread 採番(`KotohaEngine::next_request_id`)で利用する。
+    /// 複数 thread から共有する seed に対しては `next_from_atomic` を使うこと。
+    #[must_use]
+    pub const fn next(self) -> Self {
+        Self(self.0.wrapping_add(1))
+    }
+
+    /// `AtomicU64` を seed として次 ID を採番する(thread-safe)。
+    ///
+    /// 戻り値は採番後の値 (= `seed.fetch_add(1) + 1`)。`Ordering::Relaxed`
+    /// で十分(因果関係は engine-loop 側 channel send/recv で確立される)。
+    #[must_use]
+    pub fn next_from_atomic(seed: &AtomicU64) -> Self {
+        Self(seed.fetch_add(1, Ordering::Relaxed).wrapping_add(1))
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<RequestId> for u64 {
+    fn from(id: RequestId) -> Self {
+        id.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(RequestId::default(), RequestId::ZERO);
+        assert_eq!(RequestId::default().as_u64(), 0);
+    }
+
+    #[test]
+    fn next_is_monotonic_with_wrapping() {
+        let mut id = RequestId::ZERO;
+        id = id.next();
+        assert_eq!(id.as_u64(), 1);
+        id = id.next();
+        assert_eq!(id.as_u64(), 2);
+
+        let max = RequestId::new(u64::MAX);
+        assert_eq!(max.next(), RequestId::ZERO);
+    }
+
+    #[test]
+    fn next_from_atomic_returns_post_increment_value() {
+        let seed = AtomicU64::new(0);
+        let first = RequestId::next_from_atomic(&seed);
+        let second = RequestId::next_from_atomic(&seed);
+        assert_eq!(first.as_u64(), 1);
+        assert_eq!(second.as_u64(), 2);
+    }
+
+    #[test]
+    fn display_renders_inner_u64() {
+        assert_eq!(format!("{}", RequestId::new(42)), "42");
+    }
+
+    #[test]
+    fn into_u64_round_trip() {
+        let id = RequestId::new(7);
+        let raw: u64 = id.into();
+        assert_eq!(raw, 7);
+    }
+}

--- a/crates/kotoha-engine-reactor-linux/tests/integration.rs
+++ b/crates/kotoha-engine-reactor-linux/tests/integration.rs
@@ -11,6 +11,7 @@
 use std::time::{Duration, Instant};
 
 use kotoha_engine_core::reactor::{Event, EventReactor, IBusResetKind, ReactorError};
+use kotoha_engine_core::request_id::RequestId;
 use kotoha_engine_reactor_linux::{start, ReactorHandles};
 
 /// `shutdown_tx` を drop するだけで `Event::Shutdown` が `recv()` から
@@ -114,7 +115,7 @@ fn bursty_events_are_all_delivered() {
                 .expect("bridge send");
             worker_clone
                 .send(Event::WorkerOutput {
-                    request_id: i,
+                    request_id: RequestId::new(i),
                     payload: kotoha_engine_core::reactor::WorkerPayload::Error("bench".into()),
                 })
                 .expect("worker send");


### PR DESCRIPTION
## Summary

Replace bare \`u64\` across the engine ⇄ ranker-worker channel with a \`RequestId\` newtype so the type system enforces \"this is a ranker request identifier\". Closes #185.

## Why

PR #183 self-review (type-design dimension) flagged that bare \`u64\` invites accidental swap with other numeric IDs (user ID, candidate index, etc.). The type system currently cannot enforce \"this is a request identifier.\"

## Change scope (7 files / +164 / -26)

### New module

\`crates/kotoha-engine-core/src/request_id.rs\` (122 lines incl. tests):
- \`RequestId(u64)\` with \`Debug\` / \`Clone\` / \`Copy\` / \`Default\` / \`PartialEq\` / \`Eq\` / \`PartialOrd\` / \`Ord\` / \`Hash\` + \`Display\` + \`From<RequestId> for u64\`
- \`const ZERO\` sentinel; \`Default == ZERO\`
- \`const new(raw: u64)\`, \`const as_u64()\`, \`const next()\` (\`wrapping_add(1)\`)
- \`next_from_atomic(&AtomicU64)\` for future thread-shared seed scenarios
- 5 unit tests

### Migration sites

- \`engine/event.rs\` — \`RankRequest.request_id\`
- \`reactor/event.rs\` — \`Event::WorkerOutput.request_id\`
- \`engine/mod.rs\` — \`RequestHandle.id\` / \`KotohaEngine.request_id_seed\` (init \`RequestId::ZERO\`) / \`next_request_id() -> RequestId\` / \`apply_candidate_update(request_id: RequestId, ...)\` / 4 tests use \`RequestId::new(N)\`
- \`engine/worker.rs\` — \`try_send_event(request_id: RequestId, ...)\`
- \`reactor-linux/tests/integration.rs\` — \`Event::WorkerOutput { request_id: RequestId::new(i), ... }\`

### tracing macros

\`tracing::*!(request_id, ...)\` → \`tracing::*!(request_id = %request_id, ...)\` (Display formatting, unchanged numeric rendering).

### Caller compatibility

\`kotoha-bin/src/engine_loop.rs\` required **no changes**. The destructure-then-pass pattern works as both ends now operate on \`RequestId\`.

## Self-review

- **Type design**: bare \`u64\` swap risk eliminated; \`Default\` gives \`RequestId::ZERO\` matching the existing seed init
- **Architecture**: no behavioral change; pure type refinement
- **Testing**: 5 new unit tests; 0 regression
- **Silent failure**: tracing rendering unchanged
- **Performance**: zero-cost (Copy + const fn accessors)

## Deviation from ISSUE

ISSUE #185 suggested \`kotoha-engine-core::types\` location. This PR uses top-level \`kotoha_engine_core::request_id\` (no existing \`types\` module; CLAUDE.md encourages file splitting). \`next_from_atomic\` is added with test coverage despite no current consumer (CLAUDE.md design-priority: err toward expressive abstraction).

## Test plan

- [x] \`cargo build --workspace --all-features\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers\` no failures (5 new \`RequestId\` tests, 0 regression)
- [x] \`cargo fmt --all -- --check\` clean
- [x] lefthook pre-commit + pre-push pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)