### PR TITLE
fix(core): raise system dict size cap to 256 MiB to admit pinned SudachiDict-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Phase 0 の canonical smoke test として `scripts/phase0-smoke.sh` を提供�
 
 ## Phase 2 P2-A: SudachiDict-core の取得と配置
 
-Phase 2 P2-A の Dictionary backend は SudachiDict-core(v20260116、約 70MB、Apache-2.0)を runtime load で使用する。Kotoha は辞書を bundle しないため、ユーザー側で手動配置する必要がある(Phase 1 の `KOTOHA_LLAMA_MODEL_PATH` と同一 pattern の運用)。
+Phase 2 P2-A の Dictionary backend は SudachiDict-core(v20260116、zip download 約 70MB / 展開後 `system_core.dic` 約 217MB、Apache-2.0)を runtime load で使用する。Kotoha は辞書を bundle しないため、ユーザー側で手動配置する必要がある(Phase 1 の `KOTOHA_LLAMA_MODEL_PATH` と同一 pattern の運用)。
 
 ### 取得手順
 

--- a/crates/kotoha-core/src/dict/sudachi_adapter.rs
+++ b/crates/kotoha-core/src/dict/sudachi_adapter.rs
@@ -16,10 +16,20 @@ use crate::dict::engine::{EngineCandidate, MorphologicalEngine};
 use crate::kanji::KanjiError;
 
 /// SudachiDict-core を runtime load する際の最大許容サイズ(bytes)。
-/// 200 MiB は v20260116 release の実サイズ(約 70 MB)に対し将来の dictionary 拡張を
-/// 見越した上限。これを超える file が指定された場合は CWE-400 / 資源枯渇防止のため
-/// load を reject する(P2-A hardening item 2)。
-const SYSTEM_DICT_MAX_BYTES: u64 = 200 * 1024 * 1024;
+/// v20260116 release の `system_core.dic` は展開後 217,203,456 bytes(約 207 MiB。
+/// zip download は約 70 MB)であり、256 MiB は同 release に対し約 24% の将来拡張
+/// 余地を持つ上限。SudachiDict-full(500 MB 超、p2-a spec §3 で棄却済)および
+/// 異常 file は引き続き reject し、CWE-400 / 資源枯渇防止の意図を保つ
+/// (P2-A hardening item 2、ISSUE #206)。
+const SYSTEM_DICT_MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+/// README が pin する SudachiDict-core v20260116 の展開後サイズ(bytes)。
+const SUDACHI_CORE_V20260116_BYTES: u64 = 217_203_456;
+
+// size cap が pin 済み辞書の展開後サイズを下回ると、サポート対象の辞書そのものが
+// load 不能になる(ISSUE #206 の regression)。cap を引き下げる変更は compile error
+// で機械的に block する。
+const _: () = assert!(SYSTEM_DICT_MAX_BYTES >= SUDACHI_CORE_V20260116_BYTES);
 
 /// sudachi.rs の engine_id() で返す固定 label。Layer 3 golden test から
 /// 同一文字列でアサートするため、module スコープの `pub(crate)` const として

--- a/crates/kotoha-core/src/dict/sudachi_adapter.rs
+++ b/crates/kotoha-core/src/dict/sudachi_adapter.rs
@@ -24,11 +24,14 @@ use crate::kanji::KanjiError;
 const SYSTEM_DICT_MAX_BYTES: u64 = 256 * 1024 * 1024;
 
 /// README が pin する SudachiDict-core v20260116 の展開後サイズ(bytes)。
+///
+/// size cap が pin 済み辞書の展開後サイズを下回ると、サポート対象の辞書そのものが
+/// load 不能になる(ISSUE #206 の regression)。下の compile-time assertion が
+/// cap を引き下げる変更を compile error で機械的に block する。
+/// dict release tag 更新時の同期手順は [`SUDACHI_ENGINE_ID_LABEL`] の
+/// `# 同期義務` を参照。
 const SUDACHI_CORE_V20260116_BYTES: u64 = 217_203_456;
 
-// size cap が pin 済み辞書の展開後サイズを下回ると、サポート対象の辞書そのものが
-// load 不能になる(ISSUE #206 の regression)。cap を引き下げる変更は compile error
-// で機械的に block する。
 const _: () = assert!(SYSTEM_DICT_MAX_BYTES >= SUDACHI_CORE_V20260116_BYTES);
 
 /// sudachi.rs の engine_id() で返す固定 label。Layer 3 golden test から
