### PR TITLE
chore(scripts): canonical hook script を再同期 — .trace.md 除外漏れ修正の取り込み (ISSUE #202)

### DIFF
--- a/scripts/pre-commit-doc-naming.sh
+++ b/scripts/pre-commit-doc-naming.sh
@@ -4,10 +4,13 @@
 #
 # 検証対象 (本 hook の責務):
 #   - docs/plans/                  : <yyyy-MM-dd>-<branch>.md (現行維持)
-#   - docs/specs/                  : 配置・命名 + frontmatter 必須 7 キー存在
+#   - docs/specs/                  : 配置・命名 + frontmatter 必須 8 キー存在 (ADR 0036)
 #                                  + feature/bounded_context のファイル名/dir 名一致
 #                                  + status enum + last_reviewed 形式
-#   - docs/adr/                    : NNNN-<title>.md (現行維持)
+#                                  + <feature>.bugs.md sibling (/spec-reverse ADR 0001 生成物、
+#                                    frontmatter を持たない設計) は命名のみ許可し
+#                                    frontmatter 検証から除外。配置・dir 名検証は通常 spec と同じ
+#   - docs/adr/                    : NNNN-<title>.md (README.md = ADR 索引は許可)
 #   - CLAUDE.md (ルート/サブ)      : 進捗情報の直接記載がないこと (現行維持)
 #   - docs/superpowers/ 配下       : ファイル残存禁止 (廃止検証)
 #
@@ -17,6 +20,7 @@
 #   - vault → spec symlink の解決可能性
 #   - ADR 新規追加時の vault adr-index.md 反映
 #   - YAML 厳密構文検証 (yq parse)
+#   - <feature>.bugs.md は pre-push の YAML / glossary 検証からも除外 (両 hook で一貫)
 #
 # 詳細仕様: ~/.claude/CLAUDE.md §Documentation Structure
 #
@@ -88,6 +92,23 @@ _skip_special_spec_file() {
   return 1
 }
 
+# _skip_frontmatter_check は frontmatter 検証 (check_spec_frontmatter) の対象外ファイルを判定する。
+#   - .gitkeep / README.md: spec ではない
+#   - <feature>.bugs.md: /spec-reverse ADR 0001 生成物、frontmatter を持たない設計
+#     (命名・配置検証は check_spec_filename / check_spec_placement が別途担う)
+# .bugs.md の判定は check_spec_filename の許可 regex の .bugs.md 部分と厳密に一致させ、
+# 「除外集合 ⊋ 許可集合」の逆転 (PR #690 review L-1) を防ぐ。
+_skip_frontmatter_check() {
+  local fname="$1"
+  [[ "$fname" == ".gitkeep" ]] && return 0
+  [[ "$fname" == "README.md" ]] && return 0
+  [[ "$fname" =~ ^[a-z][a-z0-9-]*\.bugs\.md$ ]] && return 0
+  # <feature>.trace.md: trace-matrix.ts 生成物 (V-model trace、frontmatter を持たない設計)。
+  # pre-push の trace-matrix-freshness が要求する生成物のため命名のみ許可し frontmatter 検証から除外。
+  [[ "$fname" =~ ^[a-z][a-z0-9-]*\.trace\.md$ ]] && return 0
+  return 1
+}
+
 check_spec_placement() {
   [[ -z "$STAGED_FILES" ]] && return 0
   local spec_files
@@ -142,8 +163,10 @@ check_spec_filename() {
     dir_path=$(dirname "$file")
     _skip_special_spec_file "$fname" "$dir_path" && continue
     [[ "$dir_path" == "docs/specs" ]] && continue
-    if [[ ! "$fname" =~ ^[a-z][a-z0-9-]*\.md$ ]]; then
-      ERRORS+=("Spec 命名違反: $file (期待: kebab-case ^[a-z][a-z0-9-]*\\.md\$, アンダースコア prefix は予約)")
+    # <feature>.md (通常 spec)、<feature>.bugs.md (/spec-reverse ADR 0001 の bug sibling)、
+    # <feature>.trace.md (trace-matrix.ts の V-model trace 生成物) を許可。
+    if [[ ! "$fname" =~ ^[a-z][a-z0-9-]*(\.bugs|\.trace)?\.md$ ]]; then
+      ERRORS+=("Spec 命名違反: $file (期待: kebab-case ^[a-z][a-z0-9-]*(\\.bugs|\\.trace)?\\.md\$, アンダースコア prefix は予約)")
     fi
   done <<< "$spec_files"
 }
@@ -155,7 +178,9 @@ _extract_frontmatter() {
 
 _validate_required_keys() {
   local file="$1" fm="$2"
-  local required_keys=("feature" "status" "bounded_context" "related_issues" "related_prs" "glossary_refs" "last_reviewed")
+  # ADR 0036 (2026-05-12) で test_plan_status を 8 番目の必須 field として追加。
+  # hub ~/.claude/rules/testing.md §8 + spec-management.md 整合。
+  local required_keys=("feature" "status" "bounded_context" "related_issues" "related_prs" "glossary_refs" "last_reviewed" "test_plan_status")
   local missing=()
   local key
   for key in "${required_keys[@]}"; do
@@ -173,11 +198,14 @@ _validate_required_keys() {
 _validate_field_consistency() {
   local file="$1" fm="$2" slug="$3" bc_dir="$4"
   local valid_status=("draft" "reviewed" "implemented" "deprecated")
-  local feature_value bc_value status_value last_reviewed_value
+  # ADR 0036 (2026-05-12) で test_plan_status enum 検証追加。hub testing.md §8 整合。
+  local valid_test_plan_status=("draft" "designed" "executing" "evaluated")
+  local feature_value bc_value status_value last_reviewed_value test_plan_status_value
   feature_value=$(echo "$fm" | awk -F': *' '/^feature:/{print $2; exit}')
   bc_value=$(echo "$fm" | awk -F': *' '/^bounded_context:/{print $2; exit}')
   status_value=$(echo "$fm" | awk -F': *' '/^status:/{print $2; exit}')
   last_reviewed_value=$(echo "$fm" | awk -F': *' '/^last_reviewed:/{print $2; exit}')
+  test_plan_status_value=$(echo "$fm" | awk -F': *' '/^test_plan_status:/{print $2; exit}')
 
   if [[ "$feature_value" != "$slug" ]]; then
     ERRORS+=("Frontmatter 値不整合: $file (feature='$feature_value' ≠ ファイル名 '$slug')")
@@ -195,6 +223,13 @@ _validate_field_consistency() {
   if [[ ! "$last_reviewed_value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
     ERRORS+=("Frontmatter last_reviewed 形式違反: $file (期待: yyyy-MM-dd)")
   fi
+  local is_valid_tps=0
+  for v in "${valid_test_plan_status[@]}"; do
+    [[ "$test_plan_status_value" == "$v" ]] && is_valid_tps=1 && break
+  done
+  if [[ $is_valid_tps -eq 0 ]]; then
+    ERRORS+=("Frontmatter test_plan_status 値違反: $file (test_plan_status='$test_plan_status_value', 期待: draft|designed|executing|evaluated)")
+  fi
 }
 
 check_spec_frontmatter() {
@@ -206,8 +241,7 @@ check_spec_frontmatter() {
     local fname dir_path bc_dir slug
     fname=$(basename "$file")
     dir_path=$(dirname "$file")
-    [[ "$fname" == ".gitkeep" ]] && continue
-    [[ "$fname" == "README.md" ]] && continue
+    _skip_frontmatter_check "$fname" && continue
     bc_dir=$(basename "$dir_path")
     slug="${fname%.md}"
     [ -f "$file" ] || continue
@@ -241,6 +275,8 @@ check_adr_naming() {
     local fname
     fname=$(basename "$file")
     [[ "$fname" == ".gitkeep" ]] && continue
+    # README.md は ADR 索引 (docs/adr/README.md) として許可する (docs/specs/README.md と対称)。
+    [[ "$fname" == "README.md" ]] && continue
     if [[ ! "$fname" =~ $pattern ]]; then
       ERRORS+=("ADR 命名違反: $file (期待: NNNN-<title>.md)")
     fi

--- a/scripts/pre-push-obsidian-sync.sh
+++ b/scripts/pre-push-obsidian-sync.sh
@@ -11,12 +11,18 @@
 #   6. ADR 新規追加時の vault adr-index.md 反映 (index 不在も検出)
 #   7. orphan glossary (WARN)
 #
+# 対象外:
+#   - <feature>.bugs.md (/spec-reverse ADR 0001 生成物、frontmatter を持たない設計) は
+#     spec frontmatter / glossary 検証から除外する。pre-commit-doc-naming.sh と整合
+#   - <feature>.trace.md (trace-matrix.ts 生成物、frontmatter を持たない設計) も同様に除外。
+#     pre-commit-doc-naming.sh の _skip_frontmatter_check と整合
+#
 # 動作:
 #   - $OBSIDIAN_VAULT_DIR 未設定: silent skip exit 0
 #   - yq 未 install: error exit 1
 #   - yq 抽出失敗: silent ではなく ERROR
 #   - vault 構造異常 (glossary/ や README.md 不在): WARN
-#   - upstream/HEAD~1 解決不能 (初回 commit): WARN として可視化
+#   - origin/develop/main/HEAD~1 解決不能 (初回 commit): WARN として可視化
 #
 # 一時ファイル:
 #   /tmp/spec-fm.* を mktemp で作成、chmod 600。EXIT trap で全削除。
@@ -77,7 +83,9 @@ _yq_extract() {
 validate_spec_yaml_and_concepts() {
   [ ! -d docs/specs ] && return 0
   local spec_files
-  spec_files=$(find docs/specs -name "*.md" -type f | grep -vE '(README\.md|\.gitkeep)$' || true)
+  # <feature>.bugs.md (/spec-reverse ADR 0001 生成物) と <feature>.trace.md (trace-matrix.ts 生成物) は
+  # frontmatter を持たない設計のため除外。pre-commit-doc-naming.sh の _skip_frontmatter_check と整合。
+  spec_files=$(find docs/specs -name "*.md" -type f | grep -vE '(README\.md|\.gitkeep|\.bugs\.md|\.trace\.md)$' || true)
   while IFS= read -r file; do
     [ -z "$file" ] && continue
     local fm_file
@@ -107,6 +115,19 @@ validate_spec_yaml_and_concepts() {
       if ! date -d "$last_reviewed" >/dev/null 2>&1; then
         ERRORS+=("last_reviewed 妥当日付違反: $file (値: '$last_reviewed')")
       fi
+    fi
+
+    # test_plan_status: ADR 0036 (2026-05-12) で導入された 8 番目の必須 field。
+    # enum 検証は pre-commit-doc-naming.sh で実施済みだが、yq parse 整合 + キー存在を
+    # ここでも確認 (pre-commit を bypass した manual push 経路の防御)。
+    local test_plan_status
+    if test_plan_status=$(yq -e -r '.test_plan_status' "$fm_file" 2>/dev/null); then
+      case "$test_plan_status" in
+        draft|designed|executing|evaluated) ;;
+        *) ERRORS+=("test_plan_status 値違反: $file (値: '$test_plan_status', 期待: draft|designed|executing|evaluated)") ;;
+      esac
+    else
+      ERRORS+=("test_plan_status キー不在: $file (ADR 0036 8 fields 必須)")
     fi
 
     # related_issues / related_prs / glossary_refs: yq 抽出は明示的に rc を確認
@@ -191,6 +212,8 @@ validate_adr_index_entry() {
     local fname
     fname=$(basename "$adr")
     [[ "$fname" == ".gitkeep" ]] && continue
+    # README.md は ADR 索引そのものであり ADR 本体ではないため vault adr-index 反映検証から除外する。
+    [[ "$fname" == "README.md" ]] && continue
     if [ ! -f "$idx" ]; then
       ERRORS+=("ADR index ファイル不在: $idx (vault が壊れている可能性)")
       return 1
@@ -225,8 +248,12 @@ detect_orphan_glossary() {
     if ! grep -rqF "glossary_refs" docs/specs/ 2>/dev/null; then
       # docs/specs に glossary_refs 参照行が一切ない場合は orphan 判定 skip
       WARNINGS+=("Orphan glossary: $gloss はいずれの spec の glossary_refs からも参照されていません")
-    elif ! grep -r "glossary_refs:" docs/specs/ 2>/dev/null | grep -qF "$concept" && \
-         ! grep -rE "^- |^  - " docs/specs/ 2>/dev/null | grep -qF "$concept"; then
+    # set -euo pipefail 環境下では `grep -r ... | grep -qF ...` の右側が早期 exit で
+    # stdin を close すると左側 grep が SIGPIPE で 141 を返し、pipefail で pipe 全体が
+    # non-zero と判定されて false orphan を誤検出する (ISSUE #497)。
+    # 左側を `{ ... || true; }` で wrap して SIGPIPE / 非ゼロ exit を吸収する。
+    elif ! { grep -r "glossary_refs:" docs/specs/ 2>/dev/null || true; } | grep -qF "$concept" && \
+         ! { grep -rE "^- |^  - " docs/specs/ 2>/dev/null || true; } | grep -qF "$concept"; then
       WARNINGS+=("Orphan glossary: $gloss はいずれの spec の glossary_refs からも参照されていません")
     fi
   done <<< "$new_glossary"


### PR DESCRIPTION
## 概要

canonical hook script (claude-config `0d976b9`) を `scripts/` へ再同期する。`.trace.md` 除外漏れ修正 + header コメント陳腐化修正の取り込み。

Closes #202

## 変更内容

- `scripts/pre-commit-doc-naming.sh` — canonical と byte 一致 (`diff -q` 検証済み)
- `scripts/pre-push-obsidian-sync.sh` — 同上

## 検証

- pre-push gate: clippy / fmt-check / manifest-check / test / test-dict / test-dict-persist / obsidian-sync 全 PASS
- trufflehog `--only-verified`: verified_secrets 0

## 付記 (ISSUE #202 の blocker 解消)

- #202 記載の fail 6 件 (path::tests 3 + show_subcommand 3) は現環境で再現せず (cargo test 全 PASS)。前回の /tmp worktree 環境起因と推定
- 本 PR 作業中に検出した別の間欠 fail (quota override の並列リーク) は #203 / PR #204 で先行修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)