### PR TITLE
fix(storage): insert の検査順序を duplicate → quota に変更 (ISSUE #203)

### DIFF
--- a/crates/kotoha-storage/src/user_vocab/mock.rs
+++ b/crates/kotoha-storage/src/user_vocab/mock.rs
@@ -90,15 +90,8 @@ impl UserVocabWriter for MockUserVocabStore {
         validate_score(record.score)?;
 
         let mut records = self.records.lock().unwrap();
-        // SqliteUserVocabStore と挙動を合わせるため、Mock 側でも行数上限を強制する
-        // (sec-M5 / spec §F6)。
-        let max_rows = crate::user_vocab::sqlite::effective_max_rows();
-        if records.len() >= max_rows {
-            return Err(StorageError::QuotaExceeded {
-                table: "user_vocab".to_string(),
-                max: max_rows,
-            });
-        }
+        // SqliteUserVocabStore と挙動を合わせ、重複検査 → 行数上限の順で検査する
+        // (ISSUE #203: 重複 insert は行数を増やさないため at-cap でも DuplicateEntry)。
         if records
             .iter()
             .any(|r| r.surface == record.surface && r.reading == record.reading)
@@ -106,6 +99,14 @@ impl UserVocabWriter for MockUserVocabStore {
             return Err(StorageError::DuplicateEntry {
                 surface: record.surface,
                 reading: record.reading,
+            });
+        }
+        // 行数上限の強制 (sec-M5 / spec §F6)。
+        let max_rows = crate::user_vocab::sqlite::effective_max_rows();
+        if records.len() >= max_rows {
+            return Err(StorageError::QuotaExceeded {
+                table: "user_vocab".to_string(),
+                max: max_rows,
             });
         }
         let mut next_id = self.next_id.lock().unwrap();
@@ -261,6 +262,23 @@ mod tests {
         assert!(matches!(
             err,
             StorageError::QuotaExceeded { ref table, max } if table == "user_vocab" && max == 3
+        ));
+    }
+
+    /// ISSUE #203: Mock 側でも重複 insert は at-cap 状態で `DuplicateEntry` を
+    /// 返す(duplicate 検査が quota 検査より先行、SqliteStore と挙動対称)。
+    #[test]
+    fn mock_insert_duplicate_at_cap_returns_duplicate_entry_not_quota() {
+        let _guard = crate::user_vocab::sqlite::QuotaOverrideGuard::new(1);
+        let store = MockUserVocabStore::new();
+        store
+            .insert(rec("dup", "あ", 0.0))
+            .expect("first insert under cap ok");
+        let err = store.insert(rec("dup", "あ", 0.0)).unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::DuplicateEntry { ref surface, ref reading }
+                if surface == "dup" && reading == "あ"
         ));
     }
 }

--- a/crates/kotoha-storage/src/user_vocab/sqlite.rs
+++ b/crates/kotoha-storage/src/user_vocab/sqlite.rs
@@ -226,16 +226,35 @@ impl UserVocabWriter for SqliteUserVocabStore {
         };
 
         let conn = self.db.lock_conn();
