### PR TITLE
chore(deps,docs): #100 AR-3 (serial_test pin) + AR-4 (SudachiDict 40-char SHA)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # Test-only dev-deps for Layer 3 CLI integration (spec §10.3.1 / §10.6).
 tempfile = "3"
 assert_cmd = "2"
-serial_test = "3"
+serial_test = "3.4"
 # bitflags pinned via P3-A M1 (2026-05-02). KeyModifiers の bitflag 表現に使う。
 # Adopted reason: defacto standard、no_std 対応、P3-A spec §4.1 で明示要請。
 bitflags = "2.6"

--- a/docs/plans/2026-04-25-feature-91-p2-a-dictionary-layer.md
+++ b/docs/plans/2026-04-25-feature-91-p2-a-dictionary-layer.md
@@ -6,7 +6,7 @@
 
 **Architecture:** `MorphologicalEngine` / `VocabularyLookup` の 2 trait を先出し(Clean Architecture DIP)、`DictionaryBackend` が両 trait の `Box<dyn>` を保持する形で engine 切替可能性を確保する。`BackendConfig::Dictionary { config }` を `#[non_exhaustive]` enum に追加(ADR 0011 拡張点)、SudachiDict-core を `KOTOHA_SYSTEM_DICT_PATH` 経由 manual placement で runtime load する。
 
-**Tech Stack:** Rust 1.80 / edition 2021、`sudachi.rs` (git rev `90fd6068c80c` = v0.6.11、Apache-2.0)、SudachiDict-core v20260116 (Apache-2.0、manual placement)、`dict` / `dict-smoke` Cargo features (default = []、ADR 0012 整合)、Python 3.12 + uv (fixture 生成 tooling)、bash + assert.sh (smoke script)
+**Tech Stack:** Rust 1.80 / edition 2021、`sudachi.rs` (git rev `90fd6068c80c2fc3b63e0dbab0e341475bad4d8f` = v0.6.11、Apache-2.0)、SudachiDict-core v20260116 (Apache-2.0、manual placement)、`dict` / `dict-smoke` Cargo features (default = []、ADR 0012 整合)、Python 3.12 + uv (fixture 生成 tooling)、bash + assert.sh (smoke script)
 
 ---
 
@@ -33,7 +33,7 @@
 #   - lindera: MeCab-IPADIC / UniDic 要求(UniDic は商用利用制約)
 #   - vibrato: SudachiDict native 非対応(short/middle/long unit 不可)
 #   - SudachiDict→MeCab 変換: WorksApplications 公式提供なし、精度保証なし
-sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }
+sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c2fc3b63e0dbab0e341475bad4d8f" }
 ```
 
 - [ ] **Step 2: `crates/kotoha-core/Cargo.toml` `[dependencies]` に optional sudachi を追加**

--- a/docs/specs/_uncategorized/feature-91-p2-a-dictionary-layer.md
+++ b/docs/specs/_uncategorized/feature-91-p2-a-dictionary-layer.md
@@ -35,7 +35,7 @@ P2-A は Phase 2「Dictionary and learning」の最初の milestone である。
 
 - 6 module(`dict/{mod,backend,engine,vocab,sudachi_adapter,custom_vocab}.rs`)
 - `dict` / `dict-smoke` Cargo features(default = []、ADR 0012 D5)
-- `sudachi.rs` git rev pin(`90fd6068c80c` = v0.6.11、Apache-2.0)
+- `sudachi.rs` git rev pin(`90fd6068c80c2fc3b63e0dbab0e341475bad4d8f` = v0.6.11、Apache-2.0)
 - Layer 1 unit tests + Layer 2 integration tests(計 47 tests 新規)
 - Python tool `tools/p2a-fixture-gen/`(530-case fixture 生成、530 cases 生成は #92 で実施)
 - ADR / spec / README / glossary 同期更新

--- a/docs/specs/_uncategorized/p2-a-dictionary-layer.md
+++ b/docs/specs/_uncategorized/p2-a-dictionary-layer.md
@@ -76,7 +76,7 @@ P2-A brainstorming は以下 11 項目を empirical に確定した。各項目�
 
 ### 3.1 Q1: 形態素解析エンジンの選定
 
-P2-A は `sudachi.rs`(WorksApplications, Apache-2.0、git rev `90fd6068c80c` = v0.6.11)を採用する。
+P2-A は `sudachi.rs`(WorksApplications, Apache-2.0、git rev `90fd6068c80c2fc3b63e0dbab0e341475bad4d8f` = v0.6.11)を採用する。
 
 - **採用理由**: sudachi.rs は SudachiDict-core を native Rust で読込み可能であり、Phase 5 P5-A PoC が同辞書を採用済(語彙整合性が取れる)。Apache-2.0 licence は OSS 互換性を保つ
 - **lindera 棄却理由**: lindera は MeCab 互換 API を Rust で再実装したライブラリであり、辞書として MeCab-IPADIC または UniDic を要求する。UniDic は商用利用制約があるため採用不可(ADR 0014 C4 と整合)
@@ -181,9 +181,9 @@ pass rate は `category breakdown` + `length bucket breakdown` の 2 軸で集�
 
 ### 3.10 Q10: sudachi.rs version pin
 
-P2-A は sudachi.rs を `rev = "90fd6068c80c"`(v0.6.11)に pin する。
+P2-A は sudachi.rs を `rev = "90fd6068c80c2fc3b63e0dbab0e341475bad4d8f"`(v0.6.11)に pin する。
 
-- **pin 方法**: `Cargo.toml` の `[workspace.dependencies]` で git rev pin(`{ git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }`)
+- **pin 方法**: `Cargo.toml` の `[workspace.dependencies]` で git rev pin(`{ git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c2fc3b63e0dbab0e341475bad4d8f" }`)
 - **pin 理由**: sudachi.rs は crates.io 公開 version(0.6.x)が古く、最新の SudachiDict v20260116 と互換性に懸念がある。git rev pin で再現性を担保する。Phase 2 closure までは固定し、bump 必要時は別 ADR / ISSUE を起票する
 
 ### 3.11 Q11: SudachiDict-core version pin と配布方針
@@ -523,7 +523,7 @@ P2-A は workspace root の `[workspace.dependencies]` に sudachi.rs を git re
 
 ```toml
 [workspace.dependencies]
-sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c" }
+sudachi = { git = "https://github.com/WorksApplications/sudachi.rs", rev = "90fd6068c80c2fc3b63e0dbab0e341475bad4d8f" }
 ```
 
 - **licence**: Apache-2.0(Kotoha OSS 互換)


### PR DESCRIPTION
## Summary

Two opportunistic cleanups from #100 P2-A hardening follow-up backlog. Both are docs/config-only with no behavioral change. Closes #100 partially (AR-3, AR-4).

## AR-3: serial_test pinning

Bump \`serial_test = \"3\"\` to \`serial_test = \"3.4\"\` for consistency with workspace pinning style (\`proptest = \"1.5\"\`, \`clap = \"4.5\"\` — all major+minor). The crate currently resolves to 3.4.0; pinning to 3.4 makes the intent explicit.

## AR-4: SudachiDict SHA expansion

Replace 12-char short SHA \`90fd6068c80c\` with full 40-char SHA \`90fd6068c80c2fc3b63e0dbab0e341475bad4d8f\` in 3 spec/plan files. \`Cargo.toml\` already uses the 40-char SHA; this aligns the docs with the single source of truth and prevents future short-SHA collision risk from drifting into spec language.

## Triage status

ISSUE #100 has 10 items total. This PR closes 2:
- ✅ AR-3, AR-4

Remaining 8 (deferred to opportunistic future PRs):
- AR-1, AR-2 (path validation helper + SudachiAdapter::load split): code refactor
- AR-5 (SUDACHI_ENGINE_ID_LABEL spec / ADR cross-ref): docs
- TS-1, TS-2, TS-3, TS-4: test refactor
- SC-1, SC-2: ADR / supply-chain
- OB-1: tracing addition

## Self-review

- **Architecture**: N/A
- **Type design**: N/A
- **Testing**: workspace test still passes (no logic touched)
- **Silent failure**: N/A

## Test plan

- [x] cargo build --workspace clean
- [x] lefthook pre-commit + pre-push pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)