### PR TITLE
feat(engine-ibus,bin): production IBus listener via zbus #[interface] + 100ms response channel (#195)

### DIFF
--- a/crates/kotoha-bin/src/engine_loop.rs
+++ b/crates/kotoha-bin/src/engine_loop.rs
@@ -41,8 +41,11 @@ use kotoha_engine_core::reactor::{Event, EventReactor, IBusResetKind};
 pub(crate) fn run<R: EventReactor>(mut engine: KotohaEngine, reactor: R) -> anyhow::Result<()> {
     loop {
         match reactor.recv() {
-            Ok(Event::IBusKey(key)) => {
-                let _result = engine.process_key_event(key);
+            Ok(Event::IBusKey { event, respond }) => {
+                let result = engine.process_key_event(event);
+                // listener が timeout した場合 send Err は ignore
+                // (= keystroke は app に forward 済、spec §5.2 / p3-b-ibus-listener.md)
+                let _ = respond.send(result);
             }
             Ok(Event::IBusReset(kind)) => match kind {
                 IBusResetKind::FocusOut => engine.focus_out(),

--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -280,10 +280,10 @@ fn run_ibus() -> anyhow::Result<()> {
     )
     .context("spawn ranker worker thread")?;
 
-    // 11. listener thread 用の session bus connection を別途 open する
-    //     (IBusHostBridge は内部で別 connection を持つため独立)。
-    let listener_connection = zbus::blocking::Connection::session()
-        .context("open session bus for D-Bus listener thread")?;
+    // 11. listener shutdown handle pair を生成する。
+    //     listener::run は内部で `blocking::connection::Builder::session()` から
+    //     session bus connection を確立 + serve_at + name するため、main 側で
+    //     pre-built connection を渡す必要はない(Phase 3-B B6-b #195、ADR 0021)。
     let (listener_shutdown, listener_observer) =
         kotoha_engine_ibus::listener::ListenerShutdown::new();
 
@@ -315,9 +315,7 @@ fn run_ibus() -> anyhow::Result<()> {
     //     move し、engine 状態を完全所有させる。
     let listener_handle = std::thread::Builder::new()
         .name("kotoha-dbus-listener".into())
-        .spawn(move || {
-            kotoha_engine_ibus::listener::run(listener_connection, bridge_tx, listener_observer)
-        })
+        .spawn(move || kotoha_engine_ibus::listener::run(bridge_tx, listener_observer))
         .context("spawn dbus-listener thread")?;
 
     let engine_loop_handle = std::thread::Builder::new()

--- a/crates/kotoha-engine-core/src/reactor/event.rs
+++ b/crates/kotoha-engine-core/src/reactor/event.rs
@@ -4,7 +4,9 @@
 //! source(D-Bus / worker / shutdown / 将来の notification)を単一 sum 型に集約する。
 //! 詳細は spec `docs/specs/_uncategorized/p3-a-ibus-engine.md` §7.1 / ADR 0020 §採択 Q4。
 
-use crate::key_event::KeyEvent;
+use crossbeam_channel::Sender;
+
+use crate::key_event::{KeyEvent, KeyEventResult};
 use crate::ranker::CandidateUpdate;
 use crate::request_id::RequestId;
 
@@ -26,7 +28,15 @@ use crate::request_id::RequestId;
 pub enum Event {
     /// IBus session bus で受信した key event。
     /// `kotoha-dbus-listener` thread が `Sender<Event>::send` で engine-loop に届ける。
-    IBusKey(KeyEvent),
+    ///
+    /// `respond` は engine-loop が `KeyEventResult`(`Consumed` / `Forwarded`)を返す
+    /// bounded(1) channel。listener は recv_timeout(100ms) で待機し timeout 時は
+    /// `Forwarded` 相当として bool false を返す
+    /// (spec §6 / `docs/specs/_uncategorized/p3-b-ibus-listener.md`)。
+    IBusKey {
+        event: KeyEvent,
+        respond: Sender<KeyEventResult>,
+    },
 
     /// IBus focus_out / reset / disable 系の signal。
     IBusReset(IBusResetKind),

--- a/crates/kotoha-engine-ibus/src/lib.rs
+++ b/crates/kotoha-engine-ibus/src/lib.rs
@@ -31,6 +31,7 @@ pub mod keysym;
 pub mod listener;
 pub mod lookup_table;
 pub(crate) mod proxy;
+pub(crate) mod service;
 pub(crate) mod types;
 
 /// `crates/kotoha-engine-ibus/src/types.rs` の wire-format type を doc test

--- a/crates/kotoha-engine-ibus/src/listener.rs
+++ b/crates/kotoha-engine-ibus/src/listener.rs
@@ -1,32 +1,18 @@
-//! D-Bus signal listener loop(Phase 3-B B3 / ADR 0020 §採択 Q4)。
+//! D-Bus signal listener loop(Phase 3-B B3 + B6-b / ADR 0020 + ADR 0021)。
 //!
-//! ADR 0020 §採択 Q4 の `kotoha-dbus-listener` thread を担う。本 module は
-//! 4-thread topology の listener slot を埋める architectural skeleton を提供する。
+//! `kotoha-dbus-listener` thread の main を担う。zbus 5 `blocking::connection::Builder`
+//! 経由で `org.freedesktop.IBus.Engine` interface に [`crate::service::KotohaEngineService`]
+//! を登録し、IBus daemon からの method 呼び出しを 6 method に分岐 dispatch する。
 //!
-//! # Status (rev3, 2026-05-06)
+//! # Decoded methods
 //!
-//! 本 PR では「listener thread を spawn して bridge channel と engine-loop を
-//! 接続する architectural wiring」までを完了し、実 zbus message stream の
-//! decode は B6 (#136) manual smoke で完成させる。理由:
-//!
-//! - zbus 5 の `blocking::Connection` は MessageStream を直接提供せず、
-//!   `interface!` macro 経由 service registration もしくは async API + block_on
-//!   が必要で、本 PR scope (B0h-f + B3 architectural rework) を超える
-//! - IBus daemon が本 process に向けてメッセージを routing するには、別途
-//!   `RequestName` + IBus engine factory 登録が必要(spec §11 / B6 manual smoke)
-//! - 本 PR の目標(`drain_events_blocking` 撤去 + 4-thread topology)は
-//!   listener stub でも検証可能(`Event::Shutdown` 経路で thread 連携を観測)
-//!
-//! 完成形は ADR 0020 §影響範囲 ~120 lines の見積もり通り、本 module を
-//! 拡張して `zbus::interface!` macro で IBus engine interface を impl し、
-//! 各 method handler が bridge_tx に Event を送る形になる予定。
-//!
-//! # Decoded methods (planned, B6 で完成)
-//!
-//! - `ProcessKeyEvent(u keyval, u keycode, u state) -> b` → `Event::IBusKey(KeyEvent)`
+//! - `ProcessKeyEvent(u keyval, u keycode, u state) -> b` → `Event::IBusKey { event, respond }`
 //! - `Reset()` → `Event::IBusReset(IBusResetKind::Reset)`
 //! - `FocusOut()` → `Event::IBusReset(IBusResetKind::FocusOut)`
 //! - `Disable()` → `Event::IBusReset(IBusResetKind::Disable)`
+//! - `FocusIn()` / `Enable()` — daemon 側 introspection 互換 no-op stub
+//!
+//! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md`、ADR 0021。
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -102,149 +88,61 @@ impl Clone for ShutdownObserver {
     }
 }
 
-/// 本 PR の listener stub 起動を許可する env var 名。
-///
-/// production 環境では本 var 未設定で `run()` は起動拒否(spec §9.3 fail-loud)。
-/// 開発・CI 用途では `=1` を export して stub を許可する。Phase 3-B B6 で実 zbus
-/// 経路完成時に env var 自体は不要となる(本 const も削除予定)。
-pub const KOTOHA_ALLOW_LISTENER_STUB_ENV: &str = "KOTOHA_ALLOW_LISTENER_STUB";
-
-/// listener stub を許可する env var 値の判定。
-fn allow_listener_stub() -> bool {
-    matches!(
-        std::env::var(KOTOHA_ALLOW_LISTENER_STUB_ENV).as_deref(),
-        Ok("1" | "true" | "yes")
-    )
-}
-
-/// listener が `run()` 起動拒否したことを示す sentinel。
-#[derive(Debug, thiserror::Error)]
-#[error(
-    "B3 listener is a non-functional stub (Phase 3-B B0h-f rev3 / ADR 0020 §影響). \
-     The IME will not deliver any key events to the engine in this state. \
-     Set {KOTOHA_ALLOW_LISTENER_STUB_ENV}=1 only for development / CI smoke runs. \
-     Full implementation tracked in ISSUE #136 B6 manual smoke."
-)]
-pub struct ListenerStubRefused;
-
-/// D-Bus listener thread の main loop(B3 architectural skeleton)。
+/// D-Bus listener thread の main loop。
 ///
 /// # Preconditions
 ///
-/// - `_connection` は session bus に接続済(`zbus::blocking::Connection::session()`)
 /// - `bridge_tx` は engine-loop thread の `EventReactor` bridge channel
-/// - `shutdown` は main thread が `request()` で停止指示する flag
+/// - `shutdown` は main thread が `ListenerShutdown::request()` で停止指示する
+///   observer handle(#187 split-handle、#197 SIGTERM hook 経由でも request される)
 ///
 /// # Postconditions
 ///
-/// - `shutdown.load() == true` を観測したら `Ok(())` で return する
-/// - `bridge_tx.send()` が `Err` を返したら(engine-loop drop で channel close)
-///   `Ok(())` で return する
+/// - `shutdown.is_shutting_down()` を観測したら Connection を drop して `Ok(())`
+///   で return する(Connection drop で zbus internal smol executor が exit、
+///   bus name が release)
+/// - Connection 構築失敗(session bus 不在、bus name 占有等)時は Err propagate
 ///
 /// # Errors
 ///
-/// - [`ListenerStubRefused`] — `KOTOHA_ALLOW_LISTENER_STUB` が未設定で stub
-///   実装の起動を拒否した場合(spec §9.3 fail-loud / B6 完成までの safety net)
+/// - `zbus::Error` — session bus 接続 / `serve_at` / `RequestName` 失敗
 ///
-/// # Stub behavior
-///
-/// 本 PR では実 zbus message stream の decode は実装せず、shutdown flag を
-/// poll するだけのループで thread structure を establishing する。実装完了は
-/// B6 manual smoke で行う(spec §11 / ISSUE #136)。
-pub fn run(
-    _connection: zbus::blocking::Connection,
-    bridge_tx: Sender<Event>,
-    shutdown: ShutdownObserver,
-) -> anyhow::Result<()> {
-    if !allow_listener_stub() {
-        tracing::error!(
-            env_var = KOTOHA_ALLOW_LISTENER_STUB_ENV,
-            "dbus-listener refusing to start: this build ships only the B3 architectural \
-             skeleton with no zbus message decode. Set {KOTOHA_ALLOW_LISTENER_STUB_ENV}=1 to \
-             allow stub startup (development / CI only). Full implementation tracked in \
-             ISSUE #136 B6 manual smoke."
-        );
-        return Err(anyhow::Error::from(ListenerStubRefused));
-    }
-    tracing::error!(
-        "dbus-listener started in STUB mode (KOTOHA_ALLOW_LISTENER_STUB=1). \
-         No D-Bus method calls will be decoded; the IME will NOT receive key events \
-         until B6 lands. Production deployments must NOT export this env var."
+/// 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §3 / §7。
+pub fn run(bridge_tx: Sender<Event>, shutdown: ShutdownObserver) -> anyhow::Result<()> {
+    use crate::proxy::{IBUS_ENGINE_BUS_NAME, IBUS_ENGINE_OBJECT_PATH};
+    use crate::service::KotohaEngineService;
+
+    tracing::info!(
+        bus_name = IBUS_ENGINE_BUS_NAME,
+        object_path = IBUS_ENGINE_OBJECT_PATH,
+        "dbus-listener starting (zbus blocking::Builder + #[interface] dispatcher)"
     );
+
+    let service = KotohaEngineService { bridge_tx };
+    let _connection = zbus::blocking::connection::Builder::session()?
+        .serve_at(IBUS_ENGINE_OBJECT_PATH, service)?
+        .name(IBUS_ENGINE_BUS_NAME)?
+        .build()?;
+
+    // Connection's internal smol executor dispatches incoming method calls in a
+    // background thread. We just hold the connection alive and poll shutdown.
     while !shutdown.is_shutting_down() {
-        // bridge_tx が disconnected ならば engine-loop が落ちた合図。即時 exit。
-        if bridge_tx.is_full() {
-            // unbounded channel は is_full = false が普通。本 check は将来
-            // bounded に切替えた際の back-pressure 観測点として残しておく。
-        }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
-    tracing::info!("dbus-listener received shutdown signal, exiting");
+    tracing::info!("dbus-listener received shutdown signal, dropping connection and exiting");
+    // _connection drops here: zbus releases bus name + stops dispatching.
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    //! Phase 3-B B0h-f rev3 (ADR 0020) review Critical 修正:listener stub の
-    //! shutdown ordering と fail-loud 起動拒否を pin する。
+    //! Phase 3-B B6-b (#195) — ShutdownObserver split-handle (#187) と
+    //! `ListenerShutdown::clone` (#197 SIGTERM hook) の不変条件 pin。
     //!
-    //! `KOTOHA_ALLOW_LISTENER_STUB` env var の設定値ごとに run() の戻り値を観測する。
+    //! `run()` 自体の挙動 test は dbus session bus を要求するため
+    //! `crates/kotoha-engine-ibus/tests/integration.rs` (`#[ignore]`) で扱う。
 
     use super::*;
-    use crossbeam_channel::unbounded;
-    use std::time::Duration;
-
-    fn dummy_connection() -> zbus::blocking::Connection {
-        zbus::blocking::Connection::session().expect("test requires session bus")
-    }
-
-    /// `KOTOHA_ALLOW_LISTENER_STUB` 未設定で `run()` は即時 `ListenerStubRefused` を返す。
-    #[test]
-    #[ignore = "依存: dbus session bus available; CI で flaky のため opt-in"]
-    fn run_refuses_to_start_without_env_var() {
-        // 本 test は env var を unsafely 操作するため、他 test と並列実行 unsafe。
-        // `cargo test -- --test-threads=1` で動かすか、本 test を ignore のままに留める。
-        unsafe {
-            std::env::remove_var(KOTOHA_ALLOW_LISTENER_STUB_ENV);
-        }
-        let conn = dummy_connection();
-        let (tx, _rx) = unbounded();
-        let (_trigger, observer) = ListenerShutdown::new();
-        let result = run(conn, tx, observer);
-        assert!(
-            result.is_err(),
-            "run() should reject when env var unset, got Ok"
-        );
-    }
-
-    /// `KOTOHA_ALLOW_LISTENER_STUB=1` + `ListenerShutdown::request()` で
-    /// listener thread が ~200ms 以内に `Ok(())` で return する。
-    #[test]
-    #[ignore = "依存: dbus session bus available; CI で flaky のため opt-in"]
-    fn run_exits_within_200ms_after_shutdown_request() {
-        unsafe {
-            std::env::set_var(KOTOHA_ALLOW_LISTENER_STUB_ENV, "1");
-        }
-        let conn = dummy_connection();
-        let (tx, _rx) = unbounded();
-        let (shutdown_handle, observer) = ListenerShutdown::new();
-        let listener_thread = std::thread::spawn(move || run(conn, tx, observer));
-
-        // 50ms poll cycle + 余裕で 80ms 後 request、150ms 待って exit を観測。
-        std::thread::sleep(Duration::from_millis(80));
-        shutdown_handle.request();
-        let start = std::time::Instant::now();
-        let result = listener_thread.join().expect("thread join");
-        let elapsed = start.elapsed();
-        assert!(result.is_ok(), "expected Ok(()), got {result:?}");
-        assert!(
-            elapsed < Duration::from_millis(200),
-            "listener should exit within 200ms after shutdown request, took {elapsed:?}"
-        );
-        unsafe {
-            std::env::remove_var(KOTOHA_ALLOW_LISTENER_STUB_ENV);
-        }
-    }
 
     /// `ShutdownObserver::is_shutting_down()` は trigger からの `request()` を
     /// 観測する。本 test は dbus session bus に依存せず実行可能。

--- a/crates/kotoha-engine-ibus/src/proxy.rs
+++ b/crates/kotoha-engine-ibus/src/proxy.rs
@@ -56,13 +56,11 @@ pub(crate) const IBUS_ENGINE_INTERFACE: &str = "org.freedesktop.IBus.Engine";
 ///
 /// 同 UID で同名 process が既に publish していると `Builder::name(...)` が `Err` を返し、
 /// listener thread の起動が失敗する。
-#[allow(dead_code)] // Task 4 で listener::run から参照される
 pub(crate) const IBUS_ENGINE_BUS_NAME: &str = "org.freedesktop.IBus.Engine.Kotoha";
 
 /// Kotoha engine service の D-Bus object path(spec §7.1)。
 ///
 /// `Builder::serve_at(...)` でこの path に `KotohaEngineService` を登録する。
-#[allow(dead_code)] // Task 4 で listener::run から参照される
 pub(crate) const IBUS_ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
 
 /// `UpdatePreeditText` signal member 名(IBus 1.5.x 仕様)。

--- a/crates/kotoha-engine-ibus/src/proxy.rs
+++ b/crates/kotoha-engine-ibus/src/proxy.rs
@@ -52,6 +52,19 @@ use crate::types::{IBusLookupTable, IBusText};
 /// 対応する仕様: IBus 1.5.x `bus/inputcontext.c` の `BUS_INPUT_CONTEXT_GET_INTERFACE`。
 pub(crate) const IBUS_ENGINE_INTERFACE: &str = "org.freedesktop.IBus.Engine";
 
+/// Kotoha が `RequestName` で取得する IBus engine bus name(spec §7.1)。
+///
+/// 同 UID で同名 process が既に publish していると `Builder::name(...)` が `Err` を返し、
+/// listener thread の起動が失敗する。
+#[allow(dead_code)] // Task 4 で listener::run から参照される
+pub(crate) const IBUS_ENGINE_BUS_NAME: &str = "org.freedesktop.IBus.Engine.Kotoha";
+
+/// Kotoha engine service の D-Bus object path(spec §7.1)。
+///
+/// `Builder::serve_at(...)` でこの path に `KotohaEngineService` を登録する。
+#[allow(dead_code)] // Task 4 で listener::run から参照される
+pub(crate) const IBUS_ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
+
 /// `UpdatePreeditText` signal member 名(IBus 1.5.x 仕様)。
 pub(crate) const MEMBER_UPDATE_PREEDIT_TEXT: &str = "UpdatePreeditText";
 /// `CommitText` signal member 名。

--- a/crates/kotoha-engine-ibus/src/service.rs
+++ b/crates/kotoha-engine-ibus/src/service.rs
@@ -1,0 +1,232 @@
+//! `KotohaEngineService` — IBus engine method dispatcher。
+//!
+//! Phase 3-B B6-b (#195) で導入。zbus 5 `#[interface]` macro 経由で
+//! `org.freedesktop.IBus.Engine` interface の 6 method を実装する。
+//!
+//! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §4 / §5。
+
+use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use zbus::interface;
+
+use kotoha_engine_core::key_event::KeyEventResult;
+use kotoha_engine_core::reactor::{Event, IBusResetKind};
+
+use crate::keysym;
+
+/// IBus engine method dispatcher。
+///
+/// `bridge_tx` 経由で engine-loop thread に Event を届ける。state を保持しない
+/// (ADR 0020 §採択 Q4 lock-free 原則)。zbus が internal smol executor で本 struct
+/// の method を dispatch する。
+///
+/// # 配置
+///
+/// `pub(crate)` で crate 外部に export しない。`listener::run` 内で構築・登録される。
+#[allow(dead_code)] // Task 4 で listener::run から参照される
+pub(crate) struct KotohaEngineService {
+    /// engine-loop thread に Event を送る単方向 channel。
+    pub(crate) bridge_tx: Sender<Event>,
+}
+
+/// `process_key_event` の response 待機 timeout。
+///
+/// 通常 ~1ms / heavy ~10ms / recovery ~50ms 全てを吸収しつつ、bug 状態 (>100ms) のみ
+/// fallback fire するように設定(spec §6.1)。
+#[allow(dead_code)] // Task 4 で listener から間接参照(本 module 内で process_key_event が利用)
+const PROCESS_KEY_EVENT_TIMEOUT: Duration = Duration::from_millis(100);
+
+// `#[interface]` macro は trait dispatch handler を生成する。本 impl の method は
+// macro 経由でのみ呼ばれるため、static dead_code analysis では不可視。Task 4 で
+// listener::run が本 service を Builder::serve_at に渡し production 経路が成立する
+// が、それでも Rust 側の lint は method を未使用扱いするため allow を維持する。
+#[allow(dead_code)]
+#[interface(name = "org.freedesktop.IBus.Engine")]
+impl KotohaEngineService {
+    /// `ProcessKeyEvent(u keyval, u keycode, u state) -> b`
+    ///
+    /// IBus 1.5.x 仕様準拠。戻り値 true は Kotoha が消費した、false は app に forward する。
+    fn process_key_event(&self, keyval: u32, keycode: u32, state: u32) -> bool {
+        let event = keysym::from_ibus(keyval, keycode, state);
+        let (resp_tx, resp_rx) = crossbeam_channel::bounded::<KeyEventResult>(1);
+        if self
+            .bridge_tx
+            .send(Event::IBusKey {
+                event,
+                respond: resp_tx,
+            })
+            .is_err()
+        {
+            tracing::warn!(
+                error_id = "listener.process_key_event.bridge_disconnected",
+                "engine-loop disconnected; forwarding key to app"
+            );
+            return false;
+        }
+        match resp_rx.recv_timeout(PROCESS_KEY_EVENT_TIMEOUT) {
+            Ok(KeyEventResult::Consumed) => true,
+            Ok(KeyEventResult::Forwarded) => false,
+            Err(_) => {
+                tracing::warn!(
+                    error_id = "listener.process_key_event.timeout",
+                    timeout_ms = PROCESS_KEY_EVENT_TIMEOUT.as_millis() as u64,
+                    "engine response timeout; forwarding key to app"
+                );
+                false
+            }
+        }
+    }
+
+    /// `FocusOut()` — engine 側 reset 経路を発火する。応答不要。
+    fn focus_out(&self) {
+        let _ = self
+            .bridge_tx
+            .send(Event::IBusReset(IBusResetKind::FocusOut));
+    }
+
+    /// `Reset()` — engine 側 reset 経路。応答不要。
+    fn reset(&self) {
+        let _ = self.bridge_tx.send(Event::IBusReset(IBusResetKind::Reset));
+    }
+
+    /// `Disable()` — engine 側 disable 経路。応答不要。
+    fn disable(&self) {
+        let _ = self
+            .bridge_tx
+            .send(Event::IBusReset(IBusResetKind::Disable));
+    }
+
+    /// `FocusIn()` — daemon 側 introspection 互換のための no-op stub(spec §4.3)。
+    fn focus_in(&self) {
+        tracing::debug!("KotohaEngineService::focus_in (no-op)");
+    }
+
+    /// `Enable()` — daemon 側 introspection 互換のための no-op stub(spec §4.3)。
+    fn enable(&self) {
+        tracing::debug!("KotohaEngineService::enable (no-op)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1
+    //! L1 unit tests。dbus を使わず crossbeam channel 直接観測で 4 経路を pin する。
+    //!
+    //! - process_key_event normal: respond.send(Consumed) → true
+    //! - process_key_event normal: respond.send(Forwarded) → false
+    //! - process_key_event timeout (engine が応答しない) → false
+    //! - process_key_event disconnect (engine_loop drop) → false
+    //! - reset 系 3 method の Event 送信
+    //! - no-op stub 2 method の non-panic
+
+    use super::*;
+    use crossbeam_channel::{unbounded, TryRecvError};
+    use std::thread;
+
+    fn setup() -> (KotohaEngineService, crossbeam_channel::Receiver<Event>) {
+        let (tx, rx) = unbounded::<Event>();
+        let service = KotohaEngineService { bridge_tx: tx };
+        (service, rx)
+    }
+
+    #[test]
+    fn process_key_event_returns_true_on_consumed() {
+        let (service, rx) = setup();
+        let join = thread::spawn(move || service.process_key_event(0x6b, 45, 0));
+        // engine-loop に成り代わって respond.send(Consumed) する
+        match rx.recv() {
+            Ok(Event::IBusKey { event: _, respond }) => {
+                respond
+                    .send(KeyEventResult::Consumed)
+                    .expect("send Consumed");
+            }
+            other => panic!("expected IBusKey, got {other:?}"),
+        }
+        assert!(join.join().expect("thread join"));
+    }
+
+    #[test]
+    fn process_key_event_returns_false_on_forwarded() {
+        let (service, rx) = setup();
+        let join = thread::spawn(move || service.process_key_event(0xff1b, 9, 0));
+        match rx.recv() {
+            Ok(Event::IBusKey { event: _, respond }) => {
+                respond
+                    .send(KeyEventResult::Forwarded)
+                    .expect("send Forwarded");
+            }
+            other => panic!("expected IBusKey, got {other:?}"),
+        }
+        assert!(!join.join().expect("thread join"));
+    }
+
+    #[test]
+    fn process_key_event_returns_false_on_timeout() {
+        let (service, _rx) = setup();
+        // _rx を drop しないことで bridge_tx は alive、engine-loop が hang した状態を simulate
+        // (rx は受信するが respond.send は呼ばない)
+        let start = std::time::Instant::now();
+        let result = service.process_key_event(0x20, 65, 0);
+        let elapsed = start.elapsed();
+        assert!(!result, "timeout should return false (Forwarded)");
+        // 100ms ~ 200ms (timing tolerance) 内に return することを観測
+        assert!(
+            elapsed >= Duration::from_millis(100) && elapsed < Duration::from_millis(300),
+            "timeout should fire near 100ms, got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn process_key_event_returns_false_on_disconnect() {
+        let (tx, rx) = unbounded::<Event>();
+        let service = KotohaEngineService { bridge_tx: tx };
+        drop(rx); // engine-loop drop simulation
+        let result = service.process_key_event(0x20, 65, 0);
+        assert!(!result, "disconnect should return false");
+    }
+
+    #[test]
+    fn focus_out_sends_focus_out_event() {
+        let (service, rx) = setup();
+        service.focus_out();
+        match rx.try_recv() {
+            Ok(Event::IBusReset(IBusResetKind::FocusOut)) => {}
+            other => panic!("expected IBusReset(FocusOut), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reset_sends_reset_event() {
+        let (service, rx) = setup();
+        service.reset();
+        match rx.try_recv() {
+            Ok(Event::IBusReset(IBusResetKind::Reset)) => {}
+            other => panic!("expected IBusReset(Reset), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disable_sends_disable_event() {
+        let (service, rx) = setup();
+        service.disable();
+        match rx.try_recv() {
+            Ok(Event::IBusReset(IBusResetKind::Disable)) => {}
+            other => panic!("expected IBusReset(Disable), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn focus_in_does_not_panic_or_send() {
+        let (service, rx) = setup();
+        service.focus_in();
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn enable_does_not_panic_or_send() {
+        let (service, rx) = setup();
+        service.enable();
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+}

--- a/crates/kotoha-engine-ibus/src/service.rs
+++ b/crates/kotoha-engine-ibus/src/service.rs
@@ -24,7 +24,6 @@ use crate::keysym;
 /// # 配置
 ///
 /// `pub(crate)` で crate 外部に export しない。`listener::run` 内で構築・登録される。
-#[allow(dead_code)] // Task 4 で listener::run から参照される
 pub(crate) struct KotohaEngineService {
     /// engine-loop thread に Event を送る単方向 channel。
     pub(crate) bridge_tx: Sender<Event>,
@@ -34,14 +33,8 @@ pub(crate) struct KotohaEngineService {
 ///
 /// 通常 ~1ms / heavy ~10ms / recovery ~50ms 全てを吸収しつつ、bug 状態 (>100ms) のみ
 /// fallback fire するように設定(spec §6.1)。
-#[allow(dead_code)] // Task 4 で listener から間接参照(本 module 内で process_key_event が利用)
 const PROCESS_KEY_EVENT_TIMEOUT: Duration = Duration::from_millis(100);
 
-// `#[interface]` macro は trait dispatch handler を生成する。本 impl の method は
-// macro 経由でのみ呼ばれるため、static dead_code analysis では不可視。Task 4 で
-// listener::run が本 service を Builder::serve_at に渡し production 経路が成立する
-// が、それでも Rust 側の lint は method を未使用扱いするため allow を維持する。
-#[allow(dead_code)]
 #[interface(name = "org.freedesktop.IBus.Engine")]
 impl KotohaEngineService {
     /// `ProcessKeyEvent(u keyval, u keycode, u state) -> b`

--- a/crates/kotoha-engine-ibus/tests/integration.rs
+++ b/crates/kotoha-engine-ibus/tests/integration.rs
@@ -1,0 +1,83 @@
+//! Phase 3-B B6-b (#195) — listener thread + engine_loop 経路の L2 integration test。
+//!
+//! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1 L2 row。
+//!
+//! 本 test は dbus session bus に依存するため `#[ignore]` で gate し、
+//! `cargo test -p kotoha-engine-ibus -- --ignored` で opt-in 実行する。
+//! 通常 CI / pre-push hook では実行されない(L3 manual smoke #196 で実機検証する)。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossbeam_channel::unbounded;
+use kotoha_engine_core::key_event::KeyEventResult;
+use kotoha_engine_core::reactor::Event;
+use kotoha_engine_ibus::listener::{run, ListenerShutdown};
+
+/// listener::run が session bus に接続し、Event::IBusKey が bridge_tx 経由で
+/// 受け取れる経路を pin する(decode + dispatch の最小経路)。
+///
+/// 本 test は実 IBus daemon を要求しない:listener が serve_at + name で
+/// publish した状態で test 側が D-Bus client として `ProcessKeyEvent` を
+/// 呼び出し、bridge_rx で `Event::IBusKey` を観測する。
+#[test]
+#[ignore = "依存: dbus session bus available; CI で flaky のため opt-in"]
+fn listener_decodes_process_key_event() {
+    let (bridge_tx, bridge_rx) = unbounded::<Event>();
+    let (shutdown_trigger, shutdown_observer) = ListenerShutdown::new();
+
+    let listener_handle = std::thread::Builder::new()
+        .name("test-dbus-listener".into())
+        .spawn(move || run(bridge_tx, shutdown_observer))
+        .expect("spawn listener");
+
+    // listener が bus name 取得を完了するまで短時間待つ(Builder::build() は
+    // 同期的に完了するが、別 thread spawn 直後の race を避けるための margin)
+    std::thread::sleep(Duration::from_millis(100));
+
+    // test 側が D-Bus method を呼ぶ proxy を組む
+    let conn = zbus::blocking::Connection::session().expect("open test session bus");
+    let proxy = zbus::blocking::Proxy::new(
+        &conn,
+        "org.freedesktop.IBus.Engine.Kotoha",
+        "/org/freedesktop/IBus/Engine/Kotoha",
+        "org.freedesktop.IBus.Engine",
+    )
+    .expect("build proxy");
+
+    // ProcessKeyEvent 呼び出しは listener 側で respond_rx.recv_timeout を blocking で
+    // 待つため、別 thread で event を engine 役として返す
+    let bridge_rx_for_engine = Arc::new(bridge_rx);
+    let bridge_rx_clone = bridge_rx_for_engine.clone();
+    let engine_thread = std::thread::Builder::new()
+        .name("test-engine-loop-stub".into())
+        .spawn(move || {
+            // listener の process_key_event がここに event を送ってくる想定
+            match bridge_rx_clone.recv_timeout(Duration::from_millis(500)) {
+                Ok(Event::IBusKey { event: _, respond }) => {
+                    respond
+                        .send(KeyEventResult::Consumed)
+                        .expect("send Consumed back");
+                }
+                other => panic!("engine-loop stub expected IBusKey, got {other:?}"),
+            }
+        })
+        .expect("spawn engine stub");
+
+    // method を blocking で呼び出す(返り値 b)
+    let result: bool = proxy
+        .call("ProcessKeyEvent", &(0x6b_u32, 45_u32, 0_u32))
+        .expect("call ProcessKeyEvent");
+
+    engine_thread.join().expect("engine stub join");
+    assert!(result, "expected true (Consumed) from listener");
+
+    // shutdown
+    shutdown_trigger.request();
+    drop(conn);
+    let listener_result = listener_handle.join().expect("listener join");
+    assert!(
+        listener_result.is_ok(),
+        "listener exited with error: {listener_result:?}"
+    );
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,9 @@ Kotoha プロジェクトの開発フェーズと、各フェーズの到達目�
 |---|---|---|
 | [#174](https://github.com/std-koh-hinooka/kotoha-ime/issues/174) docs 構造改修と Obsidian vault 連携 | `docs/specs/_uncategorized/*` (8 spec frontmatter 整備) | [x] |
 | [#149](https://github.com/std-koh-hinooka/kotoha-ime/issues/149) P3-B B0h-f: I3 dispatch_rank_request async-ification | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [x] |
-| [#136](https://github.com/std-koh-hinooka/kotoha-ime/issues/136) P3-B B3 + B6: signal listener loop + L3 manual smoke | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [ ] |
+| [#197](https://github.com/std-koh-hinooka/kotoha-ime/issues/197) P3-B B6-a: SIGTERM/SIGINT shutdown hook | (spec 不要、kotoha-bin 局所変更) | [x] |
+| [#195](https://github.com/std-koh-hinooka/kotoha-ime/issues/195) P3-B B6-b: zbus MessageStream decode + IBus engine factory registration | `docs/specs/_uncategorized/p3-b-ibus-listener.md` | [x] |
+| [#136](https://github.com/std-koh-hinooka/kotoha-ime/issues/136) P3-B B6-c: L3 manual smoke (B6-a/B6-b 完了で残作業は manual 検証のみ) | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [ ] |
 
 <!--
 更新ルール: ~/.claude/CLAUDE.md §post-merge follow-up checklist 参照
@@ -36,7 +38,7 @@ ADR 0010 (`docs/adr/0010-kotoha-custom-romaji-base-model.md`) の決定により
 | 0 | Foundation | Cargo workspace + ローマ字→かな変換 + 入力モード管理 + CLI | 完了 |
 | 1 | Kana→Kanji conversion | llama.cpp + Gemma-2-2B-jpn-it baseline によるかな→漢字変換 (P1-2.5 follow-up で Layer 3 smoke 14/15 達成) | 完了 (14/15 PASS, P1-4 で close 2026-04-25) |
 | 2 | Dictionary and learning | システム辞書 + ユーザ辞書 + 学習キャッシュ + Hybrid Ranker | 完了 (P2-A〜P2-D 全 PR merge、最終 commit `be0fae9` 2026-05-02、test 416 PASS。follow-up backlog #92/#94/#100/#107 は OSS 公開前 triage) |
-| 3 | IBus integration | IBus engine(GNOME Mutter 用) | **進行中** (P3-A draft + P3-B B0/B0g/B0h 全/B1/B2/B3/B4/B5 完了。残 B6 = L3 manual smoke + zbus decode + SIGTERM hook) |
+| 3 | IBus integration | IBus engine(GNOME Mutter 用) | **進行中** (P3-A draft + P3-B B0/B0g/B0h 全/B1/B2/B3/B4/B5/B6-a/B6-b 完了。残 B6-c = L3 manual smoke #196 のみ) |
 | 4 | fcitx5 integration | fcitx5 addon(KDE / wlroots 用) | 未着手 |
 | 5 | **Kotoha custom romaji-base model** | raw romaji keystrokes を直接受理する Kotoha 専用 90〜180M parameter モデルの自作 (data pipeline + training + GGUF 推論統合 + evaluation)。row 3 類の ICL 限界 + typo robustness + partial-input 対応を同時解決する | 未着手 |
 | 6 | Advanced features | タイポ訂正 + 文脈リランキング (Phase 5 の romaji-base モデルを技術基盤とする) | 未着手 |
@@ -124,7 +126,9 @@ Phase 3「IBus integration」は P3-A(設計 + skeleton)と P3-B(production wiri
 | B5 (#139) | KotohaEngine + 実 `HybridRanker` end-to-end integration test | 完了(PR #139) |
 | **B2 (#170)** | IBus signal body marshalling(`proxy.rs` 5 method を実 D-Bus signal emit に置換、`IBusText` / `IBusLookupTable` wire-format 確定:`(sa{sv}sv)` / `(sa{sv}uubbiavav)`) | **完了**(PR #171 squash `4731c50`、test 536 / 547) |
 | **B0h-f + B3 (#149 + #136 一部)** | event-loop architecture 一体化(ADR 0020):4-thread lock-free topology + `EventReactor` trait + `kotoha-engine-reactor-linux` 新 crate + `drain_events_blocking` / `Arc<Mutex<dyn IMEEngine>>` 撤去 + zbus listener loop 実装 | **完了**(PR #183 squash `237eb38`、test 595 / 0、5dim self-review 12 findings 解消) |
-| **B6 (#136 残)** | L3 manual smoke on GNOME Wayland(Firefox / GNOME Text Editor / VS Code で典型変換 10 件)+ zbus `MessageStream` 完全 decode + SIGTERM/SIGINT hook(ADR 0020 §影響 rev2 で deferral 明記) | **未着手** |
+| **B6-a (#197)** | SIGTERM/SIGINT shutdown hook in kotoha-bin (`ctrlc` crate 採用、`ListenerShutdown::Clone` 追加) | **完了**(PR #198 squash `4ea777c`)|
+| **B6-b (#195)** | zbus `blocking::Builder` + `#[interface]` 経由の IBus engine method decode + `RequestName` factory registration、ADR 0021 起票 | **完了**(PR #<TBD>)|
+| **B6-c (#136 残)** | L3 manual smoke on GNOME Wayland(Firefox / GNOME Text Editor / VS Code で典型変換 10 件)、coalescing-window value empirical 確定 | **進行中**(B6-b merge 後、user-driven 実機検証)|
 
 ### Phase 3 受け入れ基準
 
@@ -219,6 +223,7 @@ v0.3.0 以降は §Milestone Specification 完了条件 (annotated tag + リリ�
 
 | 日付 | 改訂内容 |
 |------|----------|
+| 2026-05-08 | Phase 3-B B6-a(#197)+ B6-b(#195)merge 完了。listener stub から production 実装(zbus `#[interface]` + `blocking::Builder`)へ置換、ADR 0021 起票。Phase 3-B sub-milestone table を B6-a / B6-b / B6-c に分割記載。Phase 3 status row 更新(残 B6-c #196 manual smoke のみ)|
 | 2026-05-07 | Phase 3-B B0h-f + B3(#149 + #136 一部)merge 完了(PR #183 squash `237eb38`、test 595 / 0、5dim self-review 12 findings 解消)。Active マイルストーン v0.3.0 の #149 を `[x]`、Phase 3-B sub-milestone table の B0h-f + B3 entry を完了マーク。残作業は B6(L3 manual smoke + zbus decode + SIGTERM hook) |
 | 2026-05-06 | Phase 3-B B0h-f + B3 を一体化 entry に統合、ADR 0020(event-loop architecture)を起票し進行中マーク追加(branch `feature/149-p3b-b0hf-b3-event-loop`) |
 | 2026-05-05 | docs 構造移行 (PR #174): Active マイルストーン v0.3.0 table 化、完了済 v0.0.0/v0.1.0/v0.2.0 を SemVer マッピングで table 化、spec 参照を新パス (`docs/specs/_uncategorized/`) に更新 |

--- a/docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md
+++ b/docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md
@@ -1,0 +1,67 @@
+# ADR 0021: zbus integration architecture for IBus engine listener
+
+| 項目 | 値 |
+|------|----|
+| Status | Accepted |
+| Date | 2026-05-08 |
+| Phase | Phase 3-B B6-b (#195) |
+| 関連 spec | `docs/specs/_uncategorized/p3-b-ibus-listener.md` |
+| 関連 ADR | ADR 0017(IBus engine API surface and async modality)、ADR 0020(event-loop architecture) |
+
+## Context
+
+Phase 3-B B6-b で `kotoha-engine-ibus::listener::run` の stub を production 実装に置き換える。listener thread は IBus daemon から発信される `org.freedesktop.IBus.Engine` interface の method 呼び出し(`ProcessKeyEvent` ほか 5 件)を decode し、`Event` enum で engine-loop thread に伝達する責務を持つ。
+
+zbus 5 における method dispatch には複数の実現経路があり、本 ADR はその選定を記録する。
+
+## Decision
+
+以下を採択する:
+
+1. **decode pattern**: zbus 5 `#[interface]` macro を `KotohaEngineService` struct に適用する。`blocking::connection::Builder::serve_at(path, service)` + `name(bus_name)` で session bus に publish する。
+2. **`process_key_event` の戻り値プラミング**: `Event::IBusKey { event, respond: Sender<KeyEventResult> }` で respond channel を同梱し、listener は `recv_timeout(100ms)` で待機する。timeout 時は `Forwarded` 相当として bool false を返す。
+3. **threading**: listener thread は単独で `blocking::Connection` を保持し、内部 smol executor が dispatch を回す。本 crate コードは `std::sync` 同期 primitive のみ使用(ADR 0017「core は tokio 非依存」原則維持)。
+4. **stub safety net 削除**: `KOTOHA_ALLOW_LISTENER_STUB_ENV` / `allow_listener_stub` / `ListenerStubRefused` を完全削除する。listener が production 実装になるため不要。
+
+詳細実装契約は spec §4-§7 を参照。
+
+## Rejected alternatives
+
+### A. `MessageStream` + 手動 match dispatch
+
+zbus 5 の async API 主導であり、blocking 系から `MessageStream` を直接 receive する経路は限定的。`#[interface]` macro が defacto standard で記述量も少ない。本 use case で manual dispatch を採る理由は薄い。
+
+### B. `Arc<AtomicBool>` snapshot による listener-side enabled cache
+
+`process_key_event` の bool 戻り値を listener が独自判定する案。
+- 利点: 同期 channel 不要、低 latency
+- 致命的欠点: spec §5.2 row が要求する `Forwarded` 精度(Ctrl+C 等の特殊 key の forward 判定)を提供できない。「enabled だが Forwarded すべき key」を listener が常に true と返す → アプリが受け取らない誤動作
+
+### C. `ForwardKeyEvent` signal による二相 pattern
+
+`process_key_event` を常に true で claim し、後続で engine から `ForwardKeyEvent` signal を発信して daemon に keystroke 再 routing させる。
+- 利点: listener 完全 async、blocking なし
+- 欠点: API surface 拡大(`IMEHostBridge` trait に method 追加 + `IBusEngineSignals` 追加)、二相セマンティクスの複雑性、daemon round-trip を含む race condition の debug 経路、integration test が daemon 必須となり regression 検出網が薄くなる
+- 結論: maintenance vs ミリ秒単位の理論的応答性差を秤にかけ、Phase 3-B 段階では (i)+(A) を優先
+
+## Consequences
+
+### Positive
+
+- 4 thread topology(ADR 0020 §採択 Q4)を維持しつつ listener thread が production 実装になる
+- `Event::IBusKey { event, respond }` 拡張は engine_loop の既存 dispatch 経路に最小変更で統合される
+- ADR 0017 の "core は tokio 非依存" 原則を維持(zbus internal smol executor は本 crate コードに propagate しない)
+
+### Negative
+
+- `process_key_event` 経路で listener thread が最大 100ms blocking する。fast typist (10 keys/sec) でも通常 ~1ms / heavy ~10ms / recovery ~50ms で吸収できる範囲(spec §6.1)。
+- timeout fire(>100ms)時に engine が eventual に `Consumed` 判定すると double-input が原理的に起こりうる(spec §6.2 で受容、Phase 5/6 で deadline check 拡張余地)
+
+### Neutral
+
+- IBus engine factory registration の正規経路(`/usr/share/ibus/component/<name>.xml`)は本 ADR scope 外。packaging task として別 ISSUE で扱う。
+
+## Future revisit triggers
+
+- Phase 5 custom romaji-base model の inference latency が増えた場合、100ms timeout 値の引き上げ / `Event::IBusKey` への deadline 拡張 / `async fn` method 化 + smol::unblock を再評価する
+- Phase 4 fcitx5 adapter で異なる protocol への generalization が必要な場合、`KotohaEngineService` を trait 化する余地

--- a/docs/plans/2026-05-08-feature-195-zbus-listener-decode.md
+++ b/docs/plans/2026-05-08-feature-195-zbus-listener-decode.md
@@ -1,0 +1,1127 @@
+# P3-B B6-b IBus Engine Listener Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Project flow note:** This project uses **Spec-Driven, Test-After** (see `~/.claude/CLAUDE.md` §Development Flow). TDD's "write failing test first" pattern is banned per global rule. Each task implements code first, then tests are derived from the spec acceptance criteria, then verified.
+
+**Goal:** Replace the `kotoha-engine-ibus` listener stub with a production `zbus #[interface]` dispatcher that decodes 4 IBus engine methods (+2 daemon-introspection no-op stubs) and forwards them as `Event` to the engine-loop, with a response channel for `ProcessKeyEvent`'s bool return.
+
+**Architecture:** zbus 5 `#[interface]` macro on `KotohaEngineService` struct, registered via `blocking::connection::Builder::serve_at + name`. `Event::IBusKey` extends to carry a response `Sender<KeyEventResult>` with 100ms timeout fallback. `KOTOHA_ALLOW_LISTENER_STUB` safety net is removed entirely.
+
+**Tech Stack:** Rust 1.80, edition 2021, zbus 5 (blocking API), crossbeam-channel 0.5, kotoha-engine-core (`Event` / `KeyEvent` / `KeyEventResult`), kotoha-engine-ibus (existing `types` / `proxy` / `keysym` / `host_bridge`).
+
+**Spec:** `docs/specs/_uncategorized/p3-b-ibus-listener.md` (commits `79da087` + `48c7d6d` on this branch).
+
+**Branch:** `feature/195-zbus-listener-decode` (created from develop, includes the 2 spec commits).
+
+---
+
+## File map
+
+| Action | Path | Purpose |
+|---|---|---|
+| Modify | `crates/kotoha-engine-ibus/src/proxy.rs` | Add `IBUS_ENGINE_BUS_NAME` + `IBUS_ENGINE_OBJECT_PATH` constants |
+| Modify | `crates/kotoha-engine-core/src/reactor/event.rs` | Change `Event::IBusKey(KeyEvent)` → `Event::IBusKey { event, respond }` |
+| Modify | `crates/kotoha-bin/src/engine_loop.rs` | Destructure new variant + send response |
+| Modify | `crates/kotoha-engine-core/Cargo.toml` (if needed) | (already has crossbeam-channel; expose `KeyEventResult`) |
+| Create | `crates/kotoha-engine-ibus/src/service.rs` | New `KotohaEngineService` struct + `#[interface]` impl + L1 unit tests |
+| Modify | `crates/kotoha-engine-ibus/src/lib.rs` | Register new `service` module |
+| Modify | `crates/kotoha-engine-ibus/src/listener.rs` | Delete stub safety net, rewrite `run()` to build connection |
+| Create | `crates/kotoha-engine-ibus/tests/integration.rs` | L2 integration test gated with `#[ignore]` (dbus session bus required) |
+| Create | `docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md` | ADR for zbus 5 `#[interface]` + blocking Builder + bounded response channel + 100ms timeout |
+| Modify | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | Update §6.1 step [1] / §11 acceptance criteria + frontmatter `last_reviewed` |
+| Modify | `docs/ROADMAP.md` | Mark #195 `[x]` in v0.3.0 active table; update Phase 3-B sub-milestone B6 entry; revision history row |
+
+---
+
+## Task 1: Add IBus engine bus name + object path constants
+
+**Files:**
+- Modify: `crates/kotoha-engine-ibus/src/proxy.rs`
+
+- [ ] **Step 1: Add the two constants below the existing `IBUS_ENGINE_INTERFACE`**
+
+After line 53 (`pub(crate) const IBUS_ENGINE_INTERFACE: &str = "org.freedesktop.IBus.Engine";`), insert:
+
+```rust
+/// Kotoha が `RequestName` で取得する IBus engine bus name(spec §7.1)。
+///
+/// 同 UID で同名 process が既に publish していると `Builder::name(...)` が `Err` を返し、
+/// listener thread の起動が失敗する。
+pub(crate) const IBUS_ENGINE_BUS_NAME: &str = "org.freedesktop.IBus.Engine.Kotoha";
+
+/// Kotoha engine service の D-Bus object path(spec §7.1)。
+///
+/// `Builder::serve_at(...)` でこの path に `KotohaEngineService` を登録する。
+pub(crate) const IBUS_ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
+```
+
+- [ ] **Step 2: Verify build**
+
+Run:
+```bash
+cargo build -p kotoha-engine-ibus
+```
+Expected: `Finished` with no warnings (constants are `pub(crate)` and not yet referenced — fine for now, will be used in Task 4).
+
+If `unused constant` warning fires, suppress with `#[allow(dead_code)]` on each constant only if necessary. Defer the suppression to verify it's actually warned (rust 1.80 typically allows pub(crate) without warning).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/kotoha-engine-ibus/src/proxy.rs
+git commit -m "feat(engine-ibus): add IBus engine bus name + object path constants (#195)"
+```
+
+---
+
+## Task 2: Extend `Event::IBusKey` with response channel
+
+**Files:**
+- Modify: `crates/kotoha-engine-core/src/reactor/event.rs`
+- Modify: `crates/kotoha-bin/src/engine_loop.rs`
+- Modify: any caller / test that constructs `Event::IBusKey(...)`
+
+This is a **breaking change** within the workspace: the variant signature changes from tuple to struct. All sites must be updated atomically. Build verification at the end ensures no consumer is missed.
+
+- [ ] **Step 1: Change `Event::IBusKey` to struct variant**
+
+Edit `crates/kotoha-engine-core/src/reactor/event.rs`:
+
+Add import at the top of the file (after the existing imports):
+
+```rust
+use crossbeam_channel::Sender;
+
+use crate::key_event::{KeyEvent, KeyEventResult};
+use crate::ranker::CandidateUpdate;
+use crate::request_id::RequestId;
+```
+
+Note: `KeyEvent` and `CandidateUpdate` may already be imported; preserve existing imports and ADD `Sender` and `KeyEventResult`. Do NOT duplicate.
+
+Replace the variant:
+
+```rust
+    /// IBus session bus で受信した key event。
+    /// `kotoha-dbus-listener` thread が `Sender<Event>::send` で engine-loop に届ける。
+    ///
+    /// `respond` は engine-loop が `KeyEventResult`(`Consumed` / `Forwarded`)を返す
+    /// bounded(1) channel。listener は recv_timeout(100ms) で待機し timeout 時は
+    /// `Forwarded` 相当として bool false を返す(spec §6 / `docs/specs/_uncategorized/p3-b-ibus-listener.md`)。
+    IBusKey {
+        event: KeyEvent,
+        respond: Sender<KeyEventResult>,
+    },
+```
+
+- [ ] **Step 2: Update engine_loop.rs match arm**
+
+Edit `crates/kotoha-bin/src/engine_loop.rs:43-46`. Replace:
+
+```rust
+            Ok(Event::IBusKey(key)) => {
+                let _result = engine.process_key_event(key);
+            }
+```
+
+with:
+
+```rust
+            Ok(Event::IBusKey { event, respond }) => {
+                let result = engine.process_key_event(event);
+                // listener が timeout した場合 send Err は ignore (= keystroke は app に forward 済)
+                let _ = respond.send(result);
+            }
+```
+
+- [ ] **Step 3: Find and update other callers**
+
+Run a grep to surface any remaining tuple-variant constructions:
+
+```bash
+rg -n "Event::IBusKey\(" crates/ docs/
+```
+
+Expected: only references inside specs / plans (markdown). If any source file references appear, update them to the struct form. (The reactor-linux integration tests should NOT touch `IBusKey` — they use `IBusReset` and `WorkerOutput`.)
+
+- [ ] **Step 4: Build verify**
+
+Run:
+```bash
+cargo build --workspace --all-features
+```
+Expected: `Finished` with no errors. Any compile error from missed callers must be fixed in this step.
+
+- [ ] **Step 5: Test verify**
+
+Run:
+```bash
+cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers 2>&1 | /usr/bin/grep -E "FAILED|^test result:" | tail -10
+```
+Expected: 0 FAILED. Any test that previously constructed `Event::IBusKey(...)` directly must be updated.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/kotoha-engine-core/src/reactor/event.rs crates/kotoha-bin/src/engine_loop.rs
+# add other changed test files if any
+git commit -m "refactor(engine-core,bin): extend Event::IBusKey with respond channel (#195)"
+```
+
+---
+
+## Task 3: Create `KotohaEngineService` with `#[interface]` impl
+
+**Files:**
+- Create: `crates/kotoha-engine-ibus/src/service.rs`
+- Modify: `crates/kotoha-engine-ibus/src/lib.rs`
+
+- [ ] **Step 1: Verify zbus 5 `#[interface]` blocking API surface**
+
+Open Context7 if available, OR run:
+```bash
+cargo doc -p zbus --open 2>&1 | head -3
+```
+Expected API (verify in actual source — adjust if docs differ):
+- `zbus::interface` macro (re-exported from zbus root)
+- `zbus::blocking::connection::Builder` chain: `session()?`, `serve_at(path, instance)?`, `name(name)?`, `build()?`
+
+If the macro path differs in the installed zbus 5 version (e.g., `zbus::dbus_interface` in 4.x vs `zbus::interface` in 5.x), use the symbol from the installed crate.
+
+- [ ] **Step 2: Write `service.rs`**
+
+Create `crates/kotoha-engine-ibus/src/service.rs`:
+
+```rust
+//! `KotohaEngineService` — IBus engine method dispatcher。
+//!
+//! Phase 3-B B6-b (#195) で導入。zbus 5 `#[interface]` macro 経由で
+//! `org.freedesktop.IBus.Engine` interface の 6 method を実装する。
+//!
+//! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §4 / §5。
+
+use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use zbus::interface;
+
+use kotoha_engine_core::key_event::KeyEventResult;
+use kotoha_engine_core::reactor::{Event, IBusResetKind};
+
+use crate::keysym;
+
+/// IBus engine method dispatcher。
+///
+/// `bridge_tx` 経由で engine-loop thread に Event を届ける。state を保持しない
+/// (ADR 0020 §採択 Q4 lock-free 原則)。zbus が internal smol executor で本 struct
+/// の method を dispatch する。
+///
+/// # 配置
+///
+/// `pub(crate)` で crate 外部に export しない。`listener::run` 内で構築・登録される。
+pub(crate) struct KotohaEngineService {
+    /// engine-loop thread に Event を送る単方向 channel。
+    pub(crate) bridge_tx: Sender<Event>,
+}
+
+/// `process_key_event` の response 待機 timeout。
+///
+/// 通常 ~1ms / heavy ~10ms / recovery ~50ms 全てを吸収しつつ、bug 状態 (>100ms) のみ
+/// fallback fire するように設定(spec §6.1)。
+const PROCESS_KEY_EVENT_TIMEOUT: Duration = Duration::from_millis(100);
+
+#[interface(name = "org.freedesktop.IBus.Engine")]
+impl KotohaEngineService {
+    /// `ProcessKeyEvent(u keyval, u keycode, u state) -> b`
+    ///
+    /// IBus 1.5.x 仕様準拠。戻り値 true は Kotoha が消費した、false は app に forward する。
+    fn process_key_event(&self, keyval: u32, keycode: u32, state: u32) -> bool {
+        let event = keysym::from_ibus(keyval, keycode, state);
+        let (resp_tx, resp_rx) = crossbeam_channel::bounded::<KeyEventResult>(1);
+        if self
+            .bridge_tx
+            .send(Event::IBusKey {
+                event,
+                respond: resp_tx,
+            })
+            .is_err()
+        {
+            tracing::warn!(
+                error_id = "listener.process_key_event.bridge_disconnected",
+                "engine-loop disconnected; forwarding key to app"
+            );
+            return false;
+        }
+        match resp_rx.recv_timeout(PROCESS_KEY_EVENT_TIMEOUT) {
+            Ok(KeyEventResult::Consumed) => true,
+            Ok(KeyEventResult::Forwarded) => false,
+            Err(_) => {
+                tracing::warn!(
+                    error_id = "listener.process_key_event.timeout",
+                    timeout_ms = PROCESS_KEY_EVENT_TIMEOUT.as_millis() as u64,
+                    "engine response timeout; forwarding key to app"
+                );
+                false
+            }
+        }
+    }
+
+    /// `FocusOut()` — engine 側 reset 経路を発火する。応答不要。
+    fn focus_out(&self) {
+        let _ = self
+            .bridge_tx
+            .send(Event::IBusReset(IBusResetKind::FocusOut));
+    }
+
+    /// `Reset()` — engine 側 reset 経路。応答不要。
+    fn reset(&self) {
+        let _ = self.bridge_tx.send(Event::IBusReset(IBusResetKind::Reset));
+    }
+
+    /// `Disable()` — engine 側 disable 経路。応答不要。
+    fn disable(&self) {
+        let _ = self
+            .bridge_tx
+            .send(Event::IBusReset(IBusResetKind::Disable));
+    }
+
+    /// `FocusIn()` — daemon 側 introspection 互換のための no-op stub(spec §4.3)。
+    fn focus_in(&self) {
+        tracing::debug!("KotohaEngineService::focus_in (no-op)");
+    }
+
+    /// `Enable()` — daemon 側 introspection 互換のための no-op stub(spec §4.3)。
+    fn enable(&self) {
+        tracing::debug!("KotohaEngineService::enable (no-op)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1
+    //! L1 unit tests。dbus を使わず crossbeam channel 直接観測で 4 経路を pin する。
+    //!
+    //! - process_key_event normal: respond.send(Consumed) → true
+    //! - process_key_event normal: respond.send(Forwarded) → false
+    //! - process_key_event timeout (engine が応答しない) → false
+    //! - process_key_event disconnect (engine_loop drop) → false
+    //! - reset 系 3 method の Event 送信
+    //! - no-op stub 2 method の non-panic
+
+    use super::*;
+    use crossbeam_channel::{unbounded, TryRecvError};
+    use std::thread;
+
+    fn setup() -> (
+        KotohaEngineService,
+        crossbeam_channel::Receiver<Event>,
+    ) {
+        let (tx, rx) = unbounded::<Event>();
+        let service = KotohaEngineService { bridge_tx: tx };
+        (service, rx)
+    }
+
+    #[test]
+    fn process_key_event_returns_true_on_consumed() {
+        let (service, rx) = setup();
+        let join = thread::spawn(move || service.process_key_event(0x6b, 45, 0));
+        // engine-loop に成り代わって respond.send(Consumed) する
+        match rx.recv() {
+            Ok(Event::IBusKey { event: _, respond }) => {
+                respond
+                    .send(KeyEventResult::Consumed)
+                    .expect("send Consumed");
+            }
+            other => panic!("expected IBusKey, got {other:?}"),
+        }
+        assert!(join.join().expect("thread join"));
+    }
+
+    #[test]
+    fn process_key_event_returns_false_on_forwarded() {
+        let (service, rx) = setup();
+        let join = thread::spawn(move || service.process_key_event(0xff1b, 9, 0));
+        match rx.recv() {
+            Ok(Event::IBusKey { event: _, respond }) => {
+                respond
+                    .send(KeyEventResult::Forwarded)
+                    .expect("send Forwarded");
+            }
+            other => panic!("expected IBusKey, got {other:?}"),
+        }
+        assert!(!join.join().expect("thread join"));
+    }
+
+    #[test]
+    fn process_key_event_returns_false_on_timeout() {
+        let (service, _rx) = setup();
+        // _rx を drop しないことで bridge_tx は alive、engine-loop が hang した状態を simulate
+        // (rx は受信するが respond.send は呼ばない)
+        let start = std::time::Instant::now();
+        let result = service.process_key_event(0x20, 65, 0);
+        let elapsed = start.elapsed();
+        assert!(!result, "timeout should return false (Forwarded)");
+        // 100ms ~ 200ms (timing tolerance) 内に return することを観測
+        assert!(
+            elapsed >= Duration::from_millis(100) && elapsed < Duration::from_millis(300),
+            "timeout should fire near 100ms, got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn process_key_event_returns_false_on_disconnect() {
+        let (tx, rx) = unbounded::<Event>();
+        let service = KotohaEngineService { bridge_tx: tx };
+        drop(rx); // engine-loop drop simulation
+        let result = service.process_key_event(0x20, 65, 0);
+        assert!(!result, "disconnect should return false");
+    }
+
+    #[test]
+    fn focus_out_sends_focus_out_event() {
+        let (service, rx) = setup();
+        service.focus_out();
+        match rx.try_recv() {
+            Ok(Event::IBusReset(IBusResetKind::FocusOut)) => {}
+            other => panic!("expected IBusReset(FocusOut), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reset_sends_reset_event() {
+        let (service, rx) = setup();
+        service.reset();
+        match rx.try_recv() {
+            Ok(Event::IBusReset(IBusResetKind::Reset)) => {}
+            other => panic!("expected IBusReset(Reset), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disable_sends_disable_event() {
+        let (service, rx) = setup();
+        service.disable();
+        match rx.try_recv() {
+            Ok(Event::IBusReset(IBusResetKind::Disable)) => {}
+            other => panic!("expected IBusReset(Disable), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn focus_in_does_not_panic_or_send() {
+        let (service, rx) = setup();
+        service.focus_in();
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn enable_does_not_panic_or_send() {
+        let (service, rx) = setup();
+        service.enable();
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+}
+```
+
+- [ ] **Step 3: Register module in lib.rs**
+
+Edit `crates/kotoha-engine-ibus/src/lib.rs`. Find the `pub(crate) mod` section and add:
+
+```rust
+pub(crate) mod service;
+```
+
+(Place adjacent to other `pub(crate) mod` declarations like `keysym` / `proxy`. Do NOT make it `pub`.)
+
+- [ ] **Step 4: Build verify**
+
+```bash
+cargo build -p kotoha-engine-ibus 2>&1 | tail -5
+```
+Expected: `Finished`. If `#[interface]` macro fails, verify zbus 5 macro path (Step 1).
+
+- [ ] **Step 5: Test verify**
+
+```bash
+cargo test -p kotoha-engine-ibus service:: 2>&1 | tail -15
+```
+Expected: 9 tests passed (4 process_key_event + 3 reset + 2 stub).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/kotoha-engine-ibus/src/service.rs crates/kotoha-engine-ibus/src/lib.rs
+git commit -m "feat(engine-ibus): add KotohaEngineService with #[interface] dispatcher (#195)"
+```
+
+---
+
+## Task 4: Rewrite `listener::run()` to build the connection
+
+**Files:**
+- Modify: `crates/kotoha-engine-ibus/src/listener.rs`
+
+- [ ] **Step 1: Delete stub safety net**
+
+In `crates/kotoha-engine-ibus/src/listener.rs`, **remove**:
+
+- `pub const KOTOHA_ALLOW_LISTENER_STUB_ENV: &str = ...;`
+- `fn allow_listener_stub() -> bool { ... }`
+- `pub struct ListenerStubRefused;` and its `#[error]` block
+- The 2 stub `#[ignore]` tests `run_refuses_to_start_without_env_var` and `run_exits_within_200ms_after_shutdown_request`
+
+Keep:
+- `ListenerShutdown` + `ShutdownObserver` structs and their impls
+- The 3 sync unit tests `observer_reflects_trigger_state` / `cloned_observer_shares_state` / `cloned_trigger_shares_state`
+- The module-level rustdoc comment (update it though — see Step 3)
+
+- [ ] **Step 2: Rewrite `run()`**
+
+Replace the existing `pub fn run(...) -> anyhow::Result<()> { ... }` with:
+
+```rust
+/// D-Bus listener thread の main loop。
+///
+/// # Preconditions
+///
+/// - `bridge_tx` は engine-loop thread の `EventReactor` bridge channel
+/// - `shutdown` は main thread が `ListenerShutdown::request()` で停止指示する observer handle
+///   (#187 split-handle、#197 SIGTERM hook 経由でも request される)
+///
+/// # Postconditions
+///
+/// - `shutdown.is_shutting_down()` を観測したら Connection を drop して `Ok(())` で return する
+///   (Connection drop で zbus internal smol executor が exit、bus name が release)
+/// - Connection 構築失敗(session bus 不在、bus name 占有等)時は Err propagate
+///
+/// # Errors
+///
+/// - `zbus::Error` — session bus 接続 / `serve_at` / `RequestName` 失敗
+///
+/// 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §3 / §7。
+pub fn run(bridge_tx: Sender<Event>, shutdown: ShutdownObserver) -> anyhow::Result<()> {
+    use crate::proxy::{IBUS_ENGINE_BUS_NAME, IBUS_ENGINE_OBJECT_PATH};
+    use crate::service::KotohaEngineService;
+
+    tracing::info!(
+        bus_name = IBUS_ENGINE_BUS_NAME,
+        object_path = IBUS_ENGINE_OBJECT_PATH,
+        "dbus-listener starting (zbus blocking::Builder + #[interface] dispatcher)"
+    );
+
+    let service = KotohaEngineService { bridge_tx };
+    let _connection = zbus::blocking::connection::Builder::session()?
+        .serve_at(IBUS_ENGINE_OBJECT_PATH, service)?
+        .name(IBUS_ENGINE_BUS_NAME)?
+        .build()?;
+
+    // Connection's internal smol executor dispatches incoming method calls in a
+    // background thread. We just hold the connection alive and poll shutdown.
+    while !shutdown.is_shutting_down() {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    tracing::info!("dbus-listener received shutdown signal, dropping connection and exiting");
+    // _connection drops here: zbus releases bus name + stops dispatching.
+    Ok(())
+}
+```
+
+Update the module-level rustdoc (top of `listener.rs`) to reflect production status:
+
+```rust
+//! D-Bus signal listener loop(Phase 3-B B3 + B6-b / ADR 0020 + ADR 0021)。
+//!
+//! `kotoha-dbus-listener` thread の main を担う。zbus 5 `blocking::connection::Builder`
+//! 経由で `org.freedesktop.IBus.Engine` interface に [`crate::service::KotohaEngineService`]
+//! を登録し、IBus daemon からの method 呼び出しを 6 method に分岐 dispatch する。
+//!
+//! # Decoded methods
+//!
+//! - `ProcessKeyEvent(u keyval, u keycode, u state) -> b` → `Event::IBusKey { event, respond }`
+//! - `Reset()` → `Event::IBusReset(IBusResetKind::Reset)`
+//! - `FocusOut()` → `Event::IBusReset(IBusResetKind::FocusOut)`
+//! - `Disable()` → `Event::IBusReset(IBusResetKind::Disable)`
+//! - `FocusIn()` / `Enable()` — daemon 側 introspection 互換 no-op stub
+```
+
+Also update or remove the `Connection` parameter — the new `run()` does **not** take a pre-built `_connection: zbus::blocking::Connection` parameter (it builds its own via `Builder`). This is a signature change for callers.
+
+- [ ] **Step 3: Update kotoha-bin/src/main.rs caller**
+
+Find the call site (`kotoha-bin/src/main.rs:285-298`) and remove the externally-built `listener_connection`:
+
+Before:
+```rust
+    let listener_connection = zbus::blocking::Connection::session()
+        .context("open session bus for D-Bus listener thread")?;
+    let (listener_shutdown, listener_observer) =
+        kotoha_engine_ibus::listener::ListenerShutdown::new();
+```
+
+After:
+```rust
+    let (listener_shutdown, listener_observer) =
+        kotoha_engine_ibus::listener::ListenerShutdown::new();
+```
+
+And the spawn closure:
+
+Before:
+```rust
+        .spawn(move || {
+            kotoha_engine_ibus::listener::run(listener_connection, bridge_tx, listener_observer)
+        })
+```
+
+After:
+```rust
+        .spawn(move || {
+            kotoha_engine_ibus::listener::run(bridge_tx, listener_observer)
+        })
+```
+
+Update the comment at lines 283-284 to remove the "(IBusHostBridge は内部で別 connection を持つため独立)" justification — no longer relevant.
+
+- [ ] **Step 4: Build verify**
+
+```bash
+cargo build --workspace --all-features 2>&1 | tail -5
+```
+Expected: `Finished`.
+
+- [ ] **Step 5: Test verify**
+
+```bash
+cargo test -p kotoha-engine-ibus 2>&1 | /usr/bin/grep -E "FAILED|^test result:" | tail -10
+```
+Expected: 0 FAILED. The 2 obsolete stub tests should be gone, the 3 ShutdownObserver tests + 9 service tests pass.
+
+```bash
+cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers 2>&1 | /usr/bin/grep -E "FAILED|^test result:" | sort | uniq -c | tail -3
+```
+Expected: 0 FAILED workspace-wide.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/kotoha-engine-ibus/src/listener.rs crates/kotoha-bin/src/main.rs
+git commit -m "feat(engine-ibus,bin): rewrite listener::run with blocking::Builder; remove stub safety net (#195)"
+```
+
+---
+
+## Task 5: Add L2 integration test (gated with `#[ignore]`)
+
+**Files:**
+- Create: `crates/kotoha-engine-ibus/tests/integration.rs`
+
+- [ ] **Step 1: Write integration test**
+
+Create `crates/kotoha-engine-ibus/tests/integration.rs`:
+
+```rust
+//! Phase 3-B B6-b (#195) — listener thread + engine_loop 経路の L2 integration test。
+//!
+//! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1 L2 row。
+//!
+//! 本 test は dbus session bus に依存するため `#[ignore]` で gate し、
+//! `cargo test -p kotoha-engine-ibus -- --ignored` で opt-in 実行する。
+//! 通常 CI / pre-push hook では実行されない(L3 manual smoke #196 で実機検証する)。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossbeam_channel::unbounded;
+use kotoha_engine_core::key_event::KeyEventResult;
+use kotoha_engine_core::reactor::Event;
+use kotoha_engine_ibus::listener::{run, ListenerShutdown};
+
+/// listener::run が session bus に接続し、Event::IBusKey が bridge_tx 経由で
+/// 受け取れる経路を pin する(decode + dispatch の最小経路)。
+///
+/// 本 test は実 IBus daemon を要求しない:listener が serve_at + name で
+/// publish した状態で test 側が D-Bus client として `ProcessKeyEvent` を
+/// 呼び出し、bridge_rx で `Event::IBusKey` を観測する。
+#[test]
+#[ignore = "依存: dbus session bus available; CI で flaky のため opt-in"]
+fn listener_decodes_process_key_event() {
+    let (bridge_tx, bridge_rx) = unbounded::<Event>();
+    let (shutdown_trigger, shutdown_observer) = ListenerShutdown::new();
+
+    let listener_handle = std::thread::Builder::new()
+        .name("test-dbus-listener".into())
+        .spawn(move || run(bridge_tx, shutdown_observer))
+        .expect("spawn listener");
+
+    // listener が bus name 取得を完了するまで短時間待つ(Builder::build() は
+    // 同期的に完了するが、別 thread spawn 直後の race を避けるための margin)
+    std::thread::sleep(Duration::from_millis(100));
+
+    // test 側が D-Bus method を呼ぶ proxy を組む
+    let conn = zbus::blocking::Connection::session().expect("open test session bus");
+    let proxy = zbus::blocking::Proxy::new(
+        &conn,
+        "org.freedesktop.IBus.Engine.Kotoha",
+        "/org/freedesktop/IBus/Engine/Kotoha",
+        "org.freedesktop.IBus.Engine",
+    )
+    .expect("build proxy");
+
+    // ProcessKeyEvent 呼び出しは listener 側で respond_rx.recv_timeout を blocking で
+    // 待つため、別 thread で event を engine 役として返す
+    let bridge_rx_for_engine = Arc::new(bridge_rx);
+    let bridge_rx_clone = bridge_rx_for_engine.clone();
+    let engine_thread = std::thread::Builder::new()
+        .name("test-engine-loop-stub".into())
+        .spawn(move || {
+            // listener の process_key_event がここに event を送ってくる想定
+            match bridge_rx_clone.recv_timeout(Duration::from_millis(500)) {
+                Ok(Event::IBusKey { event: _, respond }) => {
+                    respond
+                        .send(KeyEventResult::Consumed)
+                        .expect("send Consumed back");
+                }
+                other => panic!("engine-loop stub expected IBusKey, got {other:?}"),
+            }
+        })
+        .expect("spawn engine stub");
+
+    // method を blocking で呼び出す(返り値 b)
+    let result: bool = proxy
+        .call("ProcessKeyEvent", &(0x6b_u32, 45_u32, 0_u32))
+        .expect("call ProcessKeyEvent");
+
+    engine_thread.join().expect("engine stub join");
+    assert!(result, "expected true (Consumed) from listener");
+
+    // shutdown
+    shutdown_trigger.request();
+    drop(conn);
+    let listener_result = listener_handle.join().expect("listener join");
+    assert!(listener_result.is_ok(), "listener exited with error: {listener_result:?}");
+}
+```
+
+- [ ] **Step 2: Verify test exists and is ignored by default**
+
+```bash
+cargo test -p kotoha-engine-ibus 2>&1 | /usr/bin/grep -E "ignored|^test result:" | head -10
+```
+Expected: at least 1 ignored test (`listener_decodes_process_key_event`). The default test run does NOT execute it.
+
+- [ ] **Step 3 (optional, requires dbus session bus): Run the ignored test**
+
+```bash
+cargo test -p kotoha-engine-ibus -- --ignored listener_decodes_process_key_event 2>&1 | tail -10
+```
+Expected on dev machine with `DBUS_SESSION_BUS_ADDRESS` set: PASS. Skip this step in CI / containers without session bus.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/kotoha-engine-ibus/tests/integration.rs
+git commit -m "test(engine-ibus): add L2 integration test for listener decode path (#195)"
+```
+
+---
+
+## Task 6: File ADR 0021
+
+**Files:**
+- Create: `docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md`
+
+- [ ] **Step 1: Write ADR**
+
+Create `docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md`:
+
+```markdown
+# ADR 0021: zbus integration architecture for IBus engine listener
+
+| 項目 | 値 |
+|------|----|
+| Status | Accepted |
+| Date | 2026-05-08 |
+| Phase | Phase 3-B B6-b (#195) |
+| 関連 spec | `docs/specs/_uncategorized/p3-b-ibus-listener.md` |
+| 関連 ADR | ADR 0017(IBus engine API surface and async modality)、ADR 0020(event-loop architecture) |
+
+## Context
+
+Phase 3-B B6-b で `kotoha-engine-ibus::listener::run` の stub を production 実装に置き換える。listener thread は IBus daemon から発信される `org.freedesktop.IBus.Engine` interface の method 呼び出し(`ProcessKeyEvent` ほか 5 件)を decode し、`Event` enum で engine-loop thread に伝達する責務を持つ。
+
+zbus 5 における method dispatch には複数の実現経路があり、本 ADR はその選定を記録する。
+
+## Decision
+
+以下を採択する:
+
+1. **decode pattern**: zbus 5 `#[interface]` macro を `KotohaEngineService` struct に適用する。`blocking::connection::Builder::serve_at(path, service)` + `name(bus_name)` で session bus に publish する。
+2. **`process_key_event` の戻り値プラミング**: `Event::IBusKey { event, respond: Sender<KeyEventResult> }` で respond channel を同梱し、listener は `recv_timeout(100ms)` で待機する。timeout 時は `Forwarded` 相当として bool false を返す。
+3. **threading**: listener thread は単独で `blocking::Connection` を保持し、内部 smol executor が dispatch を回す。本 crate コードは std::sync 同期 primitive のみ使用(ADR 0017「core は tokio 非依存」原則維持)。
+4. **stub safety net 削除**: `KOTOHA_ALLOW_LISTENER_STUB_ENV` / `allow_listener_stub` / `ListenerStubRefused` を完全削除する。listener が production 実装になるため不要。
+
+詳細実装契約は spec §4-§7 を参照。
+
+## Rejected alternatives
+
+### A. `MessageStream` + 手動 match dispatch
+
+zbus 5 の async API 主導であり、blocking 系から `MessageStream` を直接 receive する経路は限定的。`#[interface]` macro が defacto standard で記述量も少ない。本 use case で manual dispatch を採る理由は薄い。
+
+### B. `Arc<AtomicBool>` snapshot による listener-side enabled cache
+
+`process_key_event` の bool 戻り値を listener が独自判定する案。
+- 利点: 同期 channel 不要、低 latency
+- 致命的欠点: spec §5.2 row が要求する `Forwarded` 精度(Ctrl+C 等の特殊 key の forward 判定)を提供できない。「enabled だが Forwarded すべき key」を listener が常に true と返す → アプリが受け取らない誤動作
+
+### C. `ForwardKeyEvent` signal による二相 pattern
+
+`process_key_event` を常に true で claim し、後続で engine から `ForwardKeyEvent` signal を発信して daemon に keystroke 再 routing させる。
+- 利点: listener 完全 async、blocking なし
+- 欠点: API surface 拡大(`IMEHostBridge` trait に method 追加 + IBusEngineSignals 追加)、二相セマンティクスの複雑性、daemon round-trip を含む race condition の debug 経路、integration test が daemon 必須となり regression 検出網が薄くなる
+- 結論: maintenance vs ミリ秒単位の理論的応答性差を秤にかけ、Phase 3-B 段階では (i)+(A) を優先
+
+## Consequences
+
+### Positive
+
+- 4 thread topology(ADR 0020 §採択 Q4)を維持しつつ listener thread が production 実装になる
+- `Event::IBusKey { event, respond }` 拡張は engine_loop の既存 dispatch 経路に最小変更で統合される
+- ADR 0017 の "core は tokio 非依存" 原則を維持(zbus internal smol executor は本 crate コードに propagate しない)
+
+### Negative
+
+- `process_key_event` 経路で listener thread が最大 100ms blocking する。fast typist (10 keys/sec) でも通常 ~1ms / heavy ~10ms / recovery ~50ms で吸収できる範囲(spec §6.1)。
+- timeout fire(>100ms)時に engine が eventual に Consumed 判定すると double-input が原理的に起こりうる(spec §6.2 で受容、Phase 5/6 で deadline check 拡張余地)
+
+### Neutral
+
+- IBus engine factory registration の正規経路(`/usr/share/ibus/component/<name>.xml`)は本 ADR scope 外。packaging task として別 ISSUE で扱う。
+
+## Future revisit triggers
+
+- Phase 5 custom romaji-base model の inference latency が増えた場合、100ms timeout 値の引き上げ / `Event::IBusKey` への deadline 拡張 / `async fn` method 化 + smol::unblock を再評価する
+- Phase 4 fcitx5 adapter で異なる protocol への generalization が必要な場合、`KotohaEngineService` を trait 化する余地
+```
+
+- [ ] **Step 2: Verify pre-commit doc-naming hook**
+
+```bash
+git add docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md
+```
+The pre-commit hook (lefthook) validates ADR file naming. Verify the filename matches `NNNN-<title>.md` pattern.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "docs(adr): ADR 0021 zbus integration architecture for IBus listener (#195)"
+```
+
+---
+
+## Task 7: Update spec p3-a-ibus-engine.md
+
+**Files:**
+- Modify: `docs/specs/_uncategorized/p3-a-ibus-engine.md`
+
+- [ ] **Step 1: Update §6.1 step [1] listener stub description**
+
+Find §6.1 step [1] in the spec. The current text describes the listener as a stub awaiting B6 manual smoke. Replace with a sentence describing the production implementation:
+
+```markdown
+**[1] D-Bus listener thread**: `kotoha-engine-ibus::listener::run` が `blocking::connection::Builder::serve_at + name` 経由で `org.freedesktop.IBus.Engine.Kotoha` bus name + `/org/freedesktop/IBus/Engine/Kotoha` object path を publish し、`KotohaEngineService` struct(`#[interface]` macro)が IBus 1.5.x の 4 主要 method(`ProcessKeyEvent` / `FocusOut` / `Reset` / `Disable`)+ 2 no-op stub(`FocusIn` / `Enable`)を decode する。`process_key_event` は `Event::IBusKey { event, respond }` 経由で engine-loop に dispatch し、`recv_timeout(100ms)` で `KeyEventResult` を待つ。詳細は `docs/specs/_uncategorized/p3-b-ibus-listener.md` および ADR 0021 を参照。
+```
+
+(adapt wording to fit the surrounding text — preserve the existing §6.1 numbered structure)
+
+- [ ] **Step 2: Update §11 acceptance criteria checkboxes**
+
+Find §11 (or the equivalent section listing Phase 3-B acceptance criteria). Mark items B6-b satisfies as complete:
+
+- listener が IBus daemon registration を行う: `[x]` (B6-b 実装済、ADR 0021)
+- 4 IBus methods decoded: `[x]`
+- `KOTOHA_ALLOW_LISTENER_STUB_ENV` 削除: `[x]`
+
+Items still pending (B6-c #196 manual smoke):
+- L3 manual smoke 10 件: `[ ]` (#196 で扱う)
+- coalescing-window 値 empirical 確定: `[ ]` (#196 manual smoke 内で観測)
+
+(scan §11 carefully, mark only what B6-b actually delivers — defer manual smoke / empirical observations to #196)
+
+- [ ] **Step 3: Update frontmatter `last_reviewed`**
+
+In the spec frontmatter, change `last_reviewed: 2026-05-06` (or whatever current value) to `last_reviewed: 2026-05-08`.
+
+- [ ] **Step 4: Append to revision history (if exists in spec, otherwise skip)**
+
+If `## 改訂履歴` table exists at the end:
+
+```markdown
+| 2026-05-08 | Phase 3-B B6-b(#195)merge 後の §6.1 step [1] / §11 acceptance criteria 更新。listener 実装が production 化、ADR 0021 起票 |
+```
+
+- [ ] **Step 5: Verify pre-commit hooks**
+
+```bash
+git add docs/specs/_uncategorized/p3-a-ibus-engine.md
+```
+
+Run `lefthook run pre-commit` if needed; expect doc-naming + frontmatter validation to pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "docs(spec): mark P3-B B6-b acceptance criteria complete in p3-a-ibus-engine (#195)"
+```
+
+---
+
+## Task 8: Update ROADMAP
+
+**Files:**
+- Modify: `docs/ROADMAP.md`
+
+- [ ] **Step 1: Update Active milestone v0.3.0 table**
+
+Find the table under `### v0.3.0 — Phase 3 IBus integration`. The row for #136 currently reads:
+
+```markdown
+| [#136](...) P3-B B3 + B6: signal listener loop + L3 manual smoke | `docs/specs/_uncategorized/p3-a-ibus-engine.md` | [ ] |
+```
+
+Status remains `[ ]` (B6-c #196 manual smoke is still pending). Add a sub-bullet or note clarifying B6-a/b complete.
+
+Also add a new row for #195:
+
+```markdown
+| [#195](https://github.com/std-koh-hinooka/kotoha-ime/issues/195) P3-B B6-b: zbus MessageStream decode + IBus engine factory registration | `docs/specs/_uncategorized/p3-b-ibus-listener.md` | [x] |
+```
+
+(Insert this row above the #136 row to maintain logical ordering.)
+
+- [ ] **Step 2: Update Phase 3-B sub-milestone table**
+
+Find `## Phase 3 マイルストーン分割` section. Update the B6 row:
+
+Before:
+```markdown
+| **B6 (#136 残)** | L3 manual smoke on GNOME Wayland(...)+ zbus `MessageStream` 完全 decode + SIGTERM/SIGINT hook(ADR 0020 §影響 rev2 で deferral 明記) | **未着手** |
+```
+
+After:
+```markdown
+| **B6-a (#197)** | SIGTERM/SIGINT shutdown hook in kotoha-bin (ctrlc crate) | **完了**(PR #198 squash `4ea777c`) |
+| **B6-b (#195)** | zbus `blocking::Builder` + `#[interface]` 経由の IBus engine method decode + factory registration、ADR 0021 | **完了**(PR #<TBD>) |
+| **B6-c (#196 残)** | L3 manual smoke on GNOME Wayland(Firefox / GNOME Text Editor / VS Code で典型変換 10 件)、coalescing window empirical 確定 | **進行中**(B6-b merge 後、user-driven 実機検証) |
+```
+
+(replace the single B6 row with these 3 rows)
+
+- [ ] **Step 3: Update Phase 3 status row in `## Phase 一覧` table**
+
+Before:
+```markdown
+| 3 | IBus integration | IBus engine(GNOME Mutter 用) | **進行中** (P3-A draft + P3-B B0/B0g/B0h 全/B1/B2/B3/B4/B5 完了。残 B6 = L3 manual smoke + zbus decode + SIGTERM hook) |
+```
+
+After:
+```markdown
+| 3 | IBus integration | IBus engine(GNOME Mutter 用) | **進行中** (P3-A draft + P3-B B0/B0g/B0h 全/B1/B2/B3/B4/B5/B6-a/B6-b 完了。残 B6-c = L3 manual smoke #196 のみ) |
+```
+
+- [ ] **Step 4: Add revision history entry**
+
+Find the `## 改訂履歴` table at the bottom. Add a new top row:
+
+```markdown
+| 2026-05-08 | Phase 3-B B6-b(#195、PR #<TBD>)merge 完了。listener stub から production 実装(zbus `#[interface]` + `blocking::Builder`)へ置換、ADR 0021 起票。Phase 3-B sub-milestone table を B6-a / B6-b / B6-c に分割記載。Phase 3 status row 更新(残 B6-c のみ)|
+```
+
+(`<TBD>` は実 PR 番号で commit 直前に置換するか、commit 後の amend で更新)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ROADMAP.md
+git commit -m "docs(roadmap): mark P3-B B6-a/B6-b complete; split B6 sub-milestone table (#195)"
+```
+
+---
+
+## Task 9: Final verification + push + PR
+
+- [ ] **Step 1: Workspace-wide build**
+
+```bash
+cargo build --workspace --all-features 2>&1 | tail -3
+```
+Expected: `Finished`.
+
+- [ ] **Step 2: Workspace-wide clippy with -D warnings**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1 | tail -3
+```
+Expected: `Finished` with no `warning:` or `error:` lines.
+
+- [ ] **Step 3: Workspace-wide test**
+
+```bash
+cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers 2>&1 | /usr/bin/grep -E "FAILED|^failures:" | head -5
+echo "---all clear if no FAILED above---"
+```
+Expected: empty output above the marker (no failures). If `kotoha-storage` SQLite parallel test flake fires, retry once.
+
+- [ ] **Step 4: Format check**
+
+```bash
+cargo fmt --all -- --check 2>&1 | tail -3
+```
+Expected: empty output (no diff). If diff prints, run `cargo fmt --all` and amend the most recent commit.
+
+- [ ] **Step 5: Push (triggers pre-push hook chain)**
+
+```bash
+git push -u origin feature/195-zbus-listener-decode 2>&1 | tail -10
+```
+
+The pre-push hook runs `build` + `clippy` + `manifest-check` + `obsidian-sync` + `test` + `test-dict` + `test-dict-persist`. All must pass. If `test-dict-persist` flakes (kotoha-storage SQLite parallel), retry the push.
+
+- [ ] **Step 6: Switch gh account if needed and create PR**
+
+```bash
+gh auth switch --user std-koh-hinooka
+gh pr create --base develop \
+  --title "feat(engine-ibus,bin): production IBus listener via zbus #[interface] + 100ms response channel (#195)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Replace the kotoha-engine-ibus listener stub with a production zbus 5 `#[interface]` dispatcher that decodes 4 IBus engine methods (+ 2 introspection no-op stubs) and forwards them as `Event` to engine-loop. `Event::IBusKey` extends with a bounded response `Sender<KeyEventResult>` so `process_key_event` returns the IME-correct bool with a 100ms timeout fallback. `KOTOHA_ALLOW_LISTENER_STUB` env var safety net is removed entirely. Closes #195.
+
+## Spec & ADR
+
+- Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md`
+- ADR: 0021 (zbus integration architecture for IBus listener)
+- Plan: `docs/plans/2026-05-08-feature-195-zbus-listener-decode.md`
+
+## Change scope
+
+(filled in from `git diff --stat develop..HEAD` at commit time — expect ~500 lines)
+
+## Decisions captured
+
+- zbus 5 `#[interface]` macro on `KotohaEngineService` (rejected: `MessageStream` manual match)
+- `Event::IBusKey { event, respond }` synchronous response channel (rejected: `Arc<AtomicBool>` snapshot, `ForwardKeyEvent` two-phase signal)
+- 100ms timeout (rejected: 50ms — too tight for worker recovery case)
+
+## Self-review
+
+- **Architecture**: aligns ADR 0017 (tokio non-dependence) and ADR 0020 (4-thread lock-free); zbus internal smol executor does not propagate to crate code
+- **Type design**: `Event::IBusKey` struct variant makes the response channel mandatory at the type level; bounded(1) channel enforces 1:1 send/recv
+- **Testing**: 9 L1 unit tests cover the 4 process_key_event paths + 3 reset paths + 2 stub paths; 1 L2 integration test (`#[ignore]` for dbus session bus) exercises decode end-to-end
+- **Silent failure**: timeout / disconnect both emit `tracing::warn!` with `error_id` for log filtering
+- **Performance**: typical 1ms response; pathological case fallback at 100ms still under 10 keys/sec inter-keystroke interval
+
+## Test plan
+
+- [x] cargo build --workspace --all-features clean
+- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings clean
+- [x] cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers (0 failures)
+- [x] cargo fmt --all -- --check clean
+- [x] lefthook pre-commit + pre-push pass
+- [ ] L2 integration test under `cargo test -- --ignored` (manual, dev machine)
+- [ ] L3 manual smoke deferred to #196
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Note: PR creation may need `gh auth switch --user std-koh-hinooka` first if active account differs.
+
+- [ ] **Step 7: Self-review the diff**
+
+Open the PR in browser. Skim the diff for:
+- Any commented-out code that should be deleted
+- Unused imports surfaced by clippy --all-targets
+- Doc comments referencing removed types (`ListenerStubRefused`, `KOTOHA_ALLOW_LISTENER_STUB_ENV`)
+- ADR 0021 internal cross-references resolving correctly
+
+If issues found, push fix commits before merge.
+
+- [ ] **Step 8: Merge PR (under (c) cadence pre-authorization)**
+
+```bash
+gh pr merge <PR-number> --squash --delete-branch
+```
+
+- [ ] **Step 9: Sync develop locally**
+
+```bash
+git checkout develop
+git pull --ff-only
+git branch -d feature/195-zbus-listener-decode 2>&1 || true
+```
+
+- [ ] **Step 10: Update todos**
+
+Mark #195 implementation complete in TodoWrite. Note the next pending task is #196 (L3 manual smoke), which is user-driven.
+
+---
+
+## Self-review of this plan
+
+**1. Spec coverage**
+
+Walking spec sections vs plan tasks:
+
+- §2.1 scope: 6 methods + bus name + Event::IBusKey + safety-net removal + ADR — covered Tasks 1-6
+- §3 architecture: covered in Task 4 listener.rs rewrite
+- §4 KotohaEngineService API: Task 3
+- §5 data flow: Task 3 (service code) + Task 2 (engine_loop)
+- §6 timeout: Task 3 (PROCESS_KEY_EVENT_TIMEOUT constant)
+- §7 daemon integration: Task 4 (Builder chain)
+- §8 deletion: Task 4 step 1
+- §9 error: Task 3 (tracing) + Task 4 (Connection drop on shutdown)
+- §10 testing: Task 3 (L1 unit) + Task 5 (L2 ignored)
+- §11 implementation roadmap: this plan is the operational version
+- §12 ADR + spec updates: Task 6 (ADR 0021) + Task 7 (spec p3-a) + Task 8 (ROADMAP)
+- §13 forward direction: documentation only, no task
+
+✓ All sections mapped.
+
+**2. Placeholder scan**
+
+Searching for "TBD" / "TODO" / "implement later":
+
+- "PR #<TBD>" appears in Task 8 (ROADMAP entry) — intentional, replaced at commit time
+- Step 7 of Task 9 says "Open the PR in browser. Skim the diff" — this is a real action, not a placeholder
+- Otherwise no `TBD` / `add appropriate error handling` / similar placeholders
+
+✓ No placeholder violations.
+
+**3. Type consistency**
+
+- `Event::IBusKey { event, respond }` — same field names in event.rs, engine_loop.rs, service.rs throughout
+- `KeyEventResult::{Consumed, Forwarded}` — used consistently in service.rs unit tests + ADR + spec
+- `IBUS_ENGINE_BUS_NAME` / `IBUS_ENGINE_OBJECT_PATH` — referenced consistently in Task 1 (define) + Task 4 (use)
+- `KotohaEngineService` — same struct name throughout
+- `ShutdownObserver` / `ListenerShutdown` — consistent (defined in #187, kept in Task 4 with 3 unit tests preserved)
+- `run(bridge_tx, shutdown)` signature change in Task 4 step 2 + main.rs caller update in Task 4 step 3 — consistent
+
+✓ Names match across tasks.
+
+**4. Sequence soundness**
+
+- Task 1 (constants): independent, no dependency
+- Task 2 (Event variant change): breaks build until callers updated; updated atomically within Task 2
+- Task 3 (service.rs): depends on Task 2 (uses new variant); references constants from Task 1
+- Task 4 (listener.rs rewrite): depends on Task 1 (constants) + Task 3 (service struct)
+- Task 5 (L2 test): depends on Task 4 (run signature)
+- Task 6 (ADR): independent, can run any time after Task 4 implementation is fixed
+- Task 7 (spec p3-a): independent
+- Task 8 (ROADMAP): independent
+- Task 9 (final verify + PR): depends on all preceding
+
+✓ Sequence is sound.

--- a/docs/specs/_uncategorized/p3-a-ibus-engine.md
+++ b/docs/specs/_uncategorized/p3-a-ibus-engine.md
@@ -5,7 +5,7 @@ bounded_context: _uncategorized
 related_issues: ["#128", "#136", "#149"]
 related_prs: []
 glossary_refs: ["candidate","coalescing-window","event-reactor","event-loop","fan-in","hexagonal-architecture","hybrid-ranker","ime-engine","ime-host-bridge","kana","kotoha-engine","kotoha-storage","layer-3-smoke","lefthook","partial-input","phase3-ibus-engine-terms","preedit","ranker-worker","romaji"]
-last_reviewed: 2026-05-06
+last_reviewed: 2026-05-08
 ---
 
 # Phase 3-A: IBus engine integration design spec
@@ -453,7 +453,7 @@ Phase 3-B B0h-f + B3 一体化(ADR 0020)で、本 §6 / §7 の処理は以下�
 | Thread | 役割 | 既存 spec 参照 |
 |---|---|---|
 | `main` | DI wiring、thread spawn、SIGTERM/SIGINT 受領、join 順制御 | §3.3 |
-| `kotoha-dbus-listener` | zbus `blocking::MessageStream` で IBus method を受信、`Event::IBusKey` / `Event::IBusReset` に decode して bridge channel に送る | §6.1 step [1] / §6.4 入口 |
+| `kotoha-dbus-listener` | zbus `blocking::connection::Builder::serve_at + name` で `org.freedesktop.IBus.Engine.Kotoha` を publish し、`KotohaEngineService`(`#[interface]` macro)が IBus 1.5.x の 4 主要 method + 2 no-op stub を decode、`Event::IBusKey { event, respond }` / `Event::IBusReset` に変換して bridge channel に送る(B6-b #195、ADR 0021) | §6.1 step [1] / §6.4 入口 / `docs/specs/_uncategorized/p3-b-ibus-listener.md` |
 | `kotoha-engine-loop` | `KotohaEngine` を単独所有、`EventReactor::recv()` で multiplex、apply_candidate_update を実行 | §6 全体の dispatch 主体 |
 | `kotoha-ranker-worker` | 既存 `RankerWorker` パターン継承、`Event::WorkerOutput` で送信 | §7 worker 仕様 |
 

--- a/docs/specs/_uncategorized/p3-b-ibus-listener.md
+++ b/docs/specs/_uncategorized/p3-b-ibus-listener.md
@@ -1,0 +1,432 @@
+---
+feature: p3-b-ibus-listener
+status: draft
+bounded_context: _uncategorized
+related_issues: ["#136", "#195"]
+related_prs: []
+glossary_refs: ["coalescing-window", "event-loop", "event-reactor", "ime-engine", "ime-host-bridge", "phase3-ibus-engine-terms", "preedit"]
+last_reviewed: 2026-05-08
+---
+
+# Phase 3-B B6-b: IBus engine method dispatch listener
+
+| 項目 | 値 |
+|------|----|
+| Phase | Phase 3 (IBus integration) — milestone P3-B、sub-task B6-b |
+| ISSUE | [#195](https://github.com/std-koh-hinooka/kotoha-ime/issues/195) (parent: [#136](https://github.com/std-koh-hinooka/kotoha-ime/issues/136)) |
+| 起票日 | 2026-05-08 |
+| Status | Draft |
+| 関連 ADR(候補) | 0021(zbus integration architecture for IBus engine listener) |
+| 前提 spec | `docs/specs/_uncategorized/p3-a-ibus-engine.md`、`docs/adr/0020-event-loop-architecture.md` |
+| 前提 PR | #183 (B0h-f + B3 event-loop)、#187 (ShutdownObserver)、#193 (RequestId)、#198 (SIGTERM hook) |
+
+## 目次
+
+1. [§1 概要](#1-概要)
+2. [§2 スコープと範囲外](#2-スコープと範囲外)
+3. [§3 architecture](#3-architecture)
+4. [§4 `KotohaEngineService` API contract](#4-kotohaengineservice-api-contract)
+5. [§5 data flow(`process_key_event` 経路)](#5-data-flowprocess_key_event-経路)
+6. [§6 respond channel と 100ms timeout 規約](#6-respond-channel-と-100ms-timeout-規約)
+7. [§7 IBus daemon integration](#7-ibus-daemon-integration)
+8. [§8 削除コード](#8-削除コード)
+9. [§9 error handling と observability](#9-error-handling-と-observability)
+10. [§10 testing strategy](#10-testing-strategy)
+11. [§11 implementation roadmap](#11-implementation-roadmap)
+12. [§12 spec / ADR の更新箇所](#12-spec--adr-の更新箇所)
+13. [§13 forward direction](#13-forward-direction)
+
+---
+
+## §1 概要
+
+本 spec は Phase 3-B の sub-milestone **B6-b**(zbus `MessageStream` decode + IBus engine factory registration)の設計書である。
+
+Phase 3-B B0h-f + B3 (PR #183, ADR 0020) で 4-thread topology の architectural skeleton が完成したが、`kotoha-engine-ibus::listener::run` は zbus message stream の decode を実装せず、`KOTOHA_ALLOW_LISTENER_STUB=1` で起動を許可する stub に留まっていた。本 spec は listener thread を **IBus daemon からの method 呼び出しを実 receive + decode する production 実装** に置き換える設計を定める。
+
+本 spec の workflow 上の位置:
+
+```text
+[#198 SIGTERM hook merge 済] → [本 spec 起票] → [implementation plan 起票 / writing-plans skill] → [実装 PR (#195)]
+                                                                                                   ↓
+                                                               [#196 L3 manual smoke (実機検証)]
+                                                                                                   ↓
+                                                                              [v0.3.0 milestone close]
+```
+
+本 spec scope 完了後、Phase 3-B の残課題は **B6-c (#196 L3 manual smoke 実機検証)** のみとなる。
+
+---
+
+## §2 スコープと範囲外
+
+### §2.1 本 spec scope
+
+- zbus 5 `#[interface]` macro による IBus 1.5.x engine method dispatcher 実装
+- 以下 6 method の dispatch:
+  - `ProcessKeyEvent(u keyval, u keycode, u state) -> b`(主要、戻り値 b は Kotoha が消費したか)
+  - `Reset()` / `FocusOut()` / `Disable()`(reset 系 3 種)
+  - `FocusIn()` / `Enable()`(no-op stub、daemon 側 introspection 互換のため)
+- `org.freedesktop.IBus.Engine.Kotoha` bus name 取得(`RequestName` via `blocking::connection::Builder::name`)
+- `/org/freedesktop/IBus/Engine/Kotoha` object path での service 登録
+- `Event::IBusKey { event, respond }` enum 拡張(respond channel)
+- engine_loop の `Event::IBusKey` arm に `respond.send(KeyEventResult)` 経路追加
+- `KOTOHA_ALLOW_LISTENER_STUB_ENV` / `allow_listener_stub` / `ListenerStubRefused` 削除
+- ADR 0021 起票(zbus integration architecture for IBus engine listener)
+
+### §2.2 本 spec 範囲外
+
+- **L3 manual smoke 実機検証**(別 ISSUE [#196](https://github.com/std-koh-hinooka/kotoha-ime/issues/196))
+- **PageUp / PageDown / CursorUp / CursorDown / CandidateClicked 等の高度 method**(Phase 5 / 6 で UI 機能拡張時に追加)
+- **`/usr/share/ibus/component/kotoha.xml` の component 記述ファイル**(installer / packaging 段階で扱う、現状は `cargo run --bin kotoha` で開発時 ibus daemon と直接対話する想定)
+- **Phase 4 fcitx5 adapter**(別 Phase)
+- **Phase 5 partial-input + beam search**(別 Phase)
+
+---
+
+## §3 architecture
+
+### §3.1 thread topology は ADR 0020 を継承
+
+ADR 0020 §採択 Q4 で確定した 4-thread topology を維持する:
+
+| thread | 主責務 | 本 spec での変更 |
+|---|---|---|
+| `main` | DI wiring、SIGTERM/SIGINT、join | (変更なし、#198 で SIGTERM hook 完成済) |
+| `kotoha-dbus-listener` | IBus method 受信 + decode + bridge channel 送信 | **本 spec scope**。stub から production 実装へ |
+| `kotoha-engine-loop` | `EventReactor::recv()` で multiplex、apply_candidate_update | `Event::IBusKey` arm の respond.send 経路追加 |
+| `kotoha-ranker-worker` | `Event::WorkerOutput` 生成 | (変更なし) |
+
+### §3.2 listener thread の内部構造
+
+```text
+[IBus daemon] --DBus method calls--> [zbus::blocking::Connection]
+                                        ↓ (内部 smol executor、zbus が管理)
+                                        ↓ (#[interface] dispatcher)
+                                   [KotohaEngineService struct]
+                                     - bridge_tx: Sender<Event>
+                                        ↓ bridge_tx.send(Event::IBusKey { event, respond })
+                                   [crossbeam unbounded channel: bridge]
+                                        ↓
+                                   [kotoha-engine-loop thread]
+                                        ↓ engine.process_key_event(event)
+                                        ↓ respond.send(KeyEventResult)
+                                   [crossbeam bounded(1) channel: response]
+                                        ↓
+                                   [KotohaEngineService::process_key_event]
+                                        ↓ bool 返却
+                                   [zbus が daemon に反映]
+```
+
+`blocking::Connection` は zbus 内部の smol executor を背景 thread で走らせる。`#[interface]` impl の各 method は smol executor 経由で dispatch される(本 crate のコード自身は std::sync 同期 primitive のみ使用)。
+
+### §3.3 Connection ownership
+
+listener thread は `blocking::Connection` を **単独所有** する(`let conn = ...build()?` で local に bind)。Connection drop 時に zbus の内部 executor が exit し、bus name が release される。
+
+`ShutdownObserver` を polling し、shutdown 観測時に Connection を drop して thread を抜ける。
+
+---
+
+## §4 `KotohaEngineService` API contract
+
+### §4.1 配置と visibility
+
+- 配置: `crates/kotoha-engine-ibus/src/service.rs`(新規 module)
+- visibility: `pub(crate) struct KotohaEngineService`(crate 外部に export しない)
+- `listener::run` 内のみで構築・使用される
+
+### §4.2 struct 定義
+
+```rust
+pub(crate) struct KotohaEngineService {
+    /// engine-loop thread に Event を送る単方向 channel。
+    bridge_tx: crossbeam_channel::Sender<Event>,
+}
+```
+
+`bridge_tx` 以外の field は持たない:
+
+- engine state を direct に読まない(ADR 0020 §採択 Q4 lock-free 原則)
+- `ShutdownObserver` は `listener::run` の poll loop 専用、service struct は知らない
+- KeyEvent 変換 helper は free function(`KeyEvent::from_ibus_raw`)で渡す
+
+### §4.3 `#[interface]` impl
+
+`#[interface(name = "org.freedesktop.IBus.Engine")]` で 6 method を実装する:
+
+| method | signature | 内部動作 |
+|---|---|---|
+| `process_key_event` | `(u32, u32, u32) -> bool` | `Event::IBusKey { event, respond }` 送信 + 100ms blocking recv → bool |
+| `focus_out` | `() -> ()` | `Event::IBusReset(IBusResetKind::FocusOut)` 送信(応答不要)|
+| `reset` | `() -> ()` | `Event::IBusReset(IBusResetKind::Reset)` 送信 |
+| `disable` | `() -> ()` | `Event::IBusReset(IBusResetKind::Disable)` 送信 |
+| `focus_in` | `() -> ()` | `tracing::debug!`(daemon の introspection 互換用 stub)|
+| `enable` | `() -> ()` | `tracing::debug!`(同上)|
+
+`#[interface]` macro が生成する method は同期(blocking)で書く。zbus 5 の smol executor が background thread で dispatch を回すため、本 crate コード自身は async/await を使わない(ADR 0017 / ADR 0020 の "core は tokio 非依存" 原則維持)。
+
+### §4.4 IBus 1.5.x 仕様準拠点
+
+- interface 名: `org.freedesktop.IBus.Engine`(`crates/kotoha-engine-ibus/src/proxy.rs::IBUS_ENGINE_INTERFACE` と共有)
+- `ProcessKeyEvent` の signature `uuu` は IBus 1.5.x `bus/inputcontext.c` 仕様に準拠
+- 戻り値 `b`(true = 消費した、false = アプリに forward する)も同仕様
+
+---
+
+## §5 data flow(`process_key_event` 経路)
+
+### §5.1 listener 側 dispatch
+
+```rust
+fn process_key_event(&self, keyval: u32, keycode: u32, state: u32) -> bool {
+    let event = KeyEvent::from_ibus_raw(keyval, keycode, state);
+    let (resp_tx, resp_rx) = crossbeam_channel::bounded::<KeyEventResult>(1);
+    if self
+        .bridge_tx
+        .send(Event::IBusKey { event, respond: resp_tx })
+        .is_err()
+    {
+        // engine-loop 側 receiver drop = engine 死亡。app へ forward (= keystroke 失わない)
+        tracing::warn!(
+            error_id = "listener.process_key_event.bridge_disconnected",
+            "engine-loop disconnected; forwarding key to app"
+        );
+        return false;
+    }
+    match resp_rx.recv_timeout(Duration::from_millis(100)) {
+        Ok(KeyEventResult::Handled) => true,
+        Ok(KeyEventResult::Forwarded) => false,
+        Err(_) => {
+            tracing::warn!(
+                error_id = "listener.process_key_event.timeout",
+                "engine response timeout (>100ms); forwarding key to app"
+            );
+            false
+        }
+    }
+}
+```
+
+### §5.2 engine_loop 側 dispatch
+
+```rust
+Ok(Event::IBusKey { event, respond }) => {
+    let result = engine.process_key_event(event);
+    // listener が timeout した場合 send は Err、ignore (= key は app に forward 済)
+    let _ = respond.send(result);
+}
+```
+
+`KeyEventResult` は engine 状態機械の出力(spec §5.2)で、`Handled` / `Forwarded` の 2 variant を持つ既存型。
+
+---
+
+## §6 respond channel と 100ms timeout 規約
+
+### §6.1 timeout 値の根拠
+
+100ms timeout は以下を考慮した値:
+
+| ケース | engine_loop 処理時間 | 100ms timeout 内に収まるか |
+|---|---|---|
+| 通常 | ~1ms(state machine + worker channel send + respond.send) | ✓ |
+| heavy(30 候補 Replace + filter) | ~5-10ms | ✓ |
+| recovery(worker 死亡 → 再 spawn) | ~30-50ms | ✓ |
+| bug(>100ms) | timeout fire → app へ forward + tracing::warn | (fallback 経路) |
+
+10 keys/sec ピーク typing(inter-keystroke 100ms)に対し、通常 1ms / heavy 10ms / recovery 50ms 全てを 100ms 内で吸収する。fast typist の DX を損なわない。
+
+### §6.2 timeout fire 時の double-input 懸念
+
+timeout 後に engine が eventual に event を処理して `Handled` 判定した場合、preedit が表示されつつ app も raw key を受信する double-input 状態が原理的にありうる:
+
+- 発生条件: engine_loop が 100ms 以上 hang(= bug 状態)
+- 観測経路: `error_id = "listener.process_key_event.timeout"` を log filter で監視
+- mitigation: bug 状態を fix する。本 spec scope では `respond.send` Err を engine 側で観測したら処理を abort する deadline check は **入れない**(複雑性 vs benefit が見合わない)
+- Phase 5 / 6 で engine が重くなる場合は再評価し、必要なら `Event::IBusKey { event, respond, deadline: Instant }` への拡張を検討する
+
+### §6.3 `bounded(1)` の選択理由
+
+response channel は `bounded(1)`(1 element capacity):
+
+- engine 側は必ず 1 度だけ `respond.send` を呼ぶ → capacity 1 で十分
+- listener は必ず 1 度だけ `recv_timeout` を呼ぶ
+- unbounded だと send が blocking しない代わりに backpressure 検出機会を失う。bounded(1) は send / recv 1:1 を構造的に enforce する
+
+---
+
+## §7 IBus daemon integration
+
+### §7.1 bus name と object path
+
+```rust
+pub(crate) const IBUS_ENGINE_BUS_NAME: &str = "org.freedesktop.IBus.Engine.Kotoha";
+pub(crate) const IBUS_ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
+```
+
+新規定数として `crates/kotoha-engine-ibus/src/proxy.rs` に追加(既存 `IBUS_ENGINE_INTERFACE` と同じ module)。
+
+### §7.2 connection 構築
+
+```rust
+let connection = blocking::connection::Builder::session()?
+    .serve_at(IBUS_ENGINE_OBJECT_PATH, KotohaEngineService { bridge_tx })?
+    .name(IBUS_ENGINE_BUS_NAME)?
+    .build()?;
+```
+
+`build()` 完了時点で:
+
+- session bus への connection 確立
+- service struct が指定 path で publish
+- bus name `RequestName` で daemon に登録(他 process が同名で publish していたら `Err` で listener 起動失敗)
+
+### §7.3 `org.freedesktop.IBus.IBus.RegisterComponent` の取扱
+
+IBus 1.5.x では engine 登録の正規経路は `/usr/share/ibus/component/<name>.xml` ファイル配置 + ibus daemon 再起動である。`RegisterComponent` DBus method 経由の dynamic 登録もあるが、daemon 側が file ベースの registry を優先するため一般的でない。
+
+本 spec scope では:
+
+- DBus call 経路の `RegisterComponent` は **使用しない**
+- `kotoha.xml` 配置経路は **packaging task として後続 ISSUE で扱う**(本 spec 範囲外、§2.2)
+- 開発時は手動で `~/.config/ibus/component/kotoha.xml` を配置するか、ibus daemon を直接 reset して name 取得状態を観測する(L3 manual smoke #196 で検証)
+
+---
+
+## §8 削除コード
+
+本 spec で listener が production 実装になるため、以下の stub safety net を完全削除する:
+
+| 削除対象 | 配置 | 理由 |
+|---|---|---|
+| `KOTOHA_ALLOW_LISTENER_STUB_ENV` 定数 | `listener.rs` | listener が機能するため env var 不要 |
+| `allow_listener_stub()` 関数 | 同上 | 同上 |
+| `ListenerStubRefused` struct + `thiserror::Error` impl | 同上 | 同上 |
+| stub 起動時 `tracing::error!`(STUB mode 警告)| 同上 | listener が機能するため警告不要 |
+| 既存 stub poll loop(`while !shutdown.load() { sleep(50ms) }`)| 同上 | service 経由 dispatch に置換 |
+| 既存 unit test 2 件(`run_refuses_to_start_without_env_var` / `run_exits_within_200ms_after_shutdown_request`)| 同上 | stub 自体が消えるため obsolete |
+
+`ShutdownObserver` 関連 unit test 3 件(`observer_reflects_trigger_state` / `cloned_observer_shares_state` / `cloned_trigger_shares_state`)は **維持**(SIGTERM hook の正当性を pin する)。
+
+---
+
+## §9 error handling と observability
+
+### §9.1 listener 経路の error 表
+
+| 状況 | listener 動作 | observability |
+|---|---|---|
+| zbus connection 確立失敗 | `run()` Err で main thread に伝播 → process exit | `tracing::error!` + `?` propagation |
+| `RequestName` 失敗(他 process が同名占有)| 同上 | 同上 |
+| service method 内 panic | `&self` impl で field なし、panic 起こりにくい。万一発生時は zbus が catch して daemon に Err 返却、connection は維持 | zbus 標準 |
+| bridge_tx.send Err(engine_loop drop)| `false` 返却 + `error_id = "listener.process_key_event.bridge_disconnected"` | tracing::warn |
+| respond.recv timeout(>100ms)| `false` 返却 + `error_id = "listener.process_key_event.timeout"` | tracing::warn |
+| ShutdownObserver `is_shutting_down() == true` | poll loop 抜ける、Connection drop | `tracing::info!` |
+
+### §9.2 spec §9.3「silent failure 禁止」整合
+
+- timeout は warn level + `error_id` 付きで観測経路を残す(bug 早期検出)
+- bridge_tx disconnect は warn level(IME を黙って disable しない)
+- 通常経路の successful dispatch は `tracing::trace!` のみ(hot path、log volume 抑制)
+
+---
+
+## §10 testing strategy
+
+### §10.1 layer 別 test
+
+| Layer | テスト対象 | 配置 | gating |
+|---|---|---|---|
+| L1 unit | `KotohaEngineService::process_key_event` の正常 / timeout / disconnect 経路 | `crates/kotoha-engine-ibus/src/service.rs` `#[cfg(test)]` | 無条件(mock bridge_tx) |
+| L1 unit | `KotohaEngineService::{focus_out, reset, disable, focus_in, enable}` の Event 送信 | 同上 | 同上 |
+| L1 unit | `Event::IBusKey { event, respond }` の destructure と engine_loop 経路 | `crates/kotoha-bin/src/engine_loop.rs` `#[cfg(test)]` または既存 integration test | mock reactor + mock host |
+| L2 integration | listener thread + engine_loop + dummy bridge channel 経路で `process_key_event` が `Handled` を返す | `crates/kotoha-engine-ibus/tests/integration.rs`(新規) | `#[ignore]`(dbus session bus 必要)|
+| L3 manual | 実機 IBus daemon に register、Firefox / GNOME Editor / VS Code で型変換 10 件 | `docs/wbs/<date>-phase3b-b6-l3-smoke.md` | 別 PR(#196)|
+
+### §10.2 既存 test の preservation
+
+- `crates/kotoha-engine-reactor-linux/tests/integration.rs`(shutdown / fan-in / bursty / explicit_shutdown)は **無修正で pass** すべき
+- `crates/kotoha-engine-ibus/src/listener.rs::tests` の `ShutdownObserver` 系 3 件は維持
+- engine_loop 経路の既存 test(`engine_wrap_hybrid` 等)は `Event::IBusKey` の variant 形式変更に追随した update が必要
+
+### §10.3 mock 戦略
+
+- `KotohaEngineService` の test では bridge_tx を `crossbeam_channel::unbounded()` の `Sender` で構築し、test 内で `Receiver` を直接 drain して送信内容を assert
+- L2 integration の dbus session bus は CI 環境差異の温床なので `#[ignore]` で opt-in
+- production-like test は L3 manual smoke(#196)で実施
+
+---
+
+## §11 implementation roadmap
+
+実装は以下の順序で進める(各 step は同 PR 内、commit 単位):
+
+1. **Event::IBusKey 変更**: `crates/kotoha-engine-core/src/reactor/event.rs` の `Event::IBusKey(KeyEvent)` を `Event::IBusKey { event: KeyEvent, respond: Sender<KeyEventResult> }` に変更。callers(engine_loop + tests)を update
+2. **proxy.rs 定数追加**: `IBUS_ENGINE_BUS_NAME` / `IBUS_ENGINE_OBJECT_PATH`
+3. **service.rs 新規**: `KotohaEngineService` struct + `#[interface]` impl(6 method)+ unit tests
+4. **listener.rs rewrite**: `KOTOHA_ALLOW_LISTENER_STUB` 関連削除、`run()` を `blocking::connection::Builder` 経路に書き換え
+5. **kotoha-bin/src/main.rs 更新**: `KOTOHA_ALLOW_LISTENER_STUB=1` env var を起動時に export していた warning コメントの撤去(#197 で SIGTERM 関連 cleanup 済)
+6. **engine_loop.rs 更新**: `Event::IBusKey { event, respond }` の destructure + `respond.send(result)` 追加
+7. **L1 / L2 test 追加**
+8. **ADR 0021 起票**
+9. **`docs/specs/_uncategorized/p3-a-ibus-engine.md` の §6.1 step [1] / §11 acceptance criteria 更新**
+10. **ROADMAP の Phase 3-B sub-milestone table 更新**(B6-b 完了マーク、B6-c 残)
+
+PR size 想定: ~400-600 lines(spec + source + test + ADR)。Large tier 上限 ≤1000 lines に収まる。
+
+---
+
+## §12 spec / ADR の更新箇所
+
+### §12.1 ADR 0021(新規)
+
+`docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md` を起票:
+
+- 採択: zbus 5 `#[interface]` macro + `blocking::connection::Builder::serve_at + name` + bounded response channel + 100ms timeout
+- rejected:
+  - `MessageStream` 手動 dispatch(zbus 5 では async API 主導、blocking 系で MessageStream 直接受信は限定的)
+  - `Arc<AtomicBool>` snapshot による listener-side enabled cache(spec §5.2 `Forwarded` 精度を犠牲)
+  - `ForwardKeyEvent` signal 二相 pattern(API surface + race + integration test 負荷増)
+
+### §12.2 spec p3-a-ibus-engine.md の更新
+
+- §6.1 step [1] の listener stub 表現を実装済表現に更新
+- §11 acceptance criteria の listener 関連項目を満了マーク
+- §13 Open Q 2(coalescing window 値)は #196 manual smoke で確定 → status: open のまま維持
+
+### §12.3 ROADMAP
+
+`docs/ROADMAP.md` の Active milestone v0.3.0 table:
+
+- ISSUE #195 entry(B6-b)を `[x]`
+- Phase 3-B sub-milestone table の B6 entry を「進行中(B6-c #196 残)」と更新
+
+---
+
+## §13 forward direction
+
+### §13.1 Phase 5 / 6 への影響
+
+本 spec で確立する zbus dispatch pattern は Phase 5 / 6 で以下の追加 method 実装に拡張する:
+
+- `PageUp` / `PageDown` / `CursorUp` / `CursorDown`(候補 navigation、Phase 6 UX polish)
+- `CandidateClicked(u32 index)`(マウス操作対応、Phase 6)
+- `PropertyActivate(s name, u state)`(設定 UI 連携、Phase 6)
+- `SetSurroundingText(v text, u cursor, u anchor)`(文脈 reranking、Phase 6 / Phase 7)
+
+これらは `KotohaEngineService` に method 追加、`Event` enum に variant 追加、engine_loop dispatch 拡張で対応する。本 spec の design pattern を踏襲できる。
+
+### §13.2 Phase 4 fcitx5 adapter との関係
+
+Phase 4 で fcitx5 用 adapter を追加する際、`kotoha-engine-fcitx5` crate を別途新設する。`kotoha-engine-core::reactor::Event` enum の `IBusKey` / `IBusReset` variant は `IBusKey` のまま rename せず、fcitx5 側は同 variant を「key event(protocol 由来 unified)」として再解釈するか、`Fcitx5Key` variant を追加する。判断は Phase 4 kick-off 時。
+
+### §13.3 timeout 値の再評価
+
+100ms timeout は「engine が pathological 状態でない限り発火しない」値として spec §6.1 で根拠を示している。Phase 5(custom romaji-base model)で engine_loop の処理時間が増える場合、以下を再評価する:
+
+- timeout 値の引き上げ(e.g., 200ms)
+- `Event::IBusKey { ..., deadline: Instant }` 拡張で engine 側 abort 経路追加
+- service method を async fn 化して smol::unblock で response 待機(ADR 0017 再評価必要)
+
+Phase 5 spec kick-off 時に決定する。

--- a/docs/specs/_uncategorized/p3-b-ibus-listener.md
+++ b/docs/specs/_uncategorized/p3-b-ibus-listener.md
@@ -149,7 +149,7 @@ pub(crate) struct KotohaEngineService {
 
 - engine state を direct に読まない(ADR 0020 §採択 Q4 lock-free 原則)
 - `ShutdownObserver` は `listener::run` の poll loop 専用、service struct は知らない
-- KeyEvent 変換 helper は free function(`KeyEvent::from_ibus_raw`)で渡す
+- KeyEvent 変換 helper は既存 free function(`crate::keysym::from_ibus(keysym, keycode, state) -> KeyEvent`、Phase 3-B B4 実装済)を使う
 
 ### §4.3 `#[interface]` impl
 
@@ -180,7 +180,9 @@ pub(crate) struct KotohaEngineService {
 
 ```rust
 fn process_key_event(&self, keyval: u32, keycode: u32, state: u32) -> bool {
-    let event = KeyEvent::from_ibus_raw(keyval, keycode, state);
+    // 既存 helper: crates/kotoha-engine-ibus/src/keysym.rs::from_ibus
+    // (Phase 3-B B4 で IBusModifierType → KeyModifiers full mapping 実装済)
+    let event = crate::keysym::from_ibus(keyval, keycode, state);
     let (resp_tx, resp_rx) = crossbeam_channel::bounded::<KeyEventResult>(1);
     if self
         .bridge_tx
@@ -195,7 +197,7 @@ fn process_key_event(&self, keyval: u32, keycode: u32, state: u32) -> bool {
         return false;
     }
     match resp_rx.recv_timeout(Duration::from_millis(100)) {
-        Ok(KeyEventResult::Handled) => true,
+        Ok(KeyEventResult::Consumed) => true,
         Ok(KeyEventResult::Forwarded) => false,
         Err(_) => {
             tracing::warn!(
@@ -218,7 +220,7 @@ Ok(Event::IBusKey { event, respond }) => {
 }
 ```
 
-`KeyEventResult` は engine 状態機械の出力(spec §5.2)で、`Handled` / `Forwarded` の 2 variant を持つ既存型。
+`KeyEventResult` は engine 状態機械の出力(spec §5.2)で、`Consumed` / `Forwarded` の 2 variant を持つ既存型(`crates/kotoha-engine-core/src/key_event.rs`)。
 
 ---
 
@@ -239,7 +241,7 @@ Ok(Event::IBusKey { event, respond }) => {
 
 ### §6.2 timeout fire 時の double-input 懸念
 
-timeout 後に engine が eventual に event を処理して `Handled` 判定した場合、preedit が表示されつつ app も raw key を受信する double-input 状態が原理的にありうる:
+timeout 後に engine が eventual に event を処理して `Consumed` 判定した場合、preedit が表示されつつ app も raw key を受信する double-input 状態が原理的にありうる:
 
 - 発生条件: engine_loop が 100ms 以上 hang(= bug 状態)
 - 観測経路: `error_id = "listener.process_key_event.timeout"` を log filter で監視
@@ -341,7 +343,7 @@ IBus 1.5.x では engine 登録の正規経路は `/usr/share/ibus/component/<na
 | L1 unit | `KotohaEngineService::process_key_event` の正常 / timeout / disconnect 経路 | `crates/kotoha-engine-ibus/src/service.rs` `#[cfg(test)]` | 無条件(mock bridge_tx) |
 | L1 unit | `KotohaEngineService::{focus_out, reset, disable, focus_in, enable}` の Event 送信 | 同上 | 同上 |
 | L1 unit | `Event::IBusKey { event, respond }` の destructure と engine_loop 経路 | `crates/kotoha-bin/src/engine_loop.rs` `#[cfg(test)]` または既存 integration test | mock reactor + mock host |
-| L2 integration | listener thread + engine_loop + dummy bridge channel 経路で `process_key_event` が `Handled` を返す | `crates/kotoha-engine-ibus/tests/integration.rs`(新規) | `#[ignore]`(dbus session bus 必要)|
+| L2 integration | listener thread + engine_loop + dummy bridge channel 経路で `process_key_event` が `true`(= Consumed)を返す | `crates/kotoha-engine-ibus/tests/integration.rs`(新規) | `#[ignore]`(dbus session bus 必要)|
 | L3 manual | 実機 IBus daemon に register、Firefox / GNOME Editor / VS Code で型変換 10 件 | `docs/wbs/<date>-phase3b-b6-l3-smoke.md` | 別 PR(#196)|
 
 ### §10.2 既存 test の preservation
@@ -366,8 +368,8 @@ IBus 1.5.x では engine 登録の正規経路は `/usr/share/ibus/component/<na
 2. **proxy.rs 定数追加**: `IBUS_ENGINE_BUS_NAME` / `IBUS_ENGINE_OBJECT_PATH`
 3. **service.rs 新規**: `KotohaEngineService` struct + `#[interface]` impl(6 method)+ unit tests
 4. **listener.rs rewrite**: `KOTOHA_ALLOW_LISTENER_STUB` 関連削除、`run()` を `blocking::connection::Builder` 経路に書き換え
-5. **kotoha-bin/src/main.rs 更新**: `KOTOHA_ALLOW_LISTENER_STUB=1` env var を起動時に export していた warning コメントの撤去(#197 で SIGTERM 関連 cleanup 済)
-6. **engine_loop.rs 更新**: `Event::IBusKey { event, respond }` の destructure + `respond.send(result)` 追加
+5. **engine_loop.rs 更新**: `Event::IBusKey { event, respond }` の destructure + `respond.send(result)` 追加(`crates/kotoha-bin/src/engine_loop.rs:43-46` の `let _result = engine.process_key_event(key);` を `let result = ...; let _ = respond.send(result);` に置換)
+6. **kotoha-bin/src/main.rs**: 本 spec scope では追加変更不要(SIGTERM hook は #197 で配線済、`KOTOHA_ALLOW_LISTENER_STUB=1` 起動 hint のような stub 関連表現も既に main.rs に残っていない)
 7. **L1 / L2 test 追加**
 8. **ADR 0021 起票**
 9. **`docs/specs/_uncategorized/p3-a-ibus-engine.md` の §6.1 step [1] / §11 acceptance criteria 更新**


### PR DESCRIPTION
## Summary

Replace the kotoha-engine-ibus listener stub with a production zbus 5 \`#[interface]\` dispatcher that decodes 4 IBus engine methods (+ 2 introspection no-op stubs) and forwards them as \`Event\` to engine-loop. \`Event::IBusKey\` extends with a bounded response \`Sender<KeyEventResult>\` so \`process_key_event\` returns the IME-correct bool with a 100ms timeout fallback. \`KOTOHA_ALLOW_LISTENER_STUB\` env var safety net is removed entirely. Closes #195.

## Spec & ADR

- **Spec**: \`docs/specs/_uncategorized/p3-b-ibus-listener.md\` (this branch)
- **ADR 0021**: \`docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md\` (this branch)
- **Plan**: \`docs/plans/2026-05-08-feature-195-zbus-listener-decode.md\` (this branch)

## Decisions captured

- zbus 5 \`#[interface]\` macro on \`KotohaEngineService\` struct (rejected: \`MessageStream\` manual match)
- \`Event::IBusKey { event, respond }\` synchronous response channel (rejected: \`Arc<AtomicBool>\` snapshot bypass; \`ForwardKeyEvent\` two-phase signal)
- 100ms timeout (rejected: 50ms — too tight for worker recovery case; covers typical 1ms / heavy 10ms / recovery 50ms)
- \`KOTOHA_ALLOW_LISTENER_STUB\` env var + \`ListenerStubRefused\` deleted (listener is no longer a stub)

## Change scope

10 commits, +2,084 / -174 lines:

| Layer | Files |
|---|---|
| Spec / Plan / ADR | \`docs/specs/_uncategorized/p3-b-ibus-listener.md\` (new, 432 lines), \`docs/plans/2026-05-08-feature-195-zbus-listener-decode.md\` (new, 1127 lines), \`docs/adr/0021-...\` (new, 67 lines) |
| Source | \`crates/kotoha-engine-ibus/src/{service.rs (new, 233 lines, 9 unit tests), listener.rs (rewritten), proxy.rs (constants), lib.rs}\`, \`crates/kotoha-engine-core/src/reactor/event.rs\` (\`IBusKey\` struct variant), \`crates/kotoha-bin/src/{engine_loop.rs (response.send), main.rs (caller update)}\` |
| Tests | \`crates/kotoha-engine-ibus/tests/integration.rs\` (new, L2 \`#[ignore]\` dbus integration test) |
| Docs sync | \`docs/specs/_uncategorized/p3-a-ibus-engine.md\` (§6 production-ready note + \`last_reviewed\`), \`docs/ROADMAP.md\` (B6 split into a/b/c) |

## Self-review (Spec §10 derived)

- **Architecture**: aligns ADR 0017 (tokio non-dependence) and ADR 0020 (4-thread lock-free); zbus internal smol executor does not propagate to crate code.
- **Type design**: \`Event::IBusKey\` struct variant makes the response channel mandatory at the type level; \`bounded(1)\` channel enforces 1:1 send/recv.
- **Testing**:
  - 9 L1 unit tests in \`service.rs\` cover the 4 process_key_event paths (Consumed / Forwarded / timeout / disconnect) + 3 reset paths + 2 stub paths
  - 3 L1 unit tests in \`listener.rs\` continue to pin \`ShutdownObserver\` (#187) and \`ListenerShutdown::Clone\` (#197) invariants
  - 1 L2 integration test in \`tests/integration.rs\` exercises decode end-to-end (gated \`#[ignore]\` for dbus session bus availability)
- **Silent failure**: timeout / bridge_disconnect both emit \`tracing::warn!\` with \`error_id\` for log filtering (spec §9.3 fail-loud).
- **Performance**: typical 1ms response; pathological case fallback at 100ms still under 10 keys/sec inter-keystroke interval (100ms peak).
- **Backward compat**: \`KOTOHA_ALLOW_LISTENER_STUB=1\` env var no longer required — production startup no longer emits the stub-mode warning.

## Test plan

- [x] cargo build --workspace --all-features clean
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings clean
- [x] cargo test --workspace --features kotoha-storage/test-helpers,kotoha-engine-core/test-helpers — 0 failures
- [x] cargo fmt --all -- --check clean
- [x] lefthook pre-commit pass (doc-naming + secrets-scan)
- [x] lefthook pre-push pass (build + clippy + manifest-check + obsidian-sync + test + test-dict + test-dict-persist)
- [ ] L2 integration test under \`cargo test -p kotoha-engine-ibus -- --ignored listener_decodes_process_key_event\` (manual, dev machine with dbus session bus)
- [ ] L3 manual smoke deferred to #196 (Phase 3-B B6-c)

## Out-of-scope follow-up

- \`/usr/share/ibus/component/kotoha.xml\` configuration file — packaging task, separate ISSUE
- L3 manual smoke on real GNOME Wayland — #196 (B6-c, user-driven)
- coalescing-window value empirical confirmation — #196 (during manual smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)