-        // 行数上限チェック(sec-M5、spec §F6)。check + INSERT を同一 lock 下で
-        // 実行することで atomic な check-and-insert を保証する。
-        //
-        // perf-H2: `SELECT count(*)` は 50K 行の full-scan になるため、
-        // bounded existence check に置き換える。
-        // `EXISTS(SELECT 1 ... LIMIT 1 OFFSET (max - 1))` は
-        // 「max 行目(0-indexed で max-1 番目)が存在するか」を返す。
-        // 存在 ⇔ count >= max ⇔ at-cap、なので reject すべきケース。
-        // SQLite は OFFSET (max-1) で 1 行見つけた時点でスキャンを停止するため、
-        // 50K 行でも O(max) で済む(さらに primary key index 経由で実質 O(log n))。
+        // 重複検査は quota 検査より先に行う(ISSUE #203)。重複 insert は行数を
+        // 増やさない操作のため、at-cap 状態でも失敗の真因「既に存在する」を
+        // DuplicateEntry として返す。UNIQUE(surface, reading) 制約違反の mapping
+        // (末尾の match)は同一 lock 外の経路に対する backstop として残す。
+        {
+            let mut dup_stmt = conn.prepare_cached(
+                "SELECT EXISTS(SELECT 1 FROM user_vocab WHERE surface = ?1 AND reading = ?2)",
+            )?;
+            let duplicate_exists: i64 = dup_stmt
+                .query_row(rusqlite::params![record.surface, record.reading], |r| {
+                    r.get(0)
+                })?;
+            if duplicate_exists != 0 {
+                return Err(StorageError::DuplicateEntry {
+                    surface: record.surface,
+                    reading: record.reading,
+                });
+            }
+        } // dup_stmt はここで drop し、conn の borrow を解放する。
+          // 行数上限チェック(sec-M5、spec §F6)。check + INSERT を同一 lock 下で
+          // 実行することで atomic な check-and-insert を保証する。
+          //
+          // perf-H2: `SELECT count(*)` は 50K 行の full-scan になるため、
+          // bounded existence check に置き換える。
+          // `EXISTS(SELECT 1 ... LIMIT 1 OFFSET (max - 1))` は
+          // 「max 行目(0-indexed で max-1 番目)が存在するか」を返す。
+          // 存在 ⇔ count >= max ⇔ at-cap、なので reject すべきケース。
+          // SQLite は OFFSET (max-1) で 1 行見つけた時点でスキャンを停止するため、
+          // 50K 行でも O(max) で済む(さらに primary key index 経由で実質 O(log n))。
         let max_rows = effective_max_rows();
         {
             let mut count_stmt =
@@ -729,6 +748,30 @@ mod tests {
         assert!(matches!(
             err,
             StorageError::QuotaExceeded { ref table, max } if table == "user_vocab" && max == 1
+        ));
+    }
+
+    /// ISSUE #203: 重複 insert は at-cap 状態でも `QuotaExceeded` ではなく
+    /// `DuplicateEntry` を返す(duplicate 検査が quota 検査より先行する順序保証)。
+    #[test]
+    fn insert_duplicate_at_cap_returns_duplicate_entry_not_quota() {
+        let _guard = QuotaOverrideGuard::new(1);
+        let store = fresh_store();
+        let r = UserVocabRecord {
+            id: None,
+            surface: "dup".to_string(),
+            reading: "あ".to_string(),
+            pos: "名詞".to_string(),
+            score: 0.0,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.insert(r.clone()).expect("first insert under cap ok");
+        let err = store.insert(r).unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::DuplicateEntry { ref surface, ref reading }
+                if surface == "dup" && reading == "あ"
         ));
     }
 


### PR DESCRIPTION
## 概要

`user_vocab` insert の検査順序を duplicate → quota に変更する (sqlite / mock 両実装)。重複 insert は行数を増やさない操作のため、at-cap 状態でも失敗の真因「既に存在する」を `DuplicateEntry` として返すのが正しい。

Closes #203

## 背景

canonical hook script 同期 (#202) の pre-push gate で `insert_duplicate_returns_duplicate_entry_error` が間欠 fail (並列テスト時に `QuotaOverrideGuard` 非使用テストへ override 値 max=1 がリークし、quota 検査が duplicate 検査より先に発火)。本修正で当該テストは override リークと無関係に決定的 PASS となる。テスト基盤の構造レース (process-global override) の恒久対処は #203 の follow-up に残す。

## 変更内容

- `sqlite.rs`: 同一 lock 内で UNIQUE(surface, reading) の existence check を quota 検査の前に追加 (制約違反 mapping は backstop として残置)
- `mock.rs`: 検査順序を sqlite と対称に統一
- 回帰テスト 2 件追加 (`insert_duplicate_at_cap_returns_duplicate_entry_not_quota` / mock 版)

## 検証

- `cargo test -p kotoha-storage --features test-helpers`: 157 件全 PASS (新規 2 件込み)
- pre-push gate: clippy / fmt-check / manifest-check / test / test-dict / test-dict-persist / obsidian-sync 全 PASS — **#202 で fail していた test gate が green 化**
- trufflehog `--only-verified`: 対象 diff に secret なし (gitleaks pre-commit PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)