### PR TITLE
fix(ibus): connect to the IBus private bus and serve the Factory interface

### DIFF
--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -12,13 +12,15 @@
 //!    `StubRanker` fallback 許可)
 //! 7. `HybridRanker::new(sudachi, user_vocab, learning)` を構築
 //!    (LLM 統合は Phase 3-B B2+ で詳細化、現段階では dict-only)
-//! 8. `IBusHostBridge::new(object_path)` で session bus 接続
-//!    (`KOTOHA_ALLOW_STUB=1` 時のみ `StubHostBridge` fallback 許可)
-//! 9. `KotohaEngine::new(host, ranker, learning_writer)` (Result)
-//! 10. `IBusEventDispatcher::new(engine)` で event loop 起動 stub
-//!
-//! 実 D-Bus event loop(`zbus::blocking::MessageStream` 経由の signal
-//! receive + dispatch)は Phase 3-B B3 / spec §13 Open Q 9 で詳細化する。
+//! 8. reactor 起動(`ReactorHandles`、ADR 0020 4-thread topology)
+//! 9. `listener::build_connection(bridge_tx)` で IBus private bus 接続
+//!    (address discovery + Factory/Engine serve、#208 / ADR 0021 Amendment。
+//!    `KOTOHA_ALLOW_STUB=1` 時のみ stub fallback 許可)
+//! 10. `IBusHostBridge::new(connection.clone(), object_path)` で signal 経路を
+//!     listener と同一 connection に統一(spec §7.4)
+//! 11. `KotohaEngine::new(host, ranker, learning_writer)` (Result)
+//! 12. listener shutdown handle pair + SIGTERM/SIGINT hook
+//! 13. dbus-listener / engine-loop thread spawn
 //!
 //! # Panic recovery (spec §9.1 row 5)
 //!
@@ -237,31 +239,12 @@ fn run_ibus() -> anyhow::Result<()> {
             }
         };
 
-    // 8. host bridge: session bus 接続。
-    let (host_bridge, host_bridge_backend): (
-        Box<dyn kotoha_engine_core::IMEHostBridge>,
-        &'static str,
-    ) = match kotoha_engine_ibus::IBusHostBridge::new(ENGINE_OBJECT_PATH) {
-        Ok(b) => (Box::new(b), "IBusHostBridge"),
-        #[cfg(feature = "dev-stubs")]
-        Err(e) if allow_stub => {
-            tracing::error!(
-                error = ?e,
-                "IBus session bus connect failed; using StubHostBridge (KOTOHA_ALLOW_STUB=1)"
-            );
-            (Box::new(StubHostBridge), "StubHostBridge")
-        }
-        Err(e) => {
-            return Err(anyhow::Error::new(e)).with_context(|| {
-                format!("IBusHostBridge connect failed and {KOTOHA_ALLOW_STUB_ENV} is not set")
-            });
-        }
-    };
-
-    // 9. reactor (Phase 3-B B0h-f + B3 / ADR 0020):4-thread topology の core。
+    // 8. reactor (Phase 3-B B0h-f + B3 / ADR 0020):4-thread topology の core。
     //    main は `ReactorHandles` を保持し、bridge_tx / worker_tx を各 thread に
     //    move、shutdown_tx を `Drop` で発火させる。SIGTERM/SIGINT は #197 で
     //    `ctrlc::set_handler` 経由で listener_shutdown + shutdown_tx を駆動する。