@@ -42,6 +45,9 @@ const _: () = assert!(SYSTEM_DICT_MAX_BYTES >= SUDACHI_CORE_V20260116_BYTES);
 /// - `sudachi-X.Y.Z` 部分を新 sudachi.rs release tag に揃える
 /// - `sudachidict-core:vYYYYMMDD` 部分を `README.md` 配置手順で参照している
 ///   SudachiDict-core release tag に揃える
+/// - [`SUDACHI_CORE_V20260116_BYTES`] の const 名・値・doc-comment を新 release の
+///   展開後サイズに更新し、[`SYSTEM_DICT_MAX_BYTES`] が同サイズ + 将来余地を
+///   満たすか再評価する(ISSUE #206)
 ///
 /// build-time 自動化は YAGNI として見送り、PR review チェックリストで担保する。
 pub(crate) const SUDACHI_ENGINE_ID_LABEL: &str = "sudachi-0.6.11+sudachidict-core:v20260116";
@@ -288,6 +294,43 @@ mod tests {
     fn sudachi_engine_id_label_constant_is_stable() {
         assert!(SUDACHI_ENGINE_ID_LABEL.contains("sudachi"));
         assert!(SUDACHI_ENGINE_ID_LABEL.contains("0.6"));
+    }
+
+    fn unique_tmp_path(suffix: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "kotoha-p2a-sudachi-test-{}-{}{}",
+            std::process::id(),
+            nanos,
+            suffix,
+        ))
+    }
+
+    /// size cap 超過 file の reject 経路(ISSUE #206 で修正した branch)を
+    /// 実 file で検証する。`custom_vocab_load_rejects_oversized_file` と対称の
+    /// sparse file パターン(set_len のみ、実 disk 消費は数 KB)。
+    #[test]
+    fn sudachi_adapter_load_rejects_oversized_file() {
+        let path = unique_tmp_path("-large.dic");
+        let f = std::fs::File::create(&path).expect("create tmp dic");
+        f.set_len(SYSTEM_DICT_MAX_BYTES + 1)
+            .expect("set len above cap");
+        drop(f);
+        let err = SudachiAdapter::load(&path).expect_err("oversized file must reject");
+        let _ = std::fs::remove_file(&path);
+        match err {
+            KanjiError::Backend { reason } => {
+                assert!(
+                    reason.contains("size cap"),
+                    "error must mention size cap: {reason}"
+                );
+            }
+            other => panic!("expected Backend, got: {other:?}"),
+        }
     }
 
     // ======================================================================


### PR DESCRIPTION
Closes #206

## Problem

`SYSTEM_DICT_MAX_BYTES` (200 MiB) rejected the README-pinned SudachiDict-core v20260116: the doc comment treated the ~70 MB **zip download size** as the dictionary size, but the extracted `system_core.dic` is **217,203,456 bytes (~207 MiB)**. The production binary therefore could not construct `HybridRanker` at all, blocking the Phase 3-B B6-c L3 manual smoke (#136 / #196). The dict-smoke gated runner (#92) is still unimplemented, so no automated test had ever loaded the real file.

## Fix

- Raise `SYSTEM_DICT_MAX_BYTES` to 256 MiB (~24% headroom over the pinned release).
- Add `SUDACHI_CORE_V20260116_BYTES` and a **compile-time `const` assertion**: any future cap value below the pinned dict size fails the build (stronger than a unit test — clippy rejects constant runtime assertions anyway).
- Correct the cap doc comment and README §Phase 2 P2-A wording (zip download size vs on-disk size).

## Security note

The cap is a CWE-400 / resource-exhaustion guard (P2-A hardening item 2). The guard is kept; only the threshold is corrected. SudachiDict-full (500 MB+, explicitly rejected in the p2-a spec §3) and oversized files are still refused.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test -p kotoha-core` all green (142+ tests).
- Empirical: release binary with `KOTOHA_SYSTEM_DICT_PATH` pointing at the real v20260116 dict now logs `HybridRanker constructed (dict-only path)` and enters the 4-thread event loop (previously: `exceeds size cap: 217203456 > 209715200 bytes`).
- lefthook pre-push gates passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)