+    //    #208: connection 構築(step 9)が bridge_tx を要するため host bridge より
+    //    先に起動する。
     let kotoha_engine_reactor_linux::ReactorHandles {
         reactor,
         bridge_tx,
@@ -269,7 +252,48 @@ fn run_ibus() -> anyhow::Result<()> {
         shutdown_tx,
     } = kotoha_engine_reactor_linux::start();
 
-    // 10. engine(spec §9.1 row 5: spawn 失敗は Result 経由 propagate)
+    // 9. IBus private bus connection(#208 / ADR 0021 Amendment):main が構築し、
+    //    clone を host bridge(signal 経路)へ、本体を listener thread へ配布する
+    //    (spec §3.3)。stub fallback 時は listener thread 自体を spawn しない。
+    let connection = match kotoha_engine_ibus::listener::build_connection(bridge_tx) {
+        Ok(c) => Some(c),
+        #[cfg(feature = "dev-stubs")]
+        Err(e) if allow_stub => {
+            tracing::error!(
+                error = ?e,
+                "IBus private bus connect failed; using StubHostBridge without listener \
+                 (KOTOHA_ALLOW_STUB=1)"
+            );
+            None
+        }
+        Err(e) => {
+            return Err(e.context(format!(
+                "IBus private bus connect failed (is ibus-daemon running?) and \
+                 {KOTOHA_ALLOW_STUB_ENV} is not set"
+            )));
+        }
+    };
+
+    // 10. host bridge: listener と同一 connection(clone)で signal を発信する
+    //     (spec §7.4)。
+    let (host_bridge, host_bridge_backend): (
+        Box<dyn kotoha_engine_core::IMEHostBridge>,
+        &'static str,
+    ) = match &connection {
+        Some(c) => (
+            Box::new(
+                kotoha_engine_ibus::IBusHostBridge::new(c.clone(), ENGINE_OBJECT_PATH)
+                    .context("IBusHostBridge construction failed (invalid object path)")?,
+            ),
+            "IBusHostBridge",
+        ),
+        #[cfg(feature = "dev-stubs")]
+        None => (Box::new(StubHostBridge), "StubHostBridge"),
+        #[cfg(not(feature = "dev-stubs"))]
+        None => unreachable!("connection is always Some when dev-stubs is disabled"),
+    };
+
+    // 11. engine(spec §9.1 row 5: spawn 失敗は Result 経由 propagate)
     //     adapter 経由で `Arc<dyn LearningRecorder>` を engine に注入し、
     //     worker thread が生成する `Event::WorkerOutput` の送信先 (`worker_tx`) を渡す。
     let engine = kotoha_engine_core::engine::KotohaEngine::new(
@@ -280,14 +304,14 @@ fn run_ibus() -> anyhow::Result<()> {
     )
     .context("spawn ranker worker thread")?;
 
-    // 11. listener shutdown handle pair を生成する。
-    //     listener::run は内部で `blocking::connection::Builder::session()` から
-    //     session bus connection を確立 + serve_at + name するため、main 側で
-    //     pre-built connection を渡す必要はない(Phase 3-B B6-b #195、ADR 0021)。
+    // 12. listener shutdown handle pair を生成する。
+    //     connection は step 9 で main が構築済み(#208 / ADR 0021 Amendment)。
+    //     listener::run は connection を受領して dispatch 稼働の保持 + shutdown
+    //     監視のみを担う。
     let (listener_shutdown, listener_observer) =
         kotoha_engine_ibus::listener::ListenerShutdown::new();
 
-    // 11.5. SIGTERM/SIGINT shutdown hook (#197):signal 受信時に
+    // 12.5. SIGTERM/SIGINT shutdown hook (#197):signal 受信時に
     //       (a) listener_shutdown.request() で listener thread に shutdown 通知
     //       (b) shutdown_tx.send(()) で engine-loop の reactor に Event::Shutdown
     //       を駆動する。`ctrlc` crate は内部で `nix::sys::signal` を使い、
@@ -310,13 +334,24 @@ fn run_ibus() -> anyhow::Result<()> {
         .context("install SIGTERM/SIGINT signal handler")?;
     }
 
-    // 12. thread spawn(ADR 0020 §採択 Q4 4-thread topology)
+    // 13. thread spawn(ADR 0020 §採択 Q4 4-thread topology)
     //     順序:dbus-listener → engine-loop。engine_loop に engine + reactor を
-    //     move し、engine 状態を完全所有させる。
-    let listener_handle = std::thread::Builder::new()
-        .name("kotoha-dbus-listener".into())
-        .spawn(move || kotoha_engine_ibus::listener::run(bridge_tx, listener_observer))
-        .context("spawn dbus-listener thread")?;
+    //     move し、engine 状態を完全所有させる。stub fallback 時(connection
+    //     None)は listener thread を spawn しない(#208)。
+    let listener_handle = match connection {
+        Some(connection) => Some(
+            std::thread::Builder::new()
+                .name("kotoha-dbus-listener".into())
+                .spawn(move || kotoha_engine_ibus::listener::run(connection, listener_observer))
+                .context("spawn dbus-listener thread")?,
+        ),
+        None => {
+            tracing::warn!(
+                "dbus-listener thread not spawned (stub mode: no IBus private bus connection)"
+            );
+            None
+        }
+    };
 
     let engine_loop_handle = std::thread::Builder::new()
         .name("kotoha-engine-loop".into())
@@ -329,14 +364,13 @@ fn run_ibus() -> anyhow::Result<()> {
         "kotoha-bin event loop entered (4-thread topology: main / dbus-listener / engine-loop / ranker-worker)"
     );
 
-    // 13. join 順は engine-loop → dbus-listener。
+    // 14. join 順は engine-loop → dbus-listener。
     //     - engine-loop は `Event::Shutdown` 受信(SIGTERM/SIGINT 経路または
-    //       下記 step 14 の `drop(shutdown_tx)`)、または `EventReactor::recv` Err
+    //       下記の `drop(shutdown_tx)`)、または `EventReactor::recv` Err
     //       (全 Sender drop)で抜ける。
     //     - dbus-listener は `listener_shutdown.request()`(SIGTERM/SIGINT 経路
-    //       または下記 step 14 の明示 request)、もしくは engine-loop drop
-    //       による bridge_tx close で抜ける。
-    //     SIGTERM/SIGINT hook は step 11.5 の `ctrlc::set_handler` で wire 済。
+    //       または下記の明示 request)で抜ける。
+    //     SIGTERM/SIGINT hook は step 12.5 の `ctrlc::set_handler` で wire 済。
     let engine_result = engine_loop_handle
         .join()
         .map_err(panic_to_anyhow)
@@ -344,10 +378,13 @@ fn run_ibus() -> anyhow::Result<()> {
     // engine-loop が exit したら listener にも shutdown を伝え、listener join。
     listener_shutdown.request();
     drop(shutdown_tx); // reactor 側の shutdown 経路も明示閉鎖
-    let listener_result = listener_handle
-        .join()
-        .map_err(panic_to_anyhow)
-        .context("dbus-listener thread panicked")?;
+    let listener_result = match listener_handle {
+        Some(handle) => handle
+            .join()
+            .map_err(panic_to_anyhow)
+            .context("dbus-listener thread panicked")?,
+        None => Ok(()),
+    };
 
     engine_result.context("engine-loop returned an error")?;
     listener_result.context("dbus-listener returned an error")?;

--- a/crates/kotoha-bin/src/main.rs
+++ b/crates/kotoha-bin/src/main.rs
@@ -358,10 +358,17 @@ fn run_ibus() -> anyhow::Result<()> {
         .spawn(move || engine_loop::run(engine, reactor))
         .context("spawn engine-loop thread")?;
 
+    // stub mode(listener 不在)では 3-thread になるため、実 topology を log に出す
+    let thread_topology = if listener_handle.is_some() {
+        "main / dbus-listener / engine-loop / ranker-worker"
+    } else {
+        "main / engine-loop / ranker-worker (stub mode: no dbus-listener)"
+    };
     tracing::info!(
         ranker_backend,
         host_bridge_backend,
-        "kotoha-bin event loop entered (4-thread topology: main / dbus-listener / engine-loop / ranker-worker)"
+        thread_topology,
+        "kotoha-bin event loop entered (ADR 0020 topology)"
     );
 
     // 14. join 順は engine-loop → dbus-listener。

--- a/crates/kotoha-engine-core/src/reactor/event.rs
+++ b/crates/kotoha-engine-core/src/reactor/event.rs
@@ -26,7 +26,7 @@ use crate::request_id::RequestId;
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum Event {
-    /// IBus session bus で受信した key event。
+    /// IBus private bus で受信した key event(#208 で session bus 前提から改訂)。
     /// `kotoha-dbus-listener` thread が `Sender<Event>::send` で engine-loop に届ける。
     ///
     /// `respond` は engine-loop が `KeyEventResult`(`Consumed` / `Forwarded`)を返す

--- a/crates/kotoha-engine-ibus/src/discovery.rs
+++ b/crates/kotoha-engine-ibus/src/discovery.rs
@@ -1,0 +1,165 @@
+//! IBus private bus address discovery(#208 / spec §7.1)。
+//!
+//! ibus-daemon は D-Bus session bus ではなく自前の private bus 上で component を
+//! 待ち受ける。本 module は IBus client library の `ibus_get_address()` と同一
+//! semantics で address を解決する:
+//!
+//! 1. env `KOTOHA_IBUS_ADDRESS`(test / 開発時 override、Kotoha 固有)
+//! 2. env `IBUS_ADDRESS`(IBus エコシステム標準 override)
+//! 3. address file `$XDG_CONFIG_HOME/ibus/bus/<machine-id>-unix-<display>` の
+//!    `IBUS_ADDRESS=` 行(通常経路)
+//!
+//! 文字列 parse は純関数([`parse_address_file`] / [`display_number`])に分離し、
+//! env / filesystem 入力は [`discover_ibus_address`] / `address_file_path` に
+//! 集約する(L1 unit test 可能性、spec §10.1)。
+//!
+//! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §7.1、ADR 0021
+//! Amendment 2026-06-11。
+
+use std::path::PathBuf;
+
+/// test / 開発時に private bus address を直接指定する Kotoha 固有 override。
+pub(crate) const KOTOHA_IBUS_ADDRESS_ENV: &str = "KOTOHA_IBUS_ADDRESS";
+
+/// IBus エコシステム標準の address override(`ibus_get_address()` 互換)。
+pub(crate) const IBUS_ADDRESS_ENV: &str = "IBUS_ADDRESS";
+
+/// address discovery の失敗 reason(spec §9.1: いずれも listener 起動失敗 →
+/// main thread に propagate して process exit)。
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DiscoveryError {
+    #[error("machine-id not readable (/var/lib/dbus/machine-id, /etc/machine-id): {0}")]
+    MachineId(std::io::Error),
+    #[error("DISPLAY not set; cannot derive IBus address file name")]
+    DisplayUnset,
+    #[error("HOME not set; cannot resolve XDG config dir for IBus address file")]
+    HomeUnset,
+    #[error("IBus address file not readable: {path}: {source}")]
+    AddressFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("IBUS_ADDRESS= line not found in address file: {path}")]
+    AddressLineMissing { path: PathBuf },
+}
+
+/// IBus private bus address を 3 段 fallback で解決する(spec §7.1)。
+///
+/// # Errors
+///
+/// 3 source すべてで解決できない場合に [`DiscoveryError`] を返す。caller
+/// (`listener::build_connection`)は Err を main thread に propagate する。
+pub(crate) fn discover_ibus_address() -> Result<String, DiscoveryError> {
+    if let Ok(addr) = std::env::var(KOTOHA_IBUS_ADDRESS_ENV) {
+        if !addr.is_empty() {
+            tracing::info!(
+                source = KOTOHA_IBUS_ADDRESS_ENV,
+                "IBus address from env override"
+            );
+            return Ok(addr);
+        }
+    }
+    if let Ok(addr) = std::env::var(IBUS_ADDRESS_ENV) {
+        if !addr.is_empty() {
+            tracing::info!(source = IBUS_ADDRESS_ENV, "IBus address from env override");
+            return Ok(addr);
+        }
+    }
+    let path = address_file_path()?;
+    let content = std::fs::read_to_string(&path).map_err(|source| DiscoveryError::AddressFile {
+        path: path.clone(),
+        source,
+    })?;
+    let addr = parse_address_file(&content)
+        .ok_or(DiscoveryError::AddressLineMissing { path: path.clone() })?;
+    tracing::info!(file = %path.display(), "IBus address from address file");
+    Ok(addr.to_owned())
+}
+
+/// address file の path を導出する:
+/// `$XDG_CONFIG_HOME/ibus/bus/<machine-id>-unix-<display>`。
+///
+/// - `<machine-id>`: `/var/lib/dbus/machine-id`(fallback `/etc/machine-id`)、trim 済
+/// - `unix`: local display の hostname 固定値(`ibus_get_address()` 互換)
+/// - `<display>`: env `DISPLAY` の display 番号([`display_number`])
+fn address_file_path() -> Result<PathBuf, DiscoveryError> {
+    let machine_id = std::fs::read_to_string("/var/lib/dbus/machine-id")
+        .or_else(|_| std::fs::read_to_string("/etc/machine-id"))
+        .map_err(DiscoveryError::MachineId)?;
+    let display = std::env::var("DISPLAY").map_err(|_| DiscoveryError::DisplayUnset)?;
+    let config_dir = std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|_| {
+            std::env::var("HOME")
+                .map(|h| PathBuf::from(h).join(".config"))
+                .map_err(|_| DiscoveryError::HomeUnset)
+        })?;
+    let file_name = format!("{}-unix-{}", machine_id.trim(), display_number(&display));
+    Ok(config_dir.join("ibus").join("bus").join(file_name))
+}
+
+/// address file の本文から `IBUS_ADDRESS=` 行の値を取り出す純関数。
+///
+/// file 形式(ibus-daemon が生成):
+///
+/// ```text
+/// # This file is created by ibus-daemon, please do not modify it
+/// IBUS_ADDRESS=unix:abstract=/home/user/.cache/ibus/dbus-XXXX,guid=...
+/// IBUS_DAEMON_PID=12345
+/// ```
+pub(crate) fn parse_address_file(content: &str) -> Option<&str> {
+    content
+        .lines()
+        .find_map(|line| line.strip_prefix("IBUS_ADDRESS="))
+        .filter(|v| !v.is_empty())
+}
+
+/// env `DISPLAY` 値から display 番号を取り出す純関数(`":0"` → `"0"`、
+/// `":0.0"` → `"0"`)。
+fn display_number(display: &str) -> &str {
+    let trimmed = display.strip_prefix(':').unwrap_or(display);
+    trimmed.split('.').next().unwrap_or(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1
+    //! L1 unit tests。env / filesystem 非依存の純関数のみを対象とする
+    //! (`discover_ibus_address` の env 経路は L2 handshake test で
+    //! `KOTOHA_IBUS_ADDRESS` 注入により exercise される)。
+
+    use super::*;
+
+    #[test]
+    fn parse_address_file_extracts_ibus_address_line() {
+        let content = "\
+# This file is created by ibus-daemon, please do not modify it
+IBUS_ADDRESS=unix:abstract=/home/user/.cache/ibus/dbus-abcd,guid=feedface
+IBUS_DAEMON_PID=12345
+";
+        assert_eq!(
+            parse_address_file(content),
+            Some("unix:abstract=/home/user/.cache/ibus/dbus-abcd,guid=feedface")
+        );
+    }
+
+    #[test]
+    fn parse_address_file_returns_none_when_line_missing() {
+        let content = "# comment only\nIBUS_DAEMON_PID=12345\n";
+        assert_eq!(parse_address_file(content), None);
+    }
+
+    #[test]
+    fn parse_address_file_returns_none_on_empty_input() {
+        assert_eq!(parse_address_file(""), None);
+        // 値が空の IBUS_ADDRESS= 行も不正として None
+        assert_eq!(parse_address_file("IBUS_ADDRESS=\n"), None);
+    }
+
+    #[test]
+    fn display_number_strips_colon_and_screen_suffix() {
+        assert_eq!(display_number(":0"), "0");
+        assert_eq!(display_number(":0.0"), "0");
+        assert_eq!(display_number(":12"), "12");
+    }
+}

--- a/crates/kotoha-engine-ibus/src/discovery.rs
+++ b/crates/kotoha-engine-ibus/src/discovery.rs
@@ -9,14 +9,17 @@
 //! 3. address file `$XDG_CONFIG_HOME/ibus/bus/<machine-id>-unix-<display>` の
 //!    `IBUS_ADDRESS=` 行(通常経路)
 //!
-//! 文字列 parse は純関数([`parse_address_file`] / [`display_number`])に分離し、
-//! env / filesystem 入力は [`discover_ibus_address`] / `address_file_path` に
-//! 集約する(L1 unit test 可能性、spec §10.1)。
+//! 文字列 parse / path 合成は純関数([`parse_address_file`] / [`display_number`] /
+//! [`resolve_config_dir`] / [`compose_address_file_path`])に分離して L1 unit test
+//! 対象とし、env / filesystem 読み取りは [`discover_ibus_address`] /
+//! `address_file_path` に集約する(spec §10.1)。env / file 読み取りを含む
+//! 全段 fallback の結合動作は L2 handshake test(priority 1 注入)と
+//! L3 manual smoke(priority 3 実機)で検証する。
 //!
 //! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §7.1、ADR 0021
 //! Amendment 2026-06-11。
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// test / 開発時に private bus address を直接指定する Kotoha 固有 override。
 pub(crate) const KOTOHA_IBUS_ADDRESS_ENV: &str = "KOTOHA_IBUS_ADDRESS";
@@ -32,8 +35,13 @@ pub(crate) enum DiscoveryError {
     MachineId(std::io::Error),
     #[error("DISPLAY not set; cannot derive IBus address file name")]
     DisplayUnset,
-    #[error("HOME not set; cannot resolve XDG config dir for IBus address file")]
-    HomeUnset,
+    #[error(
+        "DISPLAY value {display:?} is not a local display (expected `:N` or `:N.S`); \
+         cannot derive IBus address file name"
+    )]
+    DisplayInvalid { display: String },
+    #[error("neither XDG_CONFIG_HOME nor HOME is set; cannot resolve IBus address file dir")]
+    ConfigDirUnset,
     #[error("IBus address file not readable: {path}: {source}")]
     AddressFile {
         path: PathBuf,
@@ -50,20 +58,16 @@ pub(crate) enum DiscoveryError {
 /// 3 source すべてで解決できない場合に [`DiscoveryError`] を返す。caller
 /// (`listener::build_connection`)は Err を main thread に propagate する。
 pub(crate) fn discover_ibus_address() -> Result<String, DiscoveryError> {
-    if let Ok(addr) = std::env::var(KOTOHA_IBUS_ADDRESS_ENV) {
-        if !addr.is_empty() {
-            tracing::info!(
-                source = KOTOHA_IBUS_ADDRESS_ENV,
-                "IBus address from env override"
-            );
-            return Ok(addr);
-        }
+    if let Some(addr) = env_override(KOTOHA_IBUS_ADDRESS_ENV) {
+        tracing::info!(
+            source = KOTOHA_IBUS_ADDRESS_ENV,
+            "IBus address from env override"
+        );
+        return Ok(addr);
     }
-    if let Ok(addr) = std::env::var(IBUS_ADDRESS_ENV) {
-        if !addr.is_empty() {
-            tracing::info!(source = IBUS_ADDRESS_ENV, "IBus address from env override");
-            return Ok(addr);
-        }
+    if let Some(addr) = env_override(IBUS_ADDRESS_ENV) {
+        tracing::info!(source = IBUS_ADDRESS_ENV, "IBus address from env override");
+        return Ok(addr);
     }
     let path = address_file_path()?;
     let content = std::fs::read_to_string(&path).map_err(|source| DiscoveryError::AddressFile {
@@ -76,26 +80,73 @@ pub(crate) fn discover_ibus_address() -> Result<String, DiscoveryError> {
     Ok(addr.to_owned())
 }
 
-/// address file の path を導出する:
-/// `$XDG_CONFIG_HOME/ibus/bus/<machine-id>-unix-<display>`。
+/// env override を読み、**有効値のときのみ** `Some` を返す。
 ///
-/// - `<machine-id>`: `/var/lib/dbus/machine-id`(fallback `/etc/machine-id`)、trim 済
-/// - `unix`: local display の hostname 固定値(`ibus_get_address()` 互換)
-/// - `<display>`: env `DISPLAY` の display 番号([`display_number`])
+/// silent-failure 禁止(spec §9.3): 「設定されているが空 / 非 UTF-8」の override は
+/// 黙って fallback せず、warn で観測経路を残してから次 source に進む。
+fn env_override(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) if !value.is_empty() => Some(value),
+        Ok(_) => {
+            tracing::warn!(
+                source = name,
+                "env override is set but empty; ignoring and trying the next source"
+            );
+            None
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                source = name,
+                "env override is set but not valid UTF-8; ignoring and trying the next source"
+            );
+            None
+        }
+        Err(std::env::VarError::NotPresent) => None,
+    }
+}
+
+/// address file の path を env / filesystem から導出する(純関数 3 つの結合)。
 fn address_file_path() -> Result<PathBuf, DiscoveryError> {
     let machine_id = std::fs::read_to_string("/var/lib/dbus/machine-id")
         .or_else(|_| std::fs::read_to_string("/etc/machine-id"))
         .map_err(DiscoveryError::MachineId)?;
     let display = std::env::var("DISPLAY").map_err(|_| DiscoveryError::DisplayUnset)?;
-    let config_dir = std::env::var("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .or_else(|_| {
-            std::env::var("HOME")
-                .map(|h| PathBuf::from(h).join(".config"))
-                .map_err(|_| DiscoveryError::HomeUnset)
-        })?;
-    let file_name = format!("{}-unix-{}", machine_id.trim(), display_number(&display));
-    Ok(config_dir.join("ibus").join("bus").join(file_name))
+    let display_num = display_number(&display).ok_or_else(|| DiscoveryError::DisplayInvalid {
+        display: display.clone(),
+    })?;
+    let config_dir = resolve_config_dir(
+        std::env::var("XDG_CONFIG_HOME").ok(),
+        std::env::var("HOME").ok(),
+    )?;
+    Ok(compose_address_file_path(
+        &config_dir,
+        &machine_id,
+        display_num,
+    ))
+}
+
+/// config dir を解決する純関数: `XDG_CONFIG_HOME`(非空)→ `$HOME/.config` →
+/// いずれも無ければ Err。
+fn resolve_config_dir(
+    xdg_config_home: Option<String>,
+    home: Option<String>,
+) -> Result<PathBuf, DiscoveryError> {
+    if let Some(xdg) = xdg_config_home.filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(xdg));
+    }
+    home.filter(|v| !v.is_empty())
+        .map(|h| PathBuf::from(h).join(".config"))
+        .ok_or(DiscoveryError::ConfigDirUnset)
+}
+
+/// address file の full path を合成する純関数:
+/// `<config_dir>/ibus/bus/<machine-id(trim 済)>-unix-<display_num>`。
+///
+/// - `<machine-id>`: 読み取り raw 値を受け取り、ここで trim する(末尾改行対策)
+/// - `unix`: local display の hostname 固定値(`ibus_get_address()` 互換)
+fn compose_address_file_path(config_dir: &Path, machine_id: &str, display_num: &str) -> PathBuf {
+    let file_name = format!("{}-unix-{}", machine_id.trim(), display_num);
+    config_dir.join("ibus").join("bus").join(file_name)
 }
 
 /// address file の本文から `IBUS_ADDRESS=` 行の値を取り出す純関数。
@@ -116,17 +167,27 @@ pub(crate) fn parse_address_file(content: &str) -> Option<&str> {
 
 /// env `DISPLAY` 値から display 番号を取り出す純関数(`":0"` → `"0"`、
 /// `":0.0"` → `"0"`)。
-fn display_number(display: &str) -> &str {
-    let trimmed = display.strip_prefix(':').unwrap_or(display);
-    trimmed.split('.').next().unwrap_or(trimmed)
+///
+/// spec §7.1 の対象は local display(`:N` / `:N.S` 形式)のみ。hostname prefix
+/// 付き(`localhost:0.0` 等)や数字以外を含む値は `None` で reject する
+/// (file 名への `/` / `..` 混入も構造的に塞ぐ)。
+fn display_number(display: &str) -> Option<&str> {
+    let trimmed = display.strip_prefix(':')?;
+    let num = trimmed.split('.').next().unwrap_or(trimmed);
+    if !num.is_empty() && num.bytes().all(|b| b.is_ascii_digit()) {
+        Some(num)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
 mod tests {
     //! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1
-    //! L1 unit tests。env / filesystem 非依存の純関数のみを対象とする
-    //! (`discover_ibus_address` の env 経路は L2 handshake test で
-    //! `KOTOHA_IBUS_ADDRESS` 注入により exercise される)。
+    //! L1 unit tests。env / filesystem 非依存の純関数のみを対象とする。env / file
+    //! 読み取りを含む結合動作は L2 handshake test(`KOTOHA_IBUS_ADDRESS` 注入 =
+    //! priority 1 経路)と L3 manual smoke(address file = priority 3 経路)で
+    //! 検証する。
 
     use super::*;
 
@@ -157,9 +218,54 @@ IBUS_DAEMON_PID=12345
     }
 
     #[test]
-    fn display_number_strips_colon_and_screen_suffix() {
-        assert_eq!(display_number(":0"), "0");
-        assert_eq!(display_number(":0.0"), "0");
-        assert_eq!(display_number(":12"), "12");
+    fn display_number_extracts_local_display_number() {
+        assert_eq!(display_number(":0"), Some("0"));
+        assert_eq!(display_number(":0.0"), Some("0"));
+        assert_eq!(display_number(":12"), Some("12"));
+    }
+
+    #[test]
+    fn display_number_rejects_non_local_or_malformed_display() {
+        // hostname prefix 付き network display は spec §7.1 scope 外
+        assert_eq!(display_number("localhost:0.0"), None);
+        // 数字以外(path traversal 防止: `/` や `..` を file 名に混入させない)
+        assert_eq!(display_number(":0/../../../../tmp/evil"), None);
+        assert_eq!(display_number(""), None);
+        assert_eq!(display_number(":"), None);
+    }
+
+    #[test]
+    fn resolve_config_dir_prefers_xdg_then_home() {
+        assert_eq!(
+            resolve_config_dir(Some("/xdg".into()), Some("/home/u".into())).unwrap(),
+            PathBuf::from("/xdg")
+        );
+        // XDG 未設定(または空)→ $HOME/.config
+        assert_eq!(
+            resolve_config_dir(None, Some("/home/u".into())).unwrap(),
+            PathBuf::from("/home/u/.config")
+        );
+        assert_eq!(
+            resolve_config_dir(Some(String::new()), Some("/home/u".into())).unwrap(),
+            PathBuf::from("/home/u/.config")
+        );
+        assert!(matches!(
+            resolve_config_dir(None, None),
+            Err(DiscoveryError::ConfigDirUnset)
+        ));
+    }
+
+    #[test]
+    fn compose_address_file_path_trims_machine_id_and_assembles_full_path() {
+        // machine-id file の raw 値は末尾改行を含む
+        let path = compose_address_file_path(
+            Path::new("/home/u/.config"),
+            "0123456789abcdef0123456789abcdef\n",
+            "0",
+        );
+        assert_eq!(
+            path,
+            PathBuf::from("/home/u/.config/ibus/bus/0123456789abcdef0123456789abcdef-unix-0")
+        );
     }
 }

--- a/crates/kotoha-engine-ibus/src/factory.rs
+++ b/crates/kotoha-engine-ibus/src/factory.rs
@@ -1,0 +1,80 @@
+//! `KotohaFactoryService` — IBus engine factory(#208 / spec §4.5)。
+//!
+//! ibus-daemon の engine 生成 protocol は、component が
+//! `org.freedesktop.IBus.Factory` interface を `/org/freedesktop/IBus/Factory`
+//! で serve していることを必須とする。daemon は `CreateEngine(engine_name)` を
+//! call し、返却された object path に対して engine method を発行する。
+//!
+//! 本実装は静的単一 path 採択(spec §7.3)のため、`CreateEngine` は常に
+//! 既 serve 済の [`crate::proxy::IBUS_ENGINE_OBJECT_PATH`] を返す。
+//!
+//! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §4.5 / §7.3、
+//! ADR 0021 Amendment 2026-06-11。
+
+use zbus::interface;
+
+use crate::proxy::IBUS_ENGINE_OBJECT_PATH;
+
+/// component XML `<engines>` に列挙した engine 名(`<name>kotoha</name>`)。
+/// daemon はこの名前で `CreateEngine` を call する。
+pub(crate) const ENGINE_NAME: &str = "kotoha";
+
+/// IBus engine factory。state を持たない(engine object は connection build 時に
+/// `serve_at` 済みで、本 service は path の返却のみを行う)。
+pub(crate) struct KotohaFactoryService;
+
+#[interface(name = "org.freedesktop.IBus.Factory")]
+impl KotohaFactoryService {
+    /// `CreateEngine(s engine_name) -> o`(IBus 1.5.x `ibusfactory.c` 仕様)。
+    ///
+    /// `engine_name == "kotoha"` のとき静的 engine path を返す。未知名は
+    /// `org.freedesktop.DBus.Error.InvalidArgs` で reject する(spec §9.1)。
+    fn create_engine(
+        &self,
+        engine_name: &str,
+    ) -> zbus::fdo::Result<zbus::zvariant::OwnedObjectPath> {
+        if engine_name != ENGINE_NAME {
+            tracing::warn!(
+                error_id = "factory.create_engine.unknown_engine",
+                engine_name,
+                "CreateEngine called with unknown engine name"
+            );
+            return Err(zbus::fdo::Error::InvalidArgs(format!(
+                "unknown engine name: {engine_name}"
+            )));
+        }
+        tracing::info!(engine_name, path = IBUS_ENGINE_OBJECT_PATH, "CreateEngine");
+        let path = zbus::zvariant::ObjectPath::try_from(IBUS_ENGINE_OBJECT_PATH)
+            .expect("IBUS_ENGINE_OBJECT_PATH is a valid D-Bus object path");
+        Ok(path.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1
+    //! L1 unit tests。dbus を使わず `#[interface]` の inherent method を直接呼ぶ。
+
+    use super::*;
+
+    #[test]
+    fn create_engine_returns_static_engine_path_for_kotoha() {
+        let factory = KotohaFactoryService;
+        let path = factory
+            .create_engine(ENGINE_NAME)
+            .expect("known engine name must succeed");
+        assert_eq!(path.as_str(), IBUS_ENGINE_OBJECT_PATH);
+    }
+
+    #[test]
+    fn create_engine_rejects_unknown_engine_name() {
+        let factory = KotohaFactoryService;
+        let err = factory
+            .create_engine("anthy")
+            .expect_err("unknown engine name must be rejected");
+        assert!(
+            matches!(err, zbus::fdo::Error::InvalidArgs(_)),
+            "expected InvalidArgs, got: {err:?}"
+        );
+    }
+}

--- a/crates/kotoha-engine-ibus/src/factory.rs
+++ b/crates/kotoha-engine-ibus/src/factory.rs
@@ -8,20 +8,32 @@
 //! 本実装は静的単一 path 採択(spec §7.3)のため、`CreateEngine` は常に
 //! 既 serve 済の [`crate::proxy::IBUS_ENGINE_OBJECT_PATH`] を返す。
 //!
-//! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §4.5 / §7.3、
+//! # Panic-free 規約(spec §9.1)
+//!
+//! zbus 5 は `#[interface]` handler 内の panic を catch **しない**(handler panic
+//! は dispatch task を黙殺し、以後の全 method dispatch が無 log で停止する)。
+//! このため handler 本体に panic site を置くことは禁止で、engine path は
+//! `listener::build_connection` が事前 validate した値を field 注入する。
+//!
+//! 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §4.5 / §7.3 / §9.1、
 //! ADR 0021 Amendment 2026-06-11。
 
 use zbus::interface;
-
-use crate::proxy::IBUS_ENGINE_OBJECT_PATH;
 
 /// component XML `<engines>` に列挙した engine 名(`<name>kotoha</name>`)。
 /// daemon はこの名前で `CreateEngine` を call する。
 pub(crate) const ENGINE_NAME: &str = "kotoha";
 
-/// IBus engine factory。state を持たない(engine object は connection build 時に
-/// `serve_at` 済みで、本 service は path の返却のみを行う)。
-pub(crate) struct KotohaFactoryService;
+/// IBus engine factory。
+///
+/// `engine_path` は `listener::build_connection` が事前 validate した
+/// [`crate::proxy::IBUS_ENGINE_OBJECT_PATH`] を保持する(handler 内 panic site
+/// 排除、module doc 参照)。engine object は connection build 時に `serve_at`
+/// 済みのため、`CreateEngine` は path の返却のみを行う。
+pub(crate) struct KotohaFactoryService {
+    /// 事前 validate 済の静的 engine object path(spec §7.3)。
+    pub(crate) engine_path: zbus::zvariant::OwnedObjectPath,
+}
 
 #[interface(name = "org.freedesktop.IBus.Factory")]
 impl KotohaFactoryService {
@@ -34,19 +46,21 @@ impl KotohaFactoryService {
         engine_name: &str,
     ) -> zbus::fdo::Result<zbus::zvariant::OwnedObjectPath> {
         if engine_name != ENGINE_NAME {
+            // engine_name は bus 上の任意 peer が指定できる文字列。log forging
+            // 防止のため制御文字を escape して観測する(#207 と同型の log
+            // injection 対策)。
             tracing::warn!(
                 error_id = "factory.create_engine.unknown_engine",
-                engine_name,
+                engine_name = %engine_name.escape_debug(),
                 "CreateEngine called with unknown engine name"
             );
             return Err(zbus::fdo::Error::InvalidArgs(format!(
-                "unknown engine name: {engine_name}"
+                "unknown engine name: {}",
+                engine_name.escape_debug()
             )));
         }
-        tracing::info!(engine_name, path = IBUS_ENGINE_OBJECT_PATH, "CreateEngine");
-        let path = zbus::zvariant::ObjectPath::try_from(IBUS_ENGINE_OBJECT_PATH)
-            .expect("IBUS_ENGINE_OBJECT_PATH is a valid D-Bus object path");
-        Ok(path.into())
+        tracing::info!(engine_name, path = %self.engine_path, "CreateEngine");
+        Ok(self.engine_path.clone())
     }
 }
 
@@ -56,10 +70,19 @@ mod tests {
     //! L1 unit tests。dbus を使わず `#[interface]` の inherent method を直接呼ぶ。
 
     use super::*;
+    use crate::proxy::IBUS_ENGINE_OBJECT_PATH;
+
+    fn setup() -> KotohaFactoryService {
+        KotohaFactoryService {
+            engine_path: zbus::zvariant::ObjectPath::try_from(IBUS_ENGINE_OBJECT_PATH)
+                .expect("valid path")
+                .into(),
+        }
+    }
 
     #[test]
     fn create_engine_returns_static_engine_path_for_kotoha() {
-        let factory = KotohaFactoryService;
+        let factory = setup();
         let path = factory
             .create_engine(ENGINE_NAME)
             .expect("known engine name must succeed");
@@ -68,13 +91,29 @@ mod tests {
 
     #[test]
     fn create_engine_rejects_unknown_engine_name() {
-        let factory = KotohaFactoryService;
+        let factory = setup();
         let err = factory
             .create_engine("anthy")
             .expect_err("unknown engine name must be rejected");
         assert!(
             matches!(err, zbus::fdo::Error::InvalidArgs(_)),
             "expected InvalidArgs, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn create_engine_escapes_control_characters_in_rejection() {
+        // log forging 対策: 制御文字入り engine_name は escape されて返る
+        let factory = setup();
+        let err = factory
+            .create_engine("evil\nname")
+            .expect_err("unknown engine name must be rejected");
+        let zbus::fdo::Error::InvalidArgs(msg) = err else {
+            panic!("expected InvalidArgs");
+        };
+        assert!(
+            msg.contains("evil\\nname"),
+            "control characters must be escaped in the error message: {msg}"
         );
     }
 }

--- a/crates/kotoha-engine-ibus/src/host_bridge.rs
+++ b/crates/kotoha-engine-ibus/src/host_bridge.rs
@@ -14,7 +14,8 @@ use crate::proxy::IBusEngineSignals;
 ///
 /// # Construction
 ///
-/// [`Self::new`] で session bus 接続 + engine object path を保持する。
+/// [`Self::new`] で IBus private bus connection(listener と共有、#208)+
+/// engine object path を保持する。
 ///
 /// # Thread safety
 ///
@@ -26,16 +27,17 @@ pub struct IBusHostBridge {
 }
 
 impl IBusHostBridge {
-    /// session bus + engine object path で adapter を構築する。
+    /// private bus connection(listener と共有、#208 / spec §7.4)+ engine
+    /// object path で adapter を構築する。connection は main の DI wiring が
+    /// `listener::build_connection` で確立し、clone を注入する(spec §3.3)。
     ///
     /// # Errors
     ///
-    /// - zbus connection 確立失敗(`DBUS_SESSION_BUS_ADDRESS` 不設定等)
     /// - object_path 不正(D-Bus path syntax 違反)
-    pub fn new(object_path: &str) -> zbus::Result<Self> {
+    pub fn new(connection: zbus::blocking::Connection, object_path: &str) -> zbus::Result<Self> {
         Ok(Self {
             lookup_table: LookupTable::new(),
-            signals: IBusEngineSignals::new(object_path)?,
+            signals: IBusEngineSignals::new(connection, object_path)?,
         })
     }
 }

--- a/crates/kotoha-engine-ibus/src/lib.rs
+++ b/crates/kotoha-engine-ibus/src/lib.rs
@@ -11,11 +11,9 @@
 //! - [`lookup_table::LookupTable`] — `Mutex<Vec<Candidate>>` 内部 buffer + IBus mapping
 //! - [`listener::run`] — D-Bus method call → `Event::IBusKey` / `Event::IBusReset`
 //!   decode + bridge channel forward(B0h-f + B3 / ADR 0020、driving listener thread)
-//! - `dispatcher::IBusEventDispatcher` — Phase 3-A M5 / B0h-d で導入された
-//!   `Arc<Mutex<dyn IMEEngine>>` 経由 dispatcher。Phase 3-B B0h-f + B3(ADR 0020)
-//!   で 4-thread topology に移行したため production からは未使用となった。
-//!   keysym decode 経路の test 資産として一時残置、follow-up で削除予定。
 //! - `keysym` — IBus keysym → `KeyEvent` 変換 helper(M5 で追加)
+//! - `discovery` / `factory` — IBus private bus address discovery と
+//!   `org.freedesktop.IBus.Factory` service(#208 / ADR 0021 Amendment)
 //!
 //! # Boundary 原則
 //!

--- a/crates/kotoha-engine-ibus/src/lib.rs
+++ b/crates/kotoha-engine-ibus/src/lib.rs
@@ -26,6 +26,8 @@
 // Phase 3-B B0h-f rev3 (ADR 0020) review fix:旧 `dispatcher::IBusEventDispatcher`
 // (`Arc<Mutex<dyn IMEEngine>>` ベース)は本 PR で完全削除された。listener.rs が
 // keysym decode 経路を継承する。
+pub(crate) mod discovery;
+pub(crate) mod factory;
 pub mod host_bridge;
 pub mod keysym;
 pub mod listener;

--- a/crates/kotoha-engine-ibus/src/listener.rs
+++ b/crates/kotoha-engine-ibus/src/listener.rs
@@ -1,8 +1,12 @@
 //! D-Bus signal listener loop(Phase 3-B B3 + B6-b / ADR 0020 + ADR 0021)。
 //!
-//! `kotoha-dbus-listener` thread の main を担う。zbus 5 `blocking::connection::Builder`
-//! 経由で `org.freedesktop.IBus.Engine` interface に [`crate::service::KotohaEngineService`]
-//! を登録し、IBus daemon からの method 呼び出しを 6 method に分岐 dispatch する。
+//! `kotoha-dbus-listener` thread の main を担う。[`build_connection`] が
+//! IBus private bus(address discovery 経由、#208 / spec §7.1)への
+//! `blocking::Connection` を確立し、`org.freedesktop.IBus.Factory` と
+//! `org.freedesktop.IBus.Engine` の 2 interface を serve する。connection は
+//! main thread の DI wiring が構築し、clone を signal 発信側
+//! (`IBusEngineSignals`)と共有する(spec §3.3 / §7.4)。
+//! [`run`] は connection を受領して dispatch 稼働を保持し、shutdown を監視する。
 //!
 //! # Decoded methods
 //!
@@ -88,49 +92,75 @@ impl Clone for ShutdownObserver {
     }
 }
 
-/// D-Bus listener thread の main loop。
+/// IBus private bus への connection を確立し、Factory + Engine service を
+/// serve する(#208 / spec §7.2)。
+///
+/// main thread の DI wiring が呼び、clone を `IBusEngineSignals` へ、本体を
+/// [`run`] へ配布する(spec §3.3)。
 ///
 /// # Preconditions
 ///
 /// - `bridge_tx` は engine-loop thread の `EventReactor` bridge channel
+/// - ibus-daemon が起動済みで private bus address が解決可能であること
+///   (env override または address file、spec §7.1)
+///
+/// # Postconditions
+///
+/// - private bus への connection 確立、Factory + Engine service publish、
+///   bus name `RequestName` 完了(daemon が component 起動完了を検知する)
+///
+/// # Errors
+///
+/// - [`crate::discovery::DiscoveryError`] — address discovery 失敗(spec §9.1)
+/// - `zbus::Error` — private bus 接続 / `serve_at` / `RequestName` 失敗
+pub fn build_connection(bridge_tx: Sender<Event>) -> anyhow::Result<zbus::blocking::Connection> {
+    use crate::discovery::discover_ibus_address;
+    use crate::factory::KotohaFactoryService;
+    use crate::proxy::{IBUS_ENGINE_BUS_NAME, IBUS_ENGINE_OBJECT_PATH, IBUS_FACTORY_OBJECT_PATH};
+    use crate::service::KotohaEngineService;
+
+    let address = discover_ibus_address()?;
+    tracing::info!(
+        bus_name = IBUS_ENGINE_BUS_NAME,
+        engine_path = IBUS_ENGINE_OBJECT_PATH,
+        factory_path = IBUS_FACTORY_OBJECT_PATH,
+        "connecting to IBus private bus (zbus blocking::Builder + #[interface] dispatcher)"
+    );
+    let connection = zbus::blocking::connection::Builder::address(address.as_str())?
+        .serve_at(IBUS_FACTORY_OBJECT_PATH, KotohaFactoryService)?
+        .serve_at(IBUS_ENGINE_OBJECT_PATH, KotohaEngineService { bridge_tx })?
+        .name(IBUS_ENGINE_BUS_NAME)?
+        .build()?;
+    Ok(connection)
+}
+
+/// D-Bus listener thread の main loop。
+///
+/// # Preconditions
+///
+/// - `connection` は [`build_connection`] で構築済み(main thread の DI wiring、
+///   #208 / spec §3.3)
 /// - `shutdown` は main thread が `ListenerShutdown::request()` で停止指示する
 ///   observer handle(#187 split-handle、#197 SIGTERM hook 経由でも request される)
 ///
 /// # Postconditions
 ///
-/// - `shutdown.is_shutting_down()` を観測したら Connection を drop して `Ok(())`
-///   で return する(Connection drop で zbus internal smol executor が exit、
-///   bus name が release)
-/// - Connection 構築失敗(session bus 不在、bus name 占有等)時は Err propagate
-///
-/// # Errors
-///
-/// - `zbus::Error` — session bus 接続 / `serve_at` / `RequestName` 失敗
+/// - `shutdown.is_shutting_down()` を観測したら保持 handle を drop して `Ok(())`
+///   で return する(`IBusEngineSignals` 側 clone を含む全 handle drop で zbus
+///   internal smol executor が exit、bus name が release)
 ///
 /// 詳細仕様: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §3 / §7。
-pub fn run(bridge_tx: Sender<Event>, shutdown: ShutdownObserver) -> anyhow::Result<()> {
-    use crate::proxy::{IBUS_ENGINE_BUS_NAME, IBUS_ENGINE_OBJECT_PATH};
-    use crate::service::KotohaEngineService;
-
-    tracing::info!(
-        bus_name = IBUS_ENGINE_BUS_NAME,
-        object_path = IBUS_ENGINE_OBJECT_PATH,
-        "dbus-listener starting (zbus blocking::Builder + #[interface] dispatcher)"
-    );
-
-    let service = KotohaEngineService { bridge_tx };
-    let _connection = zbus::blocking::connection::Builder::session()?
-        .serve_at(IBUS_ENGINE_OBJECT_PATH, service)?
-        .name(IBUS_ENGINE_BUS_NAME)?
-        .build()?;
-
+pub fn run(
+    connection: zbus::blocking::Connection,
+    shutdown: ShutdownObserver,
+) -> anyhow::Result<()> {
     // Connection's internal smol executor dispatches incoming method calls in a
     // background thread. We just hold the connection alive and poll shutdown.
     while !shutdown.is_shutting_down() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
     tracing::info!("dbus-listener received shutdown signal, dropping connection and exiting");
-    // _connection drops here: zbus releases bus name + stops dispatching.
+    drop(connection); // zbus releases bus name + stops dispatching (last handle).
     Ok(())
 }
 

--- a/crates/kotoha-engine-ibus/src/listener.rs
+++ b/crates/kotoha-engine-ibus/src/listener.rs
@@ -120,6 +120,12 @@ pub fn build_connection(bridge_tx: Sender<Event>) -> anyhow::Result<zbus::blocki
     use crate::service::KotohaEngineService;
 
     let address = discover_ibus_address()?;
+    // factory handler は panic-free 規約(spec §9.1: zbus は handler panic を
+    // catch しない)のため、engine path はここで事前 validate して field 注入する。
+    let engine_path: zbus::zvariant::OwnedObjectPath =
+        zbus::zvariant::ObjectPath::try_from(IBUS_ENGINE_OBJECT_PATH)
+            .map(Into::into)
+            .map_err(|e| anyhow::anyhow!("invalid IBUS_ENGINE_OBJECT_PATH constant: {e}"))?;
     tracing::info!(
         bus_name = IBUS_ENGINE_BUS_NAME,
         engine_path = IBUS_ENGINE_OBJECT_PATH,
@@ -127,7 +133,10 @@ pub fn build_connection(bridge_tx: Sender<Event>) -> anyhow::Result<zbus::blocki
         "connecting to IBus private bus (zbus blocking::Builder + #[interface] dispatcher)"
     );
     let connection = zbus::blocking::connection::Builder::address(address.as_str())?
-        .serve_at(IBUS_FACTORY_OBJECT_PATH, KotohaFactoryService)?
+        .serve_at(
+            IBUS_FACTORY_OBJECT_PATH,
+            KotohaFactoryService { engine_path },
+        )?
         .serve_at(IBUS_ENGINE_OBJECT_PATH, KotohaEngineService { bridge_tx })?
         .name(IBUS_ENGINE_BUS_NAME)?
         .build()?;
@@ -160,7 +169,11 @@ pub fn run(
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
     tracing::info!("dbus-listener received shutdown signal, dropping connection and exiting");
-    drop(connection); // zbus releases bus name + stops dispatching (last handle).
+    // 本 thread の handle を drop する。bus name release / dispatch 停止は
+    // engine-loop 側の `IBusEngineSignals` clone も drop された時点(全 handle
+    // drop 後)に起こる(SIGTERM 経路では engine-loop が drain 中でも本 drop が
+    // 先行しうる)。
+    drop(connection);
     Ok(())
 }
 

--- a/crates/kotoha-engine-ibus/src/proxy.rs
+++ b/crates/kotoha-engine-ibus/src/proxy.rs
@@ -3,7 +3,8 @@
 //! [`IBusEngineSignals`] は IBus engine が host(`InputContext`)に発する
 //! signal の helper 群。Phase 3-B B2 で 5 method すべてが
 //! `Message::signal(...)?.build(&body)?` + `connection.send(&signal)` の形で
-//! 実 D-Bus signal を session bus に発信する。
+//! 実 D-Bus signal を発信する。#208 改訂で発信先は listener と共有する
+//! **IBus private bus connection** に統一された(spec §7.4)。
 //!
 //! signal の wire-format type は [`crate::types`] module で定義(spec §4.2 r3)。
 //!
@@ -16,8 +17,8 @@
 //!
 //! # Security
 //!
-//! D-Bus session bus 上の signal はすべて **同 UID で動作する全プロセス** に
-//! 配信される。`org.freedesktop.IBus.Engine` の `UpdatePreeditText` /
+//! IBus private bus 上の signal は session bus 同様 **同 UID で動作する全プロセス**
+//! が接続・subscribe 可能である(bus socket の権限は user 単位)。`org.freedesktop.IBus.Engine` の `UpdatePreeditText` /
 //! `CommitText` を subscribe する任意 process(browser extension の subprocess、
 //! malicious npm postinstall、Electron app 等)が user の打鍵内容を
 //! 取得可能。これは IBus protocol の根本前提であり、Kotoha は
@@ -58,10 +59,17 @@ pub(crate) const IBUS_ENGINE_INTERFACE: &str = "org.freedesktop.IBus.Engine";
 /// listener thread の起動が失敗する。
 pub(crate) const IBUS_ENGINE_BUS_NAME: &str = "org.freedesktop.IBus.Engine.Kotoha";
 
-/// Kotoha engine service の D-Bus object path(spec §7.1)。
+/// Kotoha engine service の D-Bus object path(spec §7.2)。
 ///
 /// `Builder::serve_at(...)` でこの path に `KotohaEngineService` を登録する。
+/// 静的単一 path 採択(spec §7.3、#208): `CreateEngine` は常にこの path を返す。
 pub(crate) const IBUS_ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
+
+/// IBus 1.5.x factory の固定 object path(spec §7.2、#208)。
+///
+/// `Builder::serve_at(...)` でこの path に `KotohaFactoryService` を登録する。
+/// daemon の engine 生成 protocol はこの path への `CreateEngine` call を必須とする。
+pub(crate) const IBUS_FACTORY_OBJECT_PATH: &str = "/org/freedesktop/IBus/Factory";
 
 /// `UpdatePreeditText` signal member 名(IBus 1.5.x 仕様)。
 pub(crate) const MEMBER_UPDATE_PREEDIT_TEXT: &str = "UpdatePreeditText";
@@ -79,25 +87,26 @@ pub(crate) const MEMBER_HIDE_LOOKUP_TABLE: &str = "HideLookupTable";
 /// Phase 3-B B2 完了後は 5 method すべてが session bus に実 D-Bus signal を
 /// 発信する。
 pub(crate) struct IBusEngineSignals {
-    /// zbus blocking connection(session bus)。
+    /// zbus blocking connection(listener と共有する IBus private bus、#208)。
     connection: Connection,
     /// engine object path(`/org/freedesktop/IBus/Engine/Kotoha` 等)。
     object_path: zbus::zvariant::OwnedObjectPath,
 }
 
 impl IBusEngineSignals {
-    /// Session bus に接続し、engine object path で signal emit を準備する。
+    /// listener と共有する private bus connection を受け取り、engine object path
+    /// で signal emit を準備する(#208 / spec §7.4)。
+    ///
+    /// 初版は `Connection::session()` で独自接続していたが、daemon は signal の
+    /// 発信元 peer を engine の serve 元 connection で識別するため、別 connection
+    /// からの signal は `InputContext` に routing されない。connection は main の
+    /// DI wiring が構築する(spec §3.3)。
     ///
     /// # Errors
     ///
-    /// - zbus connection 確立失敗(`DBUS_SESSION_BUS_ADDRESS` 不設定等)
     /// - object_path 不正(D-Bus path syntax 違反)
-    pub(crate) fn new(object_path: &str) -> Result<Self> {
-        // path validation を session bus 接続より前に実行する(test から
-        // session 不要で path validation を exercise できるように、構造
-        // 分離は build_object_path で実施)。
+    pub(crate) fn new(connection: Connection, object_path: &str) -> Result<Self> {
         let path = build_object_path(object_path)?;
-        let connection = Connection::session()?;
         Ok(Self {
             connection,
             object_path: path,

--- a/crates/kotoha-engine-ibus/src/proxy.rs
+++ b/crates/kotoha-engine-ibus/src/proxy.rs
@@ -18,7 +18,8 @@
 //! # Security
 //!
 //! IBus private bus 上の signal は session bus 同様 **同 UID で動作する全プロセス**
-//! が接続・subscribe 可能である(bus socket の権限は user 単位)。`org.freedesktop.IBus.Engine` の `UpdatePreeditText` /
+//! が接続・subscribe 可能である(bus socket の権限は user 単位)。
+//! `org.freedesktop.IBus.Engine` の `UpdatePreeditText` /
 //! `CommitText` を subscribe する任意 process(browser extension の subprocess、
 //! malicious npm postinstall、Electron app 等)が user の打鍵内容を
 //! 取得可能。これは IBus protocol の根本前提であり、Kotoha は
@@ -84,8 +85,8 @@ pub(crate) const MEMBER_HIDE_LOOKUP_TABLE: &str = "HideLookupTable";
 
 /// IBus engine が host(`InputContext`)に発する signal の helper 群。
 ///
-/// Phase 3-B B2 完了後は 5 method すべてが session bus に実 D-Bus signal を
-/// 発信する。
+/// Phase 3-B B2 完了後は 5 method すべてが実 D-Bus signal を発信する。#208 改訂で
+/// connection は session bus から IBus private bus(listener と共有)に変更された。
 pub(crate) struct IBusEngineSignals {
     /// zbus blocking connection(listener と共有する IBus private bus、#208)。
     connection: Connection,

--- a/crates/kotoha-engine-ibus/src/service.rs
+++ b/crates/kotoha-engine-ibus/src/service.rs
@@ -99,6 +99,30 @@ impl KotohaEngineService {
     fn enable(&self) {
         tracing::debug!("KotohaEngineService::enable (no-op)");
     }
+
+    /// `SetCapabilities(u caps)` — daemon が engine 生成直後に呼ぶ capability 通知。
+    /// Phase 3-B では未使用(no-op stub、spec §2.1 #208 改訂)。
+    fn set_capabilities(&self, caps: u32) {
+        tracing::debug!(caps, "KotohaEngineService::set_capabilities (no-op)");
+    }
+
+    /// `SetCursorLocation(i x, i y, i w, i h)` — 候補 window 配置用 cursor 座標通知。
+    /// Phase 3-B では未使用(no-op stub、spec §2.1 #208 改訂)。
+    fn set_cursor_location(&self, x: i32, y: i32, w: i32, h: i32) {
+        tracing::debug!(
+            x,
+            y,
+            w,
+            h,
+            "KotohaEngineService::set_cursor_location (no-op)"
+        );
+    }
+
+    /// `Destroy()` — `org.freedesktop.IBus.Service.Destroy` 互換。静的単一 path
+    /// 採択(spec §7.3)のため object 解放は行わない(no-op stub)。
+    fn destroy(&self) {
+        tracing::debug!("KotohaEngineService::destroy (no-op)");
+    }
 }
 
 #[cfg(test)]
@@ -220,6 +244,16 @@ mod tests {
     fn enable_does_not_panic_or_send() {
         let (service, rx) = setup();
         service.enable();
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn daemon_compat_stubs_do_not_panic_or_send() {
+        // #208 改訂で追加した no-op stub 3 method(spec §2.1)
+        let (service, rx) = setup();
+        service.set_capabilities(9);
+        service.set_cursor_location(0, 0, 10, 20);
+        service.destroy();
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
     }
 }

--- a/crates/kotoha-engine-ibus/tests/ibus_host_bridge.rs
+++ b/crates/kotoha-engine-ibus/tests/ibus_host_bridge.rs
@@ -1,8 +1,9 @@
 //! L2-adapter integration test: `IBusHostBridge` の構築 smoke。
 //!
-//! 完全な mock IBus daemon は spec §10.1 / Open Q 9 で実装段階に詰める。
-//! 本 PR は **接続 only** の smoke を入れ、PR レビューで sequence assert
-//! の詳細化を Phase 3-A 本番実装段階に deferral する。
+//! #208 改訂で `IBusHostBridge::new` は connection 注入形になった(独自接続を
+//! 廃止、spec §7.4)。本 test は注入用 connection の確立に dbus session bus を
+//! 流用する(`IBusHostBridge` 自体は bus 種別に依存しない — production では
+//! private bus connection が注入される)。
 //!
 //! # B0e (ISSUE #140 / Important review feedback)
 //!
@@ -10,17 +11,18 @@
 //!
 //! - session bus が無い場合は `#[ignore]` で skip(green check で誤誘導しない)
 //! - session bus が在る場合は `result.is_ok()` を assert
-//! - session bus 在 + 接続失敗(IBus daemon 未起動等)時は明示 panic で fail surface
 
 #[test]
 #[ignore = "requires DBUS_SESSION_BUS_ADDRESS; run with `cargo test -- --ignored`"]
-fn host_bridge_constructs_with_session_bus() {
+fn host_bridge_constructs_with_injected_connection() {
     let _addr = std::env::var("DBUS_SESSION_BUS_ADDRESS")
         .expect("DBUS_SESSION_BUS_ADDRESS required for this test");
-    let result = kotoha_engine_ibus::IBusHostBridge::new("/org/freedesktop/IBus/Engine/Kotoha");
+    let connection = zbus::blocking::Connection::session().expect("open session bus for injection");
+    let result =
+        kotoha_engine_ibus::IBusHostBridge::new(connection, "/org/freedesktop/IBus/Engine/Kotoha");
     assert!(
         result.is_ok(),
-        "IBusHostBridge::new should succeed on a healthy session bus: {:?}",
+        "IBusHostBridge::new should succeed with a healthy injected connection: {:?}",
         result.err()
     );
 }

--- a/crates/kotoha-engine-ibus/tests/integration.rs
+++ b/crates/kotoha-engine-ibus/tests/integration.rs
@@ -1,10 +1,18 @@
-//! Phase 3-B B6-b (#195) — listener thread + engine_loop 経路の L2 integration test。
+//! Phase 3-B B6-b (#195) + #208 — listener thread + engine_loop 経路の
+//! L2 integration test。
 //!
-//! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1 L2 row。
+//! Spec: `docs/specs/_uncategorized/p3-b-ibus-listener.md` §10.1 L2 rows。
 //!
-//! 本 test は dbus session bus に依存するため `#[ignore]` で gate し、
+//! 使い捨て `dbus-daemon --session` を IBus private bus に見立て、
+//! `KOTOHA_IBUS_ADDRESS` 注入で `build_connection` に解決させる(spec §7.1
+//! 優先度 1 の override 経路)。test 自身が fake ibus-daemon として
+//! `CreateEngine` → `ProcessKeyEvent` の handshake を再現する。
+//!
+//! 本 test は `dbus-daemon` binary に依存するため `#[ignore]` で gate し、
 //! `cargo test -p kotoha-engine-ibus -- --ignored` で opt-in 実行する。
 //! 通常 CI / pre-push hook では実行されない(L3 manual smoke #196 で実機検証する)。
+//! env var(`KOTOHA_IBUS_ADDRESS`)を扱うため、handshake 検証は単一 test 関数に
+//! 直列化している(test 間 env 競合回避)。
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,72 +20,139 @@ use std::time::Duration;
 use crossbeam_channel::unbounded;
 use kotoha_engine_core::key_event::KeyEventResult;
 use kotoha_engine_core::reactor::Event;
-use kotoha_engine_ibus::listener::{run, ListenerShutdown};
+use kotoha_engine_ibus::listener::{build_connection, run, ListenerShutdown};
 
-/// listener::run が session bus に接続し、Event::IBusKey が bridge_tx 経由で
-/// 受け取れる経路を pin する(decode + dispatch の最小経路)。
+/// 使い捨て dbus-daemon の lifecycle guard(Drop で kill)。
+struct ThrowawayBus {
+    address: String,
+    pid: u32,
+}
+
+impl ThrowawayBus {
+    fn spawn() -> Self {
+        let output = std::process::Command::new("dbus-daemon")
+            // `--print-address` / `--print-pid` は空白区切りの次引数を fd として
+            // 解釈するため `=1`(stdout)を明示する
+            .args(["--session", "--fork", "--print-address=1", "--print-pid=1"])
+            .output()
+            .expect("spawn dbus-daemon (binary required for this test)");
+        assert!(
+            output.status.success(),
+            "dbus-daemon failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8(output.stdout).expect("dbus-daemon stdout utf8");
+        let mut lines = stdout.lines();
+        let address = lines.next().expect("address line").trim().to_owned();
+        let pid: u32 = lines
+            .next()
+            .expect("pid line")
+            .trim()
+            .parse()
+            .expect("pid number");
+        Self { address, pid }
+    }
+}
+
+impl Drop for ThrowawayBus {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("kill")
+            .arg(self.pid.to_string())
+            .status();
+    }
+}
+
+/// fake daemon として handshake 全経路を 1 関数で検証する:
 ///
-/// 本 test は実 IBus daemon を要求しない:listener が serve_at + name で
-/// publish した状態で test 側が D-Bus client として `ProcessKeyEvent` を
-/// 呼び出し、bridge_rx で `Event::IBusKey` を観測する。
+/// 1. `build_connection` が `KOTOHA_IBUS_ADDRESS` 経由で使い捨て bus に接続し
+///    Factory + Engine を serve する
+/// 2. `CreateEngine("kotoha")` が静的 engine path を返す(spec §4.5 / §7.3)
+/// 3. 返却 path への `ProcessKeyEvent` が bridge channel 経由で
+///    `Event::IBusKey` に decode され、`Consumed` 応答が `true` で返る
+/// 4. `CreateEngine("anthy")` が D-Bus error で reject される(spec §9.1)
 #[test]
-#[ignore = "依存: dbus session bus available; CI で flaky のため opt-in"]
-fn listener_decodes_process_key_event() {
+#[ignore = "依存: dbus-daemon binary; CI で flaky のため opt-in"]
+fn handshake_create_engine_and_process_key_event() {
+    let bus = ThrowawayBus::spawn();
+    std::env::set_var("KOTOHA_IBUS_ADDRESS", &bus.address);
+
     let (bridge_tx, bridge_rx) = unbounded::<Event>();
     let (shutdown_trigger, shutdown_observer) = ListenerShutdown::new();
 
+    // 1. component 側: connection 構築(Factory + Engine serve + RequestName)
+    let connection = build_connection(bridge_tx).expect("build_connection via KOTOHA_IBUS_ADDRESS");
     let listener_handle = std::thread::Builder::new()
         .name("test-dbus-listener".into())
-        .spawn(move || run(bridge_tx, shutdown_observer))
+        .spawn(move || run(connection, shutdown_observer))
         .expect("spawn listener");
 
-    // listener が bus name 取得を完了するまで短時間待つ(Builder::build() は
-    // 同期的に完了するが、別 thread spawn 直後の race を避けるための margin)
-    std::thread::sleep(Duration::from_millis(100));
-
-    // test 側が D-Bus method を呼ぶ proxy を組む
-    let conn = zbus::blocking::Connection::session().expect("open test session bus");
-    let proxy = zbus::blocking::Proxy::new(
-        &conn,
+    // 2. fake daemon 側: 同じ bus に接続し CreateEngine を call
+    let daemon_conn = zbus::blocking::connection::Builder::address(bus.address.as_str())
+        .expect("daemon-side address")
+        .build()
+        .expect("daemon-side connection");
+    let factory_proxy = zbus::blocking::Proxy::new(
+        &daemon_conn,
         "org.freedesktop.IBus.Engine.Kotoha",
-        "/org/freedesktop/IBus/Engine/Kotoha",
-        "org.freedesktop.IBus.Engine",
+        "/org/freedesktop/IBus/Factory",
+        "org.freedesktop.IBus.Factory",
     )
-    .expect("build proxy");
+    .expect("build factory proxy");
 
-    // ProcessKeyEvent 呼び出しは listener 側で respond_rx.recv_timeout を blocking で
-    // 待つため、別 thread で event を engine 役として返す
-    let bridge_rx_for_engine = Arc::new(bridge_rx);
-    let bridge_rx_clone = bridge_rx_for_engine.clone();
+    let engine_path: zbus::zvariant::OwnedObjectPath = factory_proxy
+        .call("CreateEngine", &("kotoha",))
+        .expect("CreateEngine(kotoha)");
+    assert_eq!(
+        engine_path.as_str(),
+        "/org/freedesktop/IBus/Engine/Kotoha",
+        "CreateEngine must return the static engine path (spec §7.3)"
+    );
+
+    // 3. 返却された path に ProcessKeyEvent を call(engine 役 stub が応答)
+    let bridge_rx = Arc::new(bridge_rx);
+    let bridge_rx_clone = bridge_rx.clone();
     let engine_thread = std::thread::Builder::new()
         .name("test-engine-loop-stub".into())
-        .spawn(move || {
-            // listener の process_key_event がここに event を送ってくる想定
-            match bridge_rx_clone.recv_timeout(Duration::from_millis(500)) {
+        .spawn(
+            move || match bridge_rx_clone.recv_timeout(Duration::from_millis(500)) {
                 Ok(Event::IBusKey { event: _, respond }) => {
                     respond
                         .send(KeyEventResult::Consumed)
                         .expect("send Consumed back");
                 }
                 other => panic!("engine-loop stub expected IBusKey, got {other:?}"),
-            }
-        })
+            },
+        )
         .expect("spawn engine stub");
 
-    // method を blocking で呼び出す(返り値 b)
-    let result: bool = proxy
+    let engine_proxy = zbus::blocking::Proxy::new(
+        &daemon_conn,
+        "org.freedesktop.IBus.Engine.Kotoha",
+        engine_path.as_str(),
+        "org.freedesktop.IBus.Engine",
+    )
+    .expect("build engine proxy");
+    let consumed: bool = engine_proxy
         .call("ProcessKeyEvent", &(0x6b_u32, 45_u32, 0_u32))
         .expect("call ProcessKeyEvent");
-
     engine_thread.join().expect("engine stub join");
-    assert!(result, "expected true (Consumed) from listener");
+    assert!(consumed, "expected true (Consumed) from listener");
+
+    // 4. 未知 engine 名は reject される
+    let unknown: Result<zbus::zvariant::OwnedObjectPath, zbus::Error> =
+        factory_proxy.call("CreateEngine", &("anthy",));
+    assert!(
+        unknown.is_err(),
+        "CreateEngine with unknown engine name must fail (spec §9.1)"
+    );
 
     // shutdown
     shutdown_trigger.request();
-    drop(conn);
+    drop(daemon_conn);
     let listener_result = listener_handle.join().expect("listener join");
     assert!(
         listener_result.is_ok(),
         "listener exited with error: {listener_result:?}"
     );
+    std::env::remove_var("KOTOHA_IBUS_ADDRESS");
 }

--- a/crates/kotoha-engine-ibus/tests/integration.rs
+++ b/crates/kotoha-engine-ibus/tests/integration.rs
@@ -11,8 +11,14 @@
 //! 本 test は `dbus-daemon` binary に依存するため `#[ignore]` で gate し、
 //! `cargo test -p kotoha-engine-ibus -- --ignored` で opt-in 実行する。
 //! 通常 CI / pre-push hook では実行されない(L3 manual smoke #196 で実機検証する)。
-//! env var(`KOTOHA_IBUS_ADDRESS`)を扱うため、handshake 検証は単一 test 関数に
-//! 直列化している(test 間 env 競合回避)。
+//!
+//! # env var 不変条件
+//!
+//! `std::env::set_var` は process-global で test runner は default 並列実行のため、
+//! **本 binary 内で `KOTOHA_IBUS_ADDRESS` に触れる test は本関数 1 つだけ** を
+//! 不変条件とする(Cargo の `tests/*.rs` は file ごとに別 binary = 別 process
+//! なので、他 test file とは競合しない)。本 file に env を扱う test を追加する
+//! 場合は `--test-threads=1` 指定か serial guard の導入が必要。
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,43 +28,68 @@ use kotoha_engine_core::key_event::KeyEventResult;
 use kotoha_engine_core::reactor::Event;
 use kotoha_engine_ibus::listener::{build_connection, run, ListenerShutdown};
 
-/// 使い捨て dbus-daemon の lifecycle guard(Drop で kill)。
+/// 使い捨て dbus-daemon の lifecycle guard(Drop で kill + reap)。
+///
+/// `--fork` は使わない: fork された daemon は orphan 化し、address parse が
+/// panic した場合に guard 未構築のまま leak する(review finding)。child を
+/// 直接保持し、spawn 直後(後続の fallible parse より前)に guard を構築する
+/// ことで、parse panic 時も Drop が必ず reap する。
 struct ThrowawayBus {
     address: String,
-    pid: u32,
+    child: std::process::Child,
 }
 
 impl ThrowawayBus {
     fn spawn() -> Self {
-        let output = std::process::Command::new("dbus-daemon")
-            // `--print-address` / `--print-pid` は空白区切りの次引数を fd として
-            // 解釈するため `=1`(stdout)を明示する
-            .args(["--session", "--fork", "--print-address=1", "--print-pid=1"])
-            .output()
+        use std::io::BufRead;
+        // `--print-address` は空白区切りの次引数を fd として解釈するため
+        // `=1`(stdout)を明示する
+        let mut child = std::process::Command::new("dbus-daemon")
+            .args(["--session", "--print-address=1"])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
             .expect("spawn dbus-daemon (binary required for this test)");
-        assert!(
-            output.status.success(),
-            "dbus-daemon failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let stdout = String::from_utf8(output.stdout).expect("dbus-daemon stdout utf8");
-        let mut lines = stdout.lines();
-        let address = lines.next().expect("address line").trim().to_owned();
-        let pid: u32 = lines
-            .next()
-            .expect("pid line")
-            .trim()
-            .parse()
-            .expect("pid number");
-        Self { address, pid }
+        // ここから先で panic しても Drop が child を kill できるよう、
+        // 先に guard を構築する
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut bus = Self {
+            address: String::new(),
+            child,
+        };
+        let mut line = String::new();
+        std::io::BufReader::new(stdout)
+            .read_line(&mut line)
+            .expect("read dbus-daemon address line");
+        bus.address = line.trim().to_owned();
+        assert!(!bus.address.is_empty(), "dbus-daemon printed empty address");
+        bus
     }
 }
 
 impl Drop for ThrowawayBus {
     fn drop(&mut self) {
-        let _ = std::process::Command::new("kill")
-            .arg(self.pid.to_string())
-            .status();
+        // Drop 内 panic は double-panic abort になるため結果は捨てるが、
+        // kill 失敗は process leak になるので観測経路だけ残す
+        if let Err(e) = self.child.kill() {
+            eprintln!("ThrowawayBus: failed to kill dbus-daemon: {e}");
+        }
+        let _ = self.child.wait();
+    }
+}
+
+/// env var の RAII guard(panic 時も `remove_var` を保証する)。
+struct EnvGuard(&'static str);
+
+impl EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        std::env::set_var(name, value);
+        Self(name)
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        std::env::remove_var(self.0);
     }
 }
 
@@ -74,7 +105,7 @@ impl Drop for ThrowawayBus {
 #[ignore = "依存: dbus-daemon binary; CI で flaky のため opt-in"]
 fn handshake_create_engine_and_process_key_event() {
     let bus = ThrowawayBus::spawn();
-    std::env::set_var("KOTOHA_IBUS_ADDRESS", &bus.address);
+    let _env = EnvGuard::set("KOTOHA_IBUS_ADDRESS", &bus.address);
 
     let (bridge_tx, bridge_rx) = unbounded::<Event>();
     let (shutdown_trigger, shutdown_observer) = ListenerShutdown::new();
@@ -154,5 +185,4 @@ fn handshake_create_engine_and_process_key_event() {
         listener_result.is_ok(),
         "listener exited with error: {listener_result:?}"
     );
-    std::env::remove_var("KOTOHA_IBUS_ADDRESS");
 }

--- a/docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md
+++ b/docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md
@@ -2,7 +2,7 @@
 
 | 項目 | 値 |
 |------|----|
-| Status | Accepted |
+| Status | Accepted (Amended 2026-06-11, #208) |
 | Date | 2026-05-08 |
 | Phase | Phase 3-B B6-b (#195) |
 | 関連 spec | `docs/specs/_uncategorized/p3-b-ibus-listener.md` |
@@ -61,7 +61,29 @@ zbus 5 の async API 主導であり、blocking 系から `MessageStream` を直
 
 - IBus engine factory registration の正規経路(`/usr/share/ibus/component/<name>.xml`)は本 ADR scope 外。packaging task として別 ISSUE で扱う。
 
+## Amendment 2026-06-11(ISSUE #208)
+
+B6-c L3 manual smoke(2026-06-11、Ubuntu 24.04 / GNOME 46 / IBus 1.5.29-rc2)で、採択 1 の session bus 接続では ibus-daemon との handshake が成立しないことが実機確定した(`ibus engine kotoha` が `SetGlobalEngine: Timeout`。診断詳細: ISSUE #208)。以下のとおり採択を変更・追加する:
+
+1. **接続先**(採択 1 変更): `blocking::connection::Builder::session()` → `Builder::address(<IBus private bus address>)`。address は `KOTOHA_IBUS_ADDRESS` env → `IBUS_ADDRESS` env → address file(`$XDG_CONFIG_HOME/ibus/bus/<machine-id>-<hostname>-<display>`)の 3 段 fallback で解決する(IBus client library `ibus_get_address()` 互換、spec §7.1)。
+2. **Factory interface**(採択追加): `org.freedesktop.IBus.Factory` を `/org/freedesktop/IBus/Factory` で serve し、`CreateEngine(s) -> o` で静的 engine path を返す(spec §4.5)。daemon の engine 生成 protocol はこの経路を必須とする。
+3. **signal connection 共有**(採択追加): `IBusEngineSignals` の独自 `Connection::session()` を廃止し、listener と同一の private bus connection(`Clone` handle)を共有する(spec §7.4)。connection 構築は main thread の DI wiring に移す(spec §3.3)。
+4. **engine object serve 方式**: 静的単一 path `/org/freedesktop/IBus/Engine/Kotoha` を維持する(GNOME global engine mode 前提、spec §7.3)。
+
+採択 2(respond channel + 100ms timeout)・採択 3(threading)・採択 4(stub safety net 削除)は変更しない。
+
+### Deferred in this amendment
+
+- **per-CreateEngine 動的 path**: IBus 本来の semantics だが、`IBusEngineSignals` 側の path 同期機構を要し global engine mode では複雑性が見合わない。Phase 6 multi-context で再評価する(rejected ではなく deferred、spec §13.4)。
+
+### Amendment consequences
+
+- Positive: 実機 GNOME 環境で daemon handshake が成立する設計となり、B6-c smoke の前提が回復する
+- Negative: address discovery が環境依存(machine-id file / `DISPLAY` env)の入力を持つため、純関数分離 + `KOTOHA_IBUS_ADDRESS` override で test 可能性を確保する(spec §10.1)
+- Neutral: L1/L2 test では daemon handshake を完全には再現できない(fake daemon による L2 + 実機 L3 smoke の併用、spec §10.1)
+
 ## Future revisit triggers
 
 - Phase 5 custom romaji-base model の inference latency が増えた場合、100ms timeout 値の引き上げ / `Event::IBusKey` への deadline 拡張 / `async fn` method 化 + smol::unblock を再評価する
 - Phase 4 fcitx5 adapter で異なる protocol への generalization が必要な場合、`KotohaEngineService` を trait 化する余地
+- Phase 6 multi-context で per-CreateEngine 動的 path 化を再評価する(Amendment 2026-06-11 §Deferred)

--- a/docs/plans/2026-06-11-bugfix-208-ibus-private-bus-factory.md
+++ b/docs/plans/2026-06-11-bugfix-208-ibus-private-bus-factory.md
@@ -1,0 +1,264 @@
+# ISSUE #208 — IBus private bus + Factory interface Implementation Plan
+
+**Goal:** `kotoha-engine-ibus` の D-Bus 接続先を session bus から IBus private bus(address discovery 経由)に変更し、`org.freedesktop.IBus.Factory` interface を serve して ibus-daemon との handshake(`SetGlobalEngine`)を成立させる。signal 発信経路(`IBusEngineSignals`)も同一 connection に統一する。
+
+**Spec:** `docs/specs/_uncategorized/p3-b-ibus-listener.md` §4.5 / §7(#208 改訂版)/ §10.1 / §11.1
+**ADR:** `docs/adr/0021-zbus-integration-architecture-for-ibus-listener.md` Amendment 2026-06-11
+**ISSUE:** [#208](https://github.com/std-koh-hinooka/kotoha-ime/issues/208)(parent: #136 B6-c)
+**Branch:** `bugfix/208-ibus-private-bus-factory`(Spec 改訂 commit `a106a5d` 済)
+
+---
+
+## マイルストーン位置付け
+
+| 観点 | 内容 |
+|---|---|
+| Phase | 3-B(IBus integration)、B6-c blocker 解消 |
+| 前提 | PR #207(dict size cap)merge 済、Spec/ADR 改訂 commit 済 |
+| 後続 | B6-c L3 manual smoke 再開(`docs/runbooks/2026-06-11-phase3b-b6-l3-smoke-result.md` 引継) |
+| 検証 | L1 unit(無条件)+ L2 handshake(`#[ignore]`)+ lefthook pre-push |
+
+## ファイル構成
+
+### 新規作成(2 ファイル)
+
+```
+crates/kotoha-engine-ibus/src/
+├── discovery.rs        # private bus address discovery(純関数 + env/file 入力)
+└── factory.rs          # KotohaFactoryService(org.freedesktop.IBus.Factory)
+```
+
+### 変更(6 ファイル)
+
+```
+crates/kotoha-engine-ibus/src/
+├── lib.rs              # mod discovery; mod factory; 追加
+├── proxy.rs            # IBUS_FACTORY_OBJECT_PATH 追加、IBusEngineSignals::new signature 変更
+├── service.rs          # no-op stub 3 method 追加
+├── listener.rs         # build_connection() 新設、run() を connection 受領形に変更
+└── host_bridge.rs      # IBusHostBridge::new(connection, object_path) に変更
+crates/kotoha-bin/src/
+└── main.rs             # DI wiring 順序入替(reactor → connection → host_bridge → engine → listener)
+crates/kotoha-engine-ibus/tests/
+└── integration.rs      # L2 handshake test(#[ignore])
+```
+
+---
+
+## Step 1: discovery.rs 新規(Spec §7.1)
+
+- [ ] `crates/kotoha-engine-ibus/src/discovery.rs` を作成する
+
+```rust
+pub(crate) const KOTOHA_IBUS_ADDRESS_ENV: &str = "KOTOHA_IBUS_ADDRESS";
+pub(crate) const IBUS_ADDRESS_ENV: &str = "IBUS_ADDRESS";
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DiscoveryError {
+    #[error("machine-id not readable: {0}")]
+    MachineId(std::io::Error),
+    #[error("DISPLAY not set; cannot derive IBus address file name")]
+    DisplayUnset,
+    #[error("IBus address file not readable: {path}: {source}")]
+    AddressFile { path: std::path::PathBuf, source: std::io::Error },
+    #[error("IBUS_ADDRESS= line not found in address file: {path}")]
+    AddressLineMissing { path: std::path::PathBuf },
+}
+```
+
+関数 4 つ(`discover_ibus_address` 以外は純関数または入力分離形):
+
+1. `pub(crate) fn discover_ibus_address() -> Result<String, DiscoveryError>` — 3 段 fallback: `KOTOHA_IBUS_ADDRESS` env → `IBUS_ADDRESS` env → `address_file_path()?` を read して `parse_address_file`
+2. `fn address_file_path() -> Result<PathBuf, DiscoveryError>` — `$XDG_CONFIG_HOME`(未設定時 `$HOME/.config`)`/ibus/bus/<machine-id>-unix-<display>`。machine-id は `/var/lib/dbus/machine-id` → `/etc/machine-id` fallback、trim。display は `display_number(&env DISPLAY)?`
+3. `pub(crate) fn parse_address_file(content: &str) -> Option<&str>` — 行頭 `IBUS_ADDRESS=` の最初の行の値部分を返す(コメント行 `#` 無視)
+4. `fn display_number(display: &str) -> &str` — `":0"` → `"0"`、`":0.0"` → `"0"`(先頭 `:` 除去 + 最初の `.` 以降切捨て)
+
+- [ ] L1 unit tests(同ファイル `#[cfg(test)]`、純関数のみ・env 非依存):
+  - `parse_address_file`: 正常(`IBUS_ADDRESS=unix:abstract=...` 行 + コメント行 + `IBUS_DAEMON_PID=` 行の混在)/ `IBUS_ADDRESS=` 行欠落で `None` / 空文字列で `None`
+  - `display_number`: `":0"` / `":0.0"` / `":12"` の 3 case
+
+## Step 2: proxy.rs — 定数追加 + IBusEngineSignals signature 変更(Spec §7.2 / §7.4)
+
+- [ ] `IBUS_FACTORY_OBJECT_PATH` 定数を追加する
+
+```rust
+/// IBus 1.5.x factory の固定 object path(spec §7.2、#208)。
+pub(crate) const IBUS_FACTORY_OBJECT_PATH: &str = "/org/freedesktop/IBus/Factory";
+```
+
+- [ ] `IBusEngineSignals::new` を connection 受領形に変更する(独自 `Connection::session()` を削除)
+
+```rust
+pub(crate) fn new(connection: Connection, object_path: &str) -> Result<Self> {
+    let path = build_object_path(object_path)?;
+    Ok(Self { connection, object_path: path })
+}
+```
+
+- [ ] module doc の「session bus に発信」記述を「private bus(listener と共有する connection)に発信」へ更新する(threat model 段落の「同 UID プロセス信頼」前提は private bus でも同一なので維持)
+- [ ] 既存の `build_object_path` unit tests は無修正で pass することを確認する
+
+## Step 3: factory.rs 新規(Spec §4.5)
+
+- [ ] `crates/kotoha-engine-ibus/src/factory.rs` を作成する
+
+```rust
+use zbus::interface;
+use crate::proxy::IBUS_ENGINE_OBJECT_PATH;
+
+pub(crate) struct KotohaFactoryService;
+
+#[interface(name = "org.freedesktop.IBus.Factory")]
+impl KotohaFactoryService {
+    /// `CreateEngine(s engine_name) -> o`(IBus 1.5.x `ibusfactory.c` 仕様)。
+    fn create_engine(
+        &self,
+        engine_name: &str,
+    ) -> zbus::fdo::Result<zbus::zvariant::OwnedObjectPath> {
+        if engine_name != "kotoha" {
+            tracing::warn!(
+                error_id = "factory.create_engine.unknown_engine",
+                engine_name,
+                "CreateEngine called with unknown engine name"
+            );
+            return Err(zbus::fdo::Error::InvalidArgs(format!(
+                "unknown engine name: {engine_name}"
+            )));
+        }
+        // 静的単一 path(spec §7.3): engine object は connection build 時に
+        // serve_at 済みのため、path の返却のみを行う。
+        Ok(zbus::zvariant::OwnedObjectPath::try_from(IBUS_ENGINE_OBJECT_PATH)
+            .expect("IBUS_ENGINE_OBJECT_PATH is a valid D-Bus object path"))
+    }
+}
+```
+
+- [ ] L1 unit tests: `create_engine("kotoha")` が `IBUS_ENGINE_OBJECT_PATH` を返す / `create_engine("anthy")` が `InvalidArgs` を返す(`#[interface]` の inherent method を直接呼ぶ)
+- [ ] `lib.rs` に `mod discovery; mod factory;` を追加する
+
+## Step 4: service.rs — daemon 互換 no-op stub 追加(Spec §2.1)
+
+- [ ] `#[interface]` impl に 3 method を追加する(いずれも `tracing::debug!` のみ)
+
+```rust
+/// daemon が engine 生成直後に呼ぶ capability 通知。Phase 3-B では未使用(no-op)。
+fn set_capabilities(&self, caps: u32) { tracing::debug!(caps, "SetCapabilities (no-op)"); }
+/// 候補 window 配置用 cursor 座標通知。Phase 3-B では未使用(no-op)。
+fn set_cursor_location(&self, x: i32, y: i32, w: i32, h: i32) {
+    tracing::debug!(x, y, w, h, "SetCursorLocation (no-op)");
+}
+/// `org.freedesktop.IBus.Service.Destroy` 互換。静的単一 path(spec §7.3)のため
+/// object 解放は行わない(no-op)。
+fn destroy(&self) { tracing::debug!("Destroy (no-op)"); }
+```
+
+- [ ] 既存 6 method の unit tests が無修正で pass することを確認する
+
+## Step 5: listener.rs — build_connection 分離 + run の connection 受領化(Spec §3.3 / §7.2)
+
+- [ ] `pub fn build_connection(bridge_tx: Sender<Event>) -> anyhow::Result<zbus::blocking::Connection>` を新設する
+
+```rust
+pub fn build_connection(
+    bridge_tx: Sender<Event>,
+) -> anyhow::Result<zbus::blocking::Connection> {
+    use crate::discovery::discover_ibus_address;
+    use crate::factory::KotohaFactoryService;
+    use crate::proxy::{IBUS_ENGINE_BUS_NAME, IBUS_ENGINE_OBJECT_PATH, IBUS_FACTORY_OBJECT_PATH};
+    use crate::service::KotohaEngineService;
+
+    let address = discover_ibus_address()?;
+    let connection = zbus::blocking::connection::Builder::address(address.as_str())?
+        .serve_at(IBUS_FACTORY_OBJECT_PATH, KotohaFactoryService)?
+        .serve_at(IBUS_ENGINE_OBJECT_PATH, KotohaEngineService { bridge_tx })?
+        .name(IBUS_ENGINE_BUS_NAME)?
+        .build()?;
+    Ok(connection)
+}
+```
+
+- [ ] `run` の signature を `pub fn run(connection: zbus::blocking::Connection, shutdown: ShutdownObserver) -> anyhow::Result<()>` に変更する — connection 構築コードを除去し、shutdown poll loop + drop のみ残す
+- [ ] module doc / `run` の doc comment(Preconditions / Postconditions / Errors)を private bus + main 構築前提に更新する
+- [ ] `ShutdownObserver` 系 unit tests 3 件は無修正で pass することを確認する
+
+## Step 6: host_bridge.rs — connection 注入(Spec §7.4)
+
+- [ ] `IBusHostBridge::new` を変更する
+
+```rust
+pub fn new(connection: zbus::blocking::Connection, object_path: &str) -> zbus::Result<Self> {
+    Ok(Self {
+        lookup_table: LookupTable::new(),
+        signals: IBusEngineSignals::new(connection, object_path)?,
+    })
+}
+```
+
+- [ ] struct / `new` の doc comment(「session bus 接続」)を更新する
+
+## Step 7: main.rs — DI wiring 順序入替(Spec §3.1 / §3.3)
+
+現行順序: 8. host_bridge → 9. reactor → 10. engine → 11-12. listener spawn。
+新順序: **8. reactor → 9. connection 構築 → 10. host_bridge → 11. engine → 12-13. listener spawn**(connection 構築が `bridge_tx` を要するため)。
+
+- [ ] step 9(現 8)の host_bridge 構築を reactor の後ろに移動し、以下の形にする
+
+```rust
+// 9. private bus connection(#208 / ADR 0021 Amendment): main が構築し、
+//    clone を host bridge へ、本体を listener thread へ配布する。
+let connection = match kotoha_engine_ibus::listener::build_connection(bridge_tx.clone()) {
+    Ok(c) => Some(c),
+    #[cfg(feature = "dev-stubs")]
+    Err(e) if allow_stub => {
+        tracing::error!(error = ?e,
+            "IBus private bus connect failed; using StubHostBridge (KOTOHA_ALLOW_STUB=1)");
+        None
+    }
+    Err(e) => {
+        return Err(e).context(
+            "IBus private bus connect failed (is ibus-daemon running?) \
+             and KOTOHA_ALLOW_STUB is not set",
+        );
+    }
+};
+
+// 10. host bridge: connection clone を注入。
+let (host_bridge, host_bridge_backend): (Box<dyn kotoha_engine_core::IMEHostBridge>, &'static str) =
+    match &connection {
+        Some(c) => (
+            Box::new(kotoha_engine_ibus::IBusHostBridge::new(c.clone(), ENGINE_OBJECT_PATH)?),
+            "IBusHostBridge",
+        ),
+        #[cfg(feature = "dev-stubs")]
+        None => (Box::new(StubHostBridge), "StubHostBridge"),
+        #[cfg(not(feature = "dev-stubs"))]
+        None => unreachable!("connection is always Some when dev-stubs is disabled"),
+    };
+```
+
+- [ ] listener spawn を `connection` が `Some` の場合のみ実行し、`listener_handle: Option<JoinHandle<_>>` に変更する(stub 経路では listener 不在。join 側も `if let Some(h)` 化)
+- [ ] module doc(line 15 付近「session bus 接続」)と step 番号 comment を更新する
+- [ ] `cargo build --workspace` + `cargo clippy --workspace --all-targets -- -D warnings` を通す
+
+## Step 8: L2 handshake test(Spec §10.1)
+
+- [ ] `crates/kotoha-engine-ibus/tests/integration.rs` に `#[ignore]` test を追加する:
+  1. `dbus-daemon --session --print-address --fork` で使い捨て bus を起動(test 終了時 kill)
+  2. `KOTOHA_IBUS_ADDRESS` にその address を設定し `build_connection(bridge_tx)` 実行
+  3. fake daemon 側 connection(同 address)から destination `org.freedesktop.IBus.Engine.Kotoha` の `/org/freedesktop/IBus/Factory` に `CreateEngine("kotoha")` を call → 返却 path が `/org/freedesktop/IBus/Engine/Kotoha` であること
+  4. 同 path に `ProcessKeyEvent(0x61, 38, 0)` を call → bridge channel の `Receiver` 側で `Event::IBusKey` を受信し `respond.send(Consumed)` → call 戻り値 `true` であること
+  5. `CreateEngine("anthy")` が D-Bus error を返すこと
+- [ ] env var を扱う test なので `#[ignore]` + 単一 test 関数に直列化(test 間 env 競合回避)
+
+## Step 9: 検証 + PR
+
+- [ ] `cargo fmt --all` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace`(+ `cargo test -p kotoha-engine-ibus -- --ignored` を dbus-daemon 在環境で手動 1 回)
+- [ ] lefthook pre-push 通過
+- [ ] PR 作成(base: develop、English)。size 見積: ~500-700 lines / 9 files → **Medium-Large tier**。IBus との接続境界 = input validation 隣接につき security-touching 扱い: `team-review`(全 5 dims)+ `owasp-security` + `secrets-check`
+- [ ] merge 後: `/post-merge` → B6-c smoke 再開(handoff `2026-06-11-issue-208-ibus-bus-factory` §3 の環境固有手順)
+
+## Out of scope
+
+- per-CreateEngine 動的 path(Phase 6 再評価、Spec §13.4)
+- component XML packaging(別 ISSUE、Spec §7.5)
+- runbook errata 3 件(smoke result PR に同梱、handoff §4)

--- a/docs/specs/_uncategorized/p3-b-ibus-listener.md
+++ b/docs/specs/_uncategorized/p3-b-ibus-listener.md
@@ -398,7 +398,7 @@ IBus 1.5.x では engine 登録の正規経路は component XML ファイル配�
 | address file parse 失敗(`IBUS_ADDRESS=` 行欠落 / 不正形式)(#208) | 同上 | 同上 |
 | `CreateEngine` に未知 engine_name(#208) | `fdo::Error::InvalidArgs` 返却、connection 維持 | `error_id = "factory.create_engine.unknown_engine"` warn |
 | `RequestName` 失敗(他 process が同名占有)| `run()` Err で main thread に伝播 → process exit | `tracing::error!` + `?` propagation |
-| service method 内 panic | `&self` impl で field なし、panic 起こりにくい。万一発生時は zbus が catch して daemon に Err 返却、connection は維持 | zbus 標準 |
+| service method 内 panic | **zbus 5 は handler panic を catch しない**(2026-06-11 に zbus 5.16 vendored source で検証: `catch_unwind` 不在。panic は dispatch task を黙殺し、以後の全 method dispatch が無 log で停止する)。このため `#[interface]` handler 本体は panic-free を規約とし、panic しうる前処理(path validate 等)は `build_connection` 段階に移して Err propagate させる | handler 内 panic site 禁止(code review で gate) |
 | bridge_tx.send Err(engine_loop drop)| `false` 返却 + `error_id = "listener.process_key_event.bridge_disconnected"` | tracing::warn |
 | respond.recv timeout(>100ms)| `false` 返却 + `error_id = "listener.process_key_event.timeout"` | tracing::warn |
 | ShutdownObserver `is_shutting_down() == true` | poll loop 抜ける、Connection drop | `tracing::info!` |
@@ -420,7 +420,7 @@ IBus 1.5.x では engine 登録の正規経路は component XML ファイル配�
 | L1 unit | `KotohaEngineService::process_key_event` の正常 / timeout / disconnect 経路 | `crates/kotoha-engine-ibus/src/service.rs` `#[cfg(test)]` | 無条件(mock bridge_tx) |
 | L1 unit | `KotohaEngineService::{focus_out, reset, disable, focus_in, enable}` の Event 送信 | 同上 | 同上 |
 | L1 unit | `Event::IBusKey { event, respond }` の destructure と engine_loop 経路 | `crates/kotoha-bin/src/engine_loop.rs` `#[cfg(test)]` または既存 integration test | mock reactor + mock host |
-| L1 unit (#208) | `parse_address_file` / `discover_ibus_address` の正常 / `IBUS_ADDRESS=` 行欠落 / 不正入力 | `crates/kotoha-engine-ibus/src/discovery.rs` `#[cfg(test)]` | 無条件(純関数) |
+| L1 unit (#208) | discovery 純関数 4 つ(`parse_address_file` / `display_number` / `resolve_config_dir` / `compose_address_file_path`)の正常 / 欠落 / 不正入力(`discover_ibus_address` の env+file 結合経路は L2 の priority-1 注入と L3 実機 priority-3 で検証) | `crates/kotoha-engine-ibus/src/discovery.rs` `#[cfg(test)]` | 無条件(純関数) |
 | L1 unit (#208) | `KotohaFactoryService::create_engine` の known("kotoha")/ unknown engine_name | `crates/kotoha-engine-ibus/src/factory.rs` `#[cfg(test)]` | 無条件 |
 | L2 integration | listener thread + engine_loop + dummy bridge channel 経路で `process_key_event` が `true`(= Consumed)を返す | `crates/kotoha-engine-ibus/tests/integration.rs`(新規) | `#[ignore]`(#208 改訂: `KOTOHA_IBUS_ADDRESS` で注入した使い捨て bus を使用)|
 | L2 integration (#208) | 使い捨て `dbus-daemon --session --print-address` を private bus に見立て(`KOTOHA_IBUS_ADDRESS` で注入)、test が fake daemon として `CreateEngine` → `ProcessKeyEvent` を呼ぶ handshake 経路 | `crates/kotoha-engine-ibus/tests/integration.rs` | `#[ignore]`(`dbus-daemon` binary 必要)|

--- a/docs/specs/_uncategorized/p3-b-ibus-listener.md
+++ b/docs/specs/_uncategorized/p3-b-ibus-listener.md
@@ -2,10 +2,11 @@
 feature: p3-b-ibus-listener
 status: draft
 bounded_context: _uncategorized
-related_issues: ["#136", "#195"]
+related_issues: ["#136", "#195", "#208"]
 related_prs: []
 glossary_refs: ["coalescing-window", "event-loop", "event-reactor", "ime-engine", "ime-host-bridge", "phase3-ibus-engine-terms", "preedit"]
-last_reviewed: 2026-05-08
+test_plan_status: designed
+last_reviewed: 2026-06-11
 ---
 
 # Phase 3-B B6-b: IBus engine method dispatch listener
@@ -13,7 +14,7 @@ last_reviewed: 2026-05-08
 | 項目 | 値 |
 |------|----|
 | Phase | Phase 3 (IBus integration) — milestone P3-B、sub-task B6-b |
-| ISSUE | [#195](https://github.com/std-koh-hinooka/kotoha-ime/issues/195) (parent: [#136](https://github.com/std-koh-hinooka/kotoha-ime/issues/136)) |
+| ISSUE | [#195](https://github.com/std-koh-hinooka/kotoha-ime/issues/195) (parent: [#136](https://github.com/std-koh-hinooka/kotoha-ime/issues/136))、改訂: [#208](https://github.com/std-koh-hinooka/kotoha-ime/issues/208) |
 | 起票日 | 2026-05-08 |
 | Status | Draft |
 | 関連 ADR(候補) | 0021(zbus integration architecture for IBus engine listener) |
@@ -56,6 +57,14 @@ Phase 3-B B0h-f + B3 (PR #183, ADR 0020) で 4-thread topology の architectural
 
 本 spec scope 完了後、Phase 3-B の残課題は **B6-c (#196 L3 manual smoke 実機検証)** のみとなる。
 
+### §1.1 改訂履歴(#208、2026-06-11)
+
+2026-06-11 の B6-c L3 manual smoke(#136 / #196)で、本 spec 初版(#195)が設計した session bus 接続では ibus-daemon との handshake が成立しないことが実機で確定した(`ibus engine kotoha` が `SetGlobalEngine: Timeout`、ISSUE #208)。本改訂は以下 3 点を設計変更する:
+
+1. 接続先を D-Bus session bus から **IBus private bus**(address discovery 経由)に変更(§7.1–§7.2)
+2. `org.freedesktop.IBus.Factory` interface の serve を scope に追加(§4.5、§7.3)
+3. signal 発信経路(`IBusEngineSignals`)の connection を listener と同一の private bus connection に統一(§7.4)— smoke 診断中に `crates/kotoha-engine-ibus/src/proxy.rs` の `Connection::session()` 独自接続も同根の defect と確定したため
+
 ---
 
 ## §2 スコープと範囲外
@@ -69,6 +78,10 @@ Phase 3-B B0h-f + B3 (PR #183, ADR 0020) で 4-thread topology の architectural
   - `FocusIn()` / `Enable()`(no-op stub、daemon 側 introspection 互換のため)
 - `org.freedesktop.IBus.Engine.Kotoha` bus name 取得(`RequestName` via `blocking::connection::Builder::name`)
 - `/org/freedesktop/IBus/Engine/Kotoha` object path での service 登録
+- IBus private bus address discovery(`KOTOHA_IBUS_ADDRESS` → `IBUS_ADDRESS` → address file の 3 段 fallback、§7.1)— #208 改訂
+- `org.freedesktop.IBus.Factory` interface(`/org/freedesktop/IBus/Factory`)の serve + `CreateEngine` 実装(§4.5)— #208 改訂
+- `IBusEngineSignals` の connection を private bus connection と共有(`proxy.rs` 改修、§7.4)— #208 改訂
+- daemon 互換 no-op stub の追加: `SetCapabilities(u)` / `SetCursorLocation(iiii)` / `Destroy()` — #208 改訂
 - `Event::IBusKey { event, respond }` enum 拡張(respond channel)
 - engine_loop の `Event::IBusKey` arm に `respond.send(KeyEventResult)` 経路追加
 - `KOTOHA_ALLOW_LISTENER_STUB_ENV` / `allow_listener_stub` / `ListenerStubRefused` 削除
@@ -92,15 +105,17 @@ ADR 0020 §採択 Q4 で確定した 4-thread topology を維持する:
 
 | thread | 主責務 | 本 spec での変更 |
 |---|---|---|
-| `main` | DI wiring、SIGTERM/SIGINT、join | (変更なし、#198 で SIGTERM hook 完成済) |
-| `kotoha-dbus-listener` | IBus method 受信 + decode + bridge channel 送信 | **本 spec scope**。stub から production 実装へ |
+| `main` | DI wiring(#208 改訂: private bus connection 構築 + clone 配布を含む、§7.4)、SIGTERM/SIGINT、join | #208 改訂で connection 構築を担当 |
+| `kotoha-dbus-listener` | IBus method 受信 + decode + bridge channel 送信 | **本 spec scope**。stub から production 実装へ。#208 改訂: connection は main から受領し、dispatch 稼働の保持 + shutdown 監視を担う |
 | `kotoha-engine-loop` | `EventReactor::recv()` で multiplex、apply_candidate_update | `Event::IBusKey` arm の respond.send 経路追加 |
 | `kotoha-ranker-worker` | `Event::WorkerOutput` 生成 | (変更なし) |
 
 ### §3.2 listener thread の内部構造
 
 ```text
-[IBus daemon] --DBus method calls--> [zbus::blocking::Connection]
+[IBus daemon (private bus)] --CreateEngine("kotoha")--> [KotohaFactoryService (/org/freedesktop/IBus/Factory)]
+                                        ↓ engine object path 返却(静的: /org/freedesktop/IBus/Engine/Kotoha、§7.3)
+[IBus daemon] --DBus method calls--> [zbus::blocking::Connection(private bus、Builder::address)]
                                         ↓ (内部 smol executor、zbus が管理)
                                         ↓ (#[interface] dispatcher)
                                    [KotohaEngineService struct]
@@ -120,11 +135,11 @@ ADR 0020 §採択 Q4 で確定した 4-thread topology を維持する:
 
 `blocking::Connection` は zbus 内部の smol executor を背景 thread で走らせる。`#[interface]` impl の各 method は smol executor 経由で dispatch される(本 crate のコード自身は std::sync 同期 primitive のみ使用)。
 
-### §3.3 Connection ownership
+### §3.3 Connection ownership(#208 改訂)
 
-listener thread は `blocking::Connection` を **単独所有** する(`let conn = ...build()?` で local に bind)。Connection drop 時に zbus の内部 executor が exit し、bus name が release される。
+main thread の DI wiring が private bus への `blocking::Connection` を構築する(§7.2)。zbus の `Connection` は内部 `Arc` 共有の `Clone` 可能 handle であり、main は clone を signal 発信側(`IBusEngineSignals`、§7.4)へ、もう一方を listener thread へ渡して **同一 connection を共有**する。別 connection だと daemon が engine の serve 元と signal 発信元を別 peer と見なし、signal が `InputContext` に routing されない(#208 smoke 診断で確定した設計制約)。
 
-`ShutdownObserver` を polling し、shutdown 観測時に Connection を drop して thread を抜ける。
+listener thread は `ShutdownObserver` を polling し、shutdown 観測時に保持 handle を drop して thread を抜ける。全 clone が drop された時点で zbus 内部 executor が exit し、bus name が release される。
 
 ---
 
@@ -171,6 +186,29 @@ pub(crate) struct KotohaEngineService {
 - interface 名: `org.freedesktop.IBus.Engine`(`crates/kotoha-engine-ibus/src/proxy.rs::IBUS_ENGINE_INTERFACE` と共有)
 - `ProcessKeyEvent` の signature `uuu` は IBus 1.5.x `bus/inputcontext.c` 仕様に準拠
 - 戻り値 `b`(true = 消費した、false = アプリに forward する)も同仕様
+
+### §4.5 `KotohaFactoryService` API contract(#208 改訂)
+
+- 配置: `crates/kotoha-engine-ibus/src/factory.rs`(新規 module)
+- visibility: `pub(crate) struct KotohaFactoryService`
+- serve path: `/org/freedesktop/IBus/Factory`(IBus 1.5.x `ibusfactory.c` 仕様の固定 path)
+
+```rust
+pub(crate) struct KotohaFactoryService;
+
+#[interface(name = "org.freedesktop.IBus.Factory")]
+impl KotohaFactoryService {
+    /// `CreateEngine(s engine_name) -> o`(IBus 1.5.x factory 仕様)。
+    fn create_engine(&self, engine_name: &str) -> zbus::fdo::Result<zbus::zvariant::OwnedObjectPath>;
+}
+```
+
+| 入力 | 動作 |
+|---|---|
+| `engine_name == "kotoha"` | 静的 path `/org/freedesktop/IBus/Engine/Kotoha` を返す(§7.3 の静的単一 path 採択) |
+| その他 | `fdo::Error::InvalidArgs` を返し `tracing::warn!(error_id = "factory.create_engine.unknown_engine")` |
+
+engine object 自体は connection build 時に `serve_at` 済みのため、`CreateEngine` は **path の返却のみ** を行う(動的 `object_server().at(...)` 登録は不要)。
 
 ---
 
@@ -258,21 +296,40 @@ response channel は `bounded(1)`(1 element capacity):
 
 ---
 
-## §7 IBus daemon integration
+## §7 IBus daemon integration(#208 全面改訂)
 
-### §7.1 bus name と object path
+### §7.1 private bus address discovery
+
+ibus-daemon は D-Bus session bus ではなく **自前の private bus** 上で component を待ち受ける(2026-06-11 L3 smoke で実機確定、ISSUE #208)。Kotoha は IBus client library の `ibus_get_address()` と同一 semantics で address を解決する:
+
+| 優先 | source | 用途 |
+|---|---|---|
+| 1 | env `KOTOHA_IBUS_ADDRESS` | test / 開発時 override(Kotoha 固有) |
+| 2 | env `IBUS_ADDRESS` | IBus エコシステム標準 override |
+| 3 | address file `$XDG_CONFIG_HOME/ibus/bus/<machine-id>-<hostname>-<display>` の `IBUS_ADDRESS=` 行 | 通常経路 |
+
+address file 名の構成要素:
+
+- `<machine-id>`: `/var/lib/dbus/machine-id`(fallback: `/etc/machine-id`)の内容(trim 済 32 hex)
+- `<hostname>`: local display では固定文字列 `unix`
+- `<display>`: env `DISPLAY`(例 `:0` → `0`)の display 番号。Wayland session でも XWayland 由来の `DISPLAY` が設定される(smoke 環境 Ubuntu 24.04 / GNOME 46 で確認済)
+
+3 source すべてで解決できない場合、`run()` は Err を返し process exit する(§9.1)。address 解決は純関数 `discover_ibus_address()` / `parse_address_file(&str)` に分離し、L1 unit test 対象とする(§10.1)。
+
+### §7.2 bus name / object path / connection 構築
 
 ```rust
 pub(crate) const IBUS_ENGINE_BUS_NAME: &str = "org.freedesktop.IBus.Engine.Kotoha";
 pub(crate) const IBUS_ENGINE_OBJECT_PATH: &str = "/org/freedesktop/IBus/Engine/Kotoha";
+pub(crate) const IBUS_FACTORY_OBJECT_PATH: &str = "/org/freedesktop/IBus/Factory";   // #208 追加
 ```
 
-新規定数として `crates/kotoha-engine-ibus/src/proxy.rs` に追加(既存 `IBUS_ENGINE_INTERFACE` と同じ module)。
-
-### §7.2 connection 構築
+定数は `crates/kotoha-engine-ibus/src/proxy.rs` に配置(既存 `IBUS_ENGINE_INTERFACE` と同じ module)。
 
 ```rust
-let connection = blocking::connection::Builder::session()?
+let address = discover_ibus_address()?;   // §7.1
+let connection = blocking::connection::Builder::address(address.as_str())?
+    .serve_at(IBUS_FACTORY_OBJECT_PATH, KotohaFactoryService)?               // §4.5
     .serve_at(IBUS_ENGINE_OBJECT_PATH, KotohaEngineService { bridge_tx })?
     .name(IBUS_ENGINE_BUS_NAME)?
     .build()?;
@@ -280,19 +337,36 @@ let connection = blocking::connection::Builder::session()?
 
 `build()` 完了時点で:
 
-- session bus への connection 確立
-- service struct が指定 path で publish
-- bus name `RequestName` で daemon に登録(他 process が同名で publish していたら `Err` で listener 起動失敗)
+- private bus への connection 確立
+- Factory + Engine service が各 path で publish
+- bus name `RequestName` で private bus に登録(component XML の `<name>` と一致させ、daemon が component 起動完了を検知する)。他 process が同名で publish していたら `Err` で起動失敗
 
-### §7.3 `org.freedesktop.IBus.IBus.RegisterComponent` の取扱
+connection 構築は main thread の DI wiring が実行し、clone を `IBusEngineSignals` へ、本体を listener thread へ渡す(§3.3)。
 
-IBus 1.5.x では engine 登録の正規経路は `/usr/share/ibus/component/<name>.xml` ファイル配置 + ibus daemon 再起動である。`RegisterComponent` DBus method 経由の dynamic 登録もあるが、daemon 側が file ベースの registry を優先するため一般的でない。
+### §7.3 engine object の serve 方式: 静的単一 path
+
+IBus 本来の semantics は `CreateEngine` 呼び出しごとに `/org/freedesktop/IBus/Engine/<N>` の動的 path で engine object を生成する。本 spec は **静的単一 path** を採択する:
+
+- 採択: `CreateEngine` は常に既 serve 済の `/org/freedesktop/IBus/Engine/Kotoha` を返す
+- 根拠: GNOME は global engine mode で動作し、engine 切替は旧 engine 破棄 → 新 `CreateEngine` の順で進むため、複数 engine instance が同時に要求されない。動的 path は `IBusEngineSignals` 側の path 同期機構(`Arc<RwLock<ObjectPath>>` 等)を要し、現 Phase では複雑性が見合わない
+- 制約: 複数 `InputContext` へ独立 engine を提供できない。Phase 6(multi-context)で動的 path 化を再評価する(§13.4)
+
+### §7.4 signal 経路の connection 共有
+
+`IBusEngineSignals`(`proxy.rs`)は初版で `Connection::session()` により独自接続していた。daemon は signal の発信元 peer を engine の serve 元 connection で識別するため、別 connection からの signal は `InputContext` に届かない。本改訂で:
+
+- `IBusEngineSignals::new(connection: Connection, object_path: &str)` に signature 変更し、§7.2 で構築した private bus connection の clone を受け取る(独自 session 接続を廃止)
+- main thread の DI wiring が clone を host bridge 経由で注入する(§3.1 / §3.3)
+
+### §7.5 `org.freedesktop.IBus.IBus.RegisterComponent` の取扱
+
+IBus 1.5.x では engine 登録の正規経路は component XML ファイル配置 + ibus daemon 再起動である。`RegisterComponent` DBus method 経由の dynamic 登録もあるが、daemon 側が file ベースの registry を優先するため一般的でない。
 
 本 spec scope では:
 
 - DBus call 経路の `RegisterComponent` は **使用しない**
 - `kotoha.xml` 配置経路は **packaging task として後続 ISSUE で扱う**(本 spec 範囲外、§2.2)
-- 開発時は手動で `~/.config/ibus/component/kotoha.xml` を配置するか、ibus daemon を直接 reset して name 取得状態を観測する(L3 manual smoke #196 で検証)
+- 開発時は `IBUS_COMPONENT_PATH` env に user-scope component dir を追加して ibus-daemon を起動する(2026-06-11 smoke で確定: 本 IBus build 1.5.29-rc2 は `/usr/share/ibus/component` のみ scan し、`~/.config/ibus/component/` を読まない。手順詳細: `docs/runbooks/2026-06-11-phase3b-b6-l3-smoke-result.md` 環境逸脱表)
 
 ---
 
@@ -320,7 +394,10 @@ IBus 1.5.x では engine 登録の正規経路は `/usr/share/ibus/component/<na
 | 状況 | listener 動作 | observability |
 |---|---|---|
 | zbus connection 確立失敗 | `run()` Err で main thread に伝播 → process exit | `tracing::error!` + `?` propagation |
-| `RequestName` 失敗(他 process が同名占有)| 同上 | 同上 |
+| address discovery 失敗(§7.1 の 3 source すべて不発)(#208) | 同上 | 同上 |
+| address file parse 失敗(`IBUS_ADDRESS=` 行欠落 / 不正形式)(#208) | 同上 | 同上 |
+| `CreateEngine` に未知 engine_name(#208) | `fdo::Error::InvalidArgs` 返却、connection 維持 | `error_id = "factory.create_engine.unknown_engine"` warn |
+| `RequestName` 失敗(他 process が同名占有)| `run()` Err で main thread に伝播 → process exit | `tracing::error!` + `?` propagation |
 | service method 内 panic | `&self` impl で field なし、panic 起こりにくい。万一発生時は zbus が catch して daemon に Err 返却、connection は維持 | zbus 標準 |
 | bridge_tx.send Err(engine_loop drop)| `false` 返却 + `error_id = "listener.process_key_event.bridge_disconnected"` | tracing::warn |
 | respond.recv timeout(>100ms)| `false` 返却 + `error_id = "listener.process_key_event.timeout"` | tracing::warn |
@@ -343,7 +420,10 @@ IBus 1.5.x では engine 登録の正規経路は `/usr/share/ibus/component/<na
 | L1 unit | `KotohaEngineService::process_key_event` の正常 / timeout / disconnect 経路 | `crates/kotoha-engine-ibus/src/service.rs` `#[cfg(test)]` | 無条件(mock bridge_tx) |
 | L1 unit | `KotohaEngineService::{focus_out, reset, disable, focus_in, enable}` の Event 送信 | 同上 | 同上 |
 | L1 unit | `Event::IBusKey { event, respond }` の destructure と engine_loop 経路 | `crates/kotoha-bin/src/engine_loop.rs` `#[cfg(test)]` または既存 integration test | mock reactor + mock host |
-| L2 integration | listener thread + engine_loop + dummy bridge channel 経路で `process_key_event` が `true`(= Consumed)を返す | `crates/kotoha-engine-ibus/tests/integration.rs`(新規) | `#[ignore]`(dbus session bus 必要)|
+| L1 unit (#208) | `parse_address_file` / `discover_ibus_address` の正常 / `IBUS_ADDRESS=` 行欠落 / 不正入力 | `crates/kotoha-engine-ibus/src/discovery.rs` `#[cfg(test)]` | 無条件(純関数) |
+| L1 unit (#208) | `KotohaFactoryService::create_engine` の known("kotoha")/ unknown engine_name | `crates/kotoha-engine-ibus/src/factory.rs` `#[cfg(test)]` | 無条件 |
+| L2 integration | listener thread + engine_loop + dummy bridge channel 経路で `process_key_event` が `true`(= Consumed)を返す | `crates/kotoha-engine-ibus/tests/integration.rs`(新規) | `#[ignore]`(#208 改訂: `KOTOHA_IBUS_ADDRESS` で注入した使い捨て bus を使用)|
+| L2 integration (#208) | 使い捨て `dbus-daemon --session --print-address` を private bus に見立て(`KOTOHA_IBUS_ADDRESS` で注入)、test が fake daemon として `CreateEngine` → `ProcessKeyEvent` を呼ぶ handshake 経路 | `crates/kotoha-engine-ibus/tests/integration.rs` | `#[ignore]`(`dbus-daemon` binary 必要)|
 | L3 manual | 実機 IBus daemon に register、Firefox / GNOME Editor / VS Code で型変換 10 件 | `docs/wbs/<date>-phase3b-b6-l3-smoke.md` | 別 PR(#196)|
 
 ### §10.2 既存 test の preservation
@@ -355,14 +435,31 @@ IBus 1.5.x では engine 登録の正規経路は `/usr/share/ibus/component/<na
 ### §10.3 mock 戦略
 
 - `KotohaEngineService` の test では bridge_tx を `crossbeam_channel::unbounded()` の `Sender` で構築し、test 内で `Receiver` を直接 drain して送信内容を assert
-- L2 integration の dbus session bus は CI 環境差異の温床なので `#[ignore]` で opt-in
+- L2 integration の使い捨て dbus-daemon(`KOTOHA_IBUS_ADDRESS` 注入)は CI 環境差異の温床なので `#[ignore]` で opt-in
 - production-like test は L3 manual smoke(#196)で実施
 
 ---
 
 ## §11 implementation roadmap
 
-実装は以下の順序で進める(各 step は同 PR 内、commit 単位):
+### §11.1 #208 改訂の実装 roadmap(2026-06-11)
+
+#195 初版実装(merge 済)からの差分として、以下の順序で進める(各 step は同 PR 内、commit 単位):
+
+1. **discovery.rs 新規**: `discover_ibus_address()` + `parse_address_file()` 純関数 + L1 unit tests(§7.1)
+2. **proxy.rs 定数追加**: `IBUS_FACTORY_OBJECT_PATH`(§7.2)
+3. **factory.rs 新規**: `KotohaFactoryService` + `#[interface]` impl + L1 unit tests(§4.5)
+4. **listener.rs 改修**: `Builder::session()` → `Builder::address(...)` + Factory `serve_at` 追加。connection 構築を main の DI wiring から呼べる形に分離(§3.3 / §7.2)
+5. **proxy.rs 改修**: `IBusEngineSignals::new(connection, object_path)` signature 変更、独自 session 接続を廃止(§7.4)
+6. **service.rs 改修**: no-op stub 追加 — `SetCapabilities(u)` / `SetCursorLocation(iiii)` / `Destroy()`(§2.1)
+7. **main.rs DI wiring 改修**: connection 構築 + clone 配布(§3.1 / §3.3)
+8. **L2 handshake test 追加**(§10.1)
+9. **ADR 0021 amendment 追記**(§12.1)
+10. **smoke 再開**(#136 B6-c、`docs/runbooks/2026-06-11-phase3b-b6-l3-smoke-result.md` を引き継いでマトリクス記入)
+
+### §11.2 #195 初版実装の roadmap(実施済、履歴)
+
+実装は以下の順序で進めた(各 step は同 PR 内、commit 単位):
 
 1. **Event::IBusKey 変更**: `crates/kotoha-engine-core/src/reactor/event.rs` の `Event::IBusKey(KeyEvent)` を `Event::IBusKey { event: KeyEvent, respond: Sender<KeyEventResult> }` に変更。callers(engine_loop + tests)を update
 2. **proxy.rs 定数追加**: `IBUS_ENGINE_BUS_NAME` / `IBUS_ENGINE_OBJECT_PATH`
@@ -390,6 +487,8 @@ PR size 想定: ~400-600 lines(spec + source + test + ADR)。Large tier 上限 �
   - `MessageStream` 手動 dispatch(zbus 5 では async API 主導、blocking 系で MessageStream 直接受信は限定的)
   - `Arc<AtomicBool>` snapshot による listener-side enabled cache(spec §5.2 `Forwarded` 精度を犠牲)
   - `ForwardKeyEvent` signal 二相 pattern(API surface + race + integration test 負荷増)
+
+**Amendment(#208、2026-06-11)**: 採択 1 の「session bus に publish」は実機 handshake 不成立(ISSUE #208)により「private bus(§7.1 address discovery 経由)に publish + `org.freedesktop.IBus.Factory` serve + signal connection 共有」へ変更する。ADR 0021 本体に Amendment 節を追記する。
 
 ### §12.2 spec p3-a-ibus-engine.md の更新
 
@@ -432,3 +531,7 @@ Phase 4 で fcitx5 用 adapter を追加する際、`kotoha-engine-fcitx5` crate
 - service method を async fn 化して smol::unblock で response 待機(ADR 0017 再評価必要)
 
 Phase 5 spec kick-off 時に決定する。
+
+### §13.4 engine object 動的 path 化の再評価(#208 改訂)
+
+§7.3 の静的単一 path は GNOME global engine mode 前提の簡素化である。Phase 6 で multi-context(per-window state、複数 `InputContext` への独立 engine 提供)を扱う場合、`CreateEngine` ごとの動的 path 生成(`/org/freedesktop/IBus/Engine/<N>` + `object_server().at(...)`)と `IBusEngineSignals` の path 同期機構を再評価する。


### PR DESCRIPTION
## Summary

- The B6-c L3 manual smoke (2026-06-11) proved the engine never completes the ibus-daemon handshake (`SetGlobalEngine: Timeout`): the listener claimed its bus name on the D-Bus **session bus** while ibus-daemon waits on its **private bus**, and no `org.freedesktop.IBus.Factory` endpoint existed for `CreateEngine` (ISSUE #208).
- Design-level fix per the change-propagation rule: spec `p3-b-ibus-listener.md` §4.5/§7 revised first (commit `a106a5d`, with ADR 0021 Amendment 2026-06-11), then implemented per the plan (`docs/plans/2026-06-11-bugfix-208-ibus-private-bus-factory.md`).
- The same defect also affected the **outbound** signal path: `IBusEngineSignals` opened its own session-bus connection, so preedit/commit signals would never reach the `InputContext` even after the handshake fix. The private-bus connection is now built once in main DI wiring and shared (zbus `Connection` is a cloneable `Arc` handle).

## Changes

| Area | Change |
|---|---|
| `discovery.rs` (new) | Private-bus address resolution, 3-stage fallback: `KOTOHA_IBUS_ADDRESS` → `IBUS_ADDRESS` → address file (`$XDG_CONFIG_HOME/ibus/bus/<machine-id>-unix-<display>`), `ibus_get_address()`-compatible. Parsing split into pure functions. |
| `factory.rs` (new) | `KotohaFactoryService` serving `org.freedesktop.IBus.Factory`; `CreateEngine("kotoha")` returns the static engine path (per-CreateEngine dynamic paths deferred to Phase 6, spec §13.4); unknown names rejected with `InvalidArgs`. |
| `listener.rs` | `build_connection()` (Builder::address + Factory/Engine `serve_at` + `RequestName`); `run()` now receives the connection and only watches shutdown. |
| `proxy.rs` / `host_bridge.rs` | `IBusEngineSignals` / `IBusHostBridge` take an injected connection; own `Connection::session()` removed. |
| `service.rs` | Daemon-compat no-op stubs: `SetCapabilities` / `SetCursorLocation` / `Destroy`. |
| `main.rs` | DI wiring reordered: reactor → connection → host bridge → engine → threads. Stub fallback (`KOTOHA_ALLOW_STUB=1`) skips the listener thread. |

## Test plan

- [x] L1 unit: address-file parser (normal / missing line / empty), display-number extraction, `CreateEngine` known/unknown name, no-op stubs (7 new tests; 21 total in `kotoha-engine-ibus`)
- [x] L2 handshake (`#[ignore]`): throwaway `dbus-daemon --session` injected via `KOTOHA_IBUS_ADDRESS`; fake daemon performs `CreateEngine` → `ProcessKeyEvent` → `Consumed`; **verified passing locally** (`cargo test -p kotoha-engine-ibus --test integration -- --ignored` → `1 passed`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (both with and without `dev-stubs`)
- [x] lefthook pre-push green (build / clippy / test / test-dict / test-dict-persist / manifest / obsidian-sync)
- [ ] L3: resume B6-c manual smoke after merge (#136, runbook result doc `docs/runbooks/2026-06-11-phase3b-b6-l3-smoke-result.md`)

Closes #208. Refs #136, #196, ADR 0021